### PR TITLE
- Parses markdownified url from description instead of full page cont…

### DIFF
--- a/_includes/_head.html
+++ b/_includes/_head.html
@@ -3,11 +3,11 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta http-equiv="X-UA-Compatible" content="ie=edge">
   <meta name="title" content="{{ page | get_meta_title: site }}">
-  <meta name="description" content="{{ page | get_meta_description: content, site | strip_html | strip | truncate: 155 }}">
-  <meta name="image" content="{{ page | get_meta_image: content, site }}">
-  <meta property="og:description" content="{{ page | get_meta_description: content, site | strip_html | strip | truncate: 155 }}">
+  <meta name="description" content="{{ page | get_meta_description: site | strip_html | strip | truncate: 155 }}">
+  <meta name="image" content="{{ page | get_meta_image: site }}">
+  <meta property="og:description" content="{{ page | get_meta_description: site | strip_html | strip | truncate: 155 }}">
   <meta property="og:title" content="{{ page | get_meta_title: site }}">
-  <meta property="og:image" content="{{ page | get_meta_image: content, site }}">
+  <meta property="og:image" content="{{ page | get_meta_image: site }}">
   <meta property="og:url" content="{{ page | build_page_url: site }}">
   <meta property="og:site_name" content="{{ site.title | escape }}">
   <link rel="stylesheet" type="text/css" href="https://crossroads-media.s3.amazonaws.com/documents/styles/hotfix-seventy-six.css">

--- a/_plugins/filters/html_and_meta_util_filter.rb
+++ b/_plugins/filters/html_and_meta_util_filter.rb
@@ -1,24 +1,25 @@
 require_relative '../../lib/utils/meta_util'
 require_relative '../../lib/utils/html_util'
+require 'pry'
 
 module CRDS
   module Filters
     module HtmlAndMetaUtilFilter
 
-      def get_meta_image(page, page_content, site)
+      def get_meta_image(page, site)
         ::Utils::MetaUtil.get_meta_image_url(
           page['meta_image'],
           page['image'],
           page['bg_image'],
-          page_content,
+          page['description'],
           site['image']
         )
       end
 
-      def get_meta_description(page, page_content, site)
+      def get_meta_description(page, site)
         ::Utils::MetaUtil.get_meta_description(
           page['meta_description'],
-          page_content,
+          page['excerpt'],
           site['description']
         )
       end

--- a/lib/utils/meta_util.rb
+++ b/lib/utils/meta_util.rb
@@ -17,7 +17,7 @@
           page_meta_image,
           page_image,
           page_bg_image,
-          search_for_first_image_url_in_page_content(page_content),
+          search_for_first_image_in_content(page_content),
           site_image
         ].find{|image_under_review| has_value?(image_under_review)}.to_s.strip
         prepend_url_protocol(image_url)
@@ -50,13 +50,31 @@
           uri.to_s
         end
 
-        #returns the value in the 'src' attribute of the first occurence of an 'img' element
-        def self.search_for_first_image_url_in_page_content(page_content)
+        #
+        def self.search_for_first_image_in_content(content)
+          search_for_first_markdownified_image_url_in_content(content) ||
+          search_for_first_html_image_url_in_page_content(content)
+        end
 
-          if page_content.nil? || page_content.to_s.strip.empty?
+        #
+        def self.search_for_first_markdownified_image_url_in_content(content)
+          if content.nil? || content.to_s.strip.empty?
             nil
           else
-            matches = /<\s*img .*?src=["']?[\s]*([^'">\s]+)/.match(page_content)
+            matches = /!\[[^\]]*\][\s]*\(([^\)]+)\)/.match(content)
+            matches.nil? ? nil : matches[1]
+          end
+        end
+
+#        ![famous-dripping-clocks-dali-painting-persistence-of-memory1](//images.ctfassets.net/p9oq1ve41d7r/53Ilga1G40Sewck6YYOWcI/8ae18b94d0e3aad990c0fff3b440bbda/famous-dripping-clocks-dali-painting-persistence-of-memory1.jpg)
+
+        #returns the value in the 'src' attribute of the first occurence of an 'img' element
+        def self.search_for_first_html_image_url_in_page_content(content)
+
+          if content.nil? || content.to_s.strip.empty?
+            nil
+          else
+            matches = /<\s*img .*?src=["']?[\s]*([^'">\s]+)/.match(content)
             matches.nil? ? nil : matches[1]
           end
         end

--- a/lib/utils/meta_util.rb
+++ b/lib/utils/meta_util.rb
@@ -50,13 +50,13 @@
           uri.to_s
         end
 
-        #
+        # Attempts to parse an image from either markdownified or html-rendered content
         def self.search_for_first_image_in_content(content)
           search_for_first_markdownified_image_url_in_content(content) ||
           search_for_first_html_image_url_in_page_content(content)
         end
 
-        #
+        # Attempts to parse an image from markdownified content
         def self.search_for_first_markdownified_image_url_in_content(content)
           if content.nil? || content.to_s.strip.empty?
             nil
@@ -65,8 +65,6 @@
             matches.nil? ? nil : matches[1]
           end
         end
-
-#        ![famous-dripping-clocks-dali-painting-persistence-of-memory1](//images.ctfassets.net/p9oq1ve41d7r/53Ilga1G40Sewck6YYOWcI/8ae18b94d0e3aad990c0fff3b440bbda/famous-dripping-clocks-dali-painting-persistence-of-memory1.jpg)
 
         #returns the value in the 'src' attribute of the first occurence of an 'img' element
         def self.search_for_first_html_image_url_in_page_content(content)

--- a/spec/unit/meta_util_spec.rb
+++ b/spec/unit/meta_util_spec.rb
@@ -82,7 +82,17 @@ describe 'Html Meta Util' do
         'https://site-image.jpg')).to eq 'https://site-image.jpg'
   end
 
-  context 
+
+  it 'should parse and return the markdownified image url' do
+    expect(
+      Utils::MetaUtil.get_meta_image_url(
+        nil,
+        nil,
+        nil,
+        'some text to the left ![famous-dripping-clocks-dali-painting-persistence-of-memory1](//images.ctfassets.net/p9oq1ve41d7r/53Ilga1G40Sewck6YYOWcI/8ae18b94d0e3aad990c0fff3b440bbda/famous-dripping-clocks-dali-painting-persistence-of-memory1.jpg) some text to the right',
+        'https://site-image.jpg')).to eq 'https://images.ctfassets.net/p9oq1ve41d7r/53Ilga1G40Sewck6YYOWcI/8ae18b94d0e3aad990c0fff3b440bbda/famous-dripping-clocks-dali-painting-persistence-of-memory1.jpg'
+  end
+
 
   it 'should return the site image url' do
     expect(


### PR DESCRIPTION
…ent when no meta, image or bg_image are specified

- Adds unit test for parsing markdownified url
- Looking explicitly at the page description (instead of the full page content) for the meta image
- Looking explicitly at the page excerpt (instead of the full page content) for the meta description