### PR TITLE
Added loadenv.ps1 to gitignore file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ _redirects
 collections
 node_modules
 .DS_Store
+loadenv.ps1


### PR DESCRIPTION
this file can be used to load dynamic environment variables for windows machines that only exist in the PowerShell context currently loaded instead of loading system wide environment variables

Windows Users: create the loadenv.ps1 and then create a line for each needed environment variable as follows

`$env:NAME_OF_VARIABLE = "value_of_variable"`

Note: You must load the file before you run the serve command or the contentful command. use `.\loadenv.ps1`