### PR TITLE
US13848 Setup Project

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -35,6 +35,9 @@ assets:
   - _assets/stylesheets
   - _assets/javascripts
 
+include:
+  - _redirects
+
 exclude:
   - Gemfile
   - Gemfile.lock

--- a/_redirects
+++ b/_redirects
@@ -1,0 +1,1 @@
+/*        https://int.crossroads.net/:splat     200

--- a/netlify.toml
+++ b/netlify.toml
@@ -3,9 +3,3 @@
     bundle exec jekyll contentful &&
     bundle exec jekyll build
   '''
-
-[[redirects]]
-  from = "/*"
-  to = "https://int.crossroads.net/:splat"
-  status = 200
-  force = false


### PR DESCRIPTION
This commit sets up proxying calls using the _redirects file, instead of
the previously used netlify.toml file.