### PR TITLE
US13860 Pages

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -59,4 +59,5 @@ contentful:
         entry_mappings:
           title: title
           slug: slug
+          permalink: slug
           layout: layout


### PR DESCRIPTION
Add support for hierarchical slugs. This PR updates the project so that any page with a slug containing a slash will be respected during the build... for example:

https://5b27c49ab13fb17d7cd284f5--crds-net.netlify.com/purus-cursus-tristique/something