### PR TITLE
Fix for locations cards address not being properly formatted

### DIFF
--- a/_includes/_location-card.html
+++ b/_includes/_location-card.html
@@ -7,7 +7,7 @@
       <a href="{{ location.url }}">{{ location.name }}</a>
     </h4>
     <div class="card-text">
-      <p>{{ location.address }} (<a target="_blank" href="{{ location.map_url }}">Map</a>)</p>
+      <p>{{ location.address | markdownify }} (<a target="_blank" href="{{ location.map_url }}">Map</a>)</p>
       <p><strong>Service Times:</strong><br>{{ location.service_times }}</p>
     </div>
   </div>


### PR DESCRIPTION
added 'markdownify' to the location address so it properly adheres tomarkdown carraige return (two spaces)