### PR TITLE
Fix for chopped card text on happenings and location cards

### DIFF
--- a/_includes/_happening-card.html
+++ b/_includes/_happening-card.html
@@ -6,6 +6,6 @@
   </a>
   <div class="card-block">
     <h4 class="card-title card-title--overlap text-uppercase">{{ item.title }}</h4>
-    <div class="card-text">{{ item.description | markdownify }}</div>
+    <p class="soft-quarter-top">{{ item.description | markdownify }}</p>
   </div>
 </div>

--- a/_includes/_location-card.html
+++ b/_includes/_location-card.html
@@ -4,7 +4,7 @@
   </a>
   <div class="card-block">
     <h4 class="card-title card-title--overlap text-uppercase">
-      <a href="{{ location.url }}">{{ location.name }}</a>
+      <a class="soft-quarter-top" href="{{ location.url }}">{{ location.name }}</a>
     </h4>
     <div class="card-text">
       <p>{{ location.address | markdownify }} (<a target="_blank" href="{{ location.map_url }}">Map</a>)</p>

--- a/_includes/_locations-grid.html
+++ b/_includes/_locations-grid.html
@@ -15,7 +15,7 @@
           <a href="https://www.crossroads.net/live/">Anywhere</a>
         </h4>
         <div class="card-text">
-          <p>Experience Crossroads anywhere in the world.</p>
+          <p class="soft-quarter-top">Experience Crossroads anywhere in the world.</p>
           <p><a class="btn btn-primary" href="/live">Learn more</a></p>
         </div>
       </div>
@@ -34,7 +34,7 @@
           <a href="https://www.crossroads.net/reachout/local/prison-ministry">Blackburn Correctional Complex</a>        
         </h4>
         <div class="card-text">
-          <p>3111 Spurr Road<br> Lexington, Kentucky 40511 (
+          <p class="soft-quarter-top">3111 Spurr Road<br> Lexington, Kentucky 40511 (
             <a href="https://www.google.com/maps/place/Blackburn+Correctional+Complex/@38.111259,-84.5369852,15z/data=!4m5!3m4!1s0x0:0xde3117a58f1815e6!8m2!3d38.111259!4d-84.5369852">map</a>)
           </p>
         </div>
@@ -53,7 +53,7 @@
           <a href="https://www.crossroads.net/reachout/local/prison-ministry">Dayton Correctional Institution</a>          
         </h4>
         <div class="card-text">
-          <p>4104 Germantown Street<br> Dayton, OH 45417 (
+          <p class="soft-quarter-top">4104 Germantown Street<br> Dayton, OH 45417 (
             <a href="https://www.google.com/maps/place/Dayton+Correctional+Institution/@39.7299331,-84.2635569,16z/data=!4m13!1m7!3m6!1s0x8840876a3570fa89:0x9ea6ae7e3ae52c25!2s4104+Germantown+St,+Dayton,+OH+45417!3b1!8m2!3d39.7340797!4d-84.2527946!3m4!1s0x88408153fcd772bb:0x88d3ef6b37226fb1!8m2!3d39.7298358!4d-84.2604885" target="_blank">Map</a>)
           </p>
           <p>
@@ -75,7 +75,7 @@
           <a href="https://www.crossroads.net/reachout/local/prison-ministry">Lebanon Correctional Institution</a>          
         </h4>
         <div class="card-text">
-          <p>3791 State Route 63<br> Lebanon, OH 45036 (
+          <p class="soft-quarter-top">3791 State Route 63<br> Lebanon, OH 45036 (
             <a href="https://www.google.com/maps/place/Lebanon+Correctional+Institution/@39.4361526,-84.3032275,17z/data=!4m13!1m7!3m6!1s0x88405f31d7000efd:0x218bc0d3257fdbd1!2s3791+OH-63,+Lebanon,+OH+45036!3b1!8m2!3d39.4371221!4d-84.3014358!3m4!1s0x88405f501509302d:0x8489015a675e486e!8m2!3d39.4338915!4d-84.2990278" target="_blank">Map</a>)
           </p>
           <p>
@@ -97,7 +97,7 @@
           <a href="https://www.crossroads.net/reachout/local/prison-ministry">London Correctional Institution</a>
         </h4>
         <div class="card-text">
-          <p>1580 OH-56<br> London, OH 43140 (
+          <p class="soft-quarter-top">1580 OH-56<br> London, OH 43140 (
             <a href="https://www.google.com/maps/place/Ohio+Department+of+Rehabilitation+and+Correction+-+London+Correctional+Institution/@39.9042141,-83.4859388,17z/data=!3m1!4b1!4m5!3m4!1s0x8838ae079c4445b9:0xd171765297ab0e2c!8m2!3d39.9042141!4d-83.4837501" target="_blank">Map</a>)
           </p>
           <p>
@@ -119,7 +119,7 @@
           <a href="https://www.crossroads.net/reachout/local/prison-ministry">Marion Correctional Institution</a>         
         </h4>
         <div class="card-text">
-          <p>940 Marion-Williamsport Road<br> Marion, OH 43302 (
+          <p class="soft-quarter-top">940 Marion-Williamsport Road<br> Marion, OH 43302 (
             <a href="https://maps.google.com/?q=940+Marion-Williamsport+Road+Marion,+OH+43302&amp;entry=gmail&amp;source=g" target="_blank">Map</a>)
           </p>
           <p>
@@ -141,7 +141,7 @@
           <a href="https://www.crossroads.net/reachout/local/prison-ministry">Ohio Reformatory for Women</a>          
         </h4>
         <div class="card-text">
-          <p>1479 Collins Avenue<br> Marysville, OH 43040 (
+          <p class="soft-quarter-top">1479 Collins Avenue<br> Marysville, OH 43040 (
             <a href="https://www.google.com/maps/place/Ohio+Reformatory+for+Women/@40.2242328,-83.3932216,15z/data=!4m5!3m4!1s0x0:0x2161dc1eea876928!8m2!3d40.2242328!4d-83.3932216" target="_blank">Map</a>)
           </p>
           <p>
@@ -163,7 +163,7 @@
           <a href="https://www.crossroads.net/reachout/local/prison-ministry">Warren Correctional Institution</a>         
         </h4>
         <div class="card-text">
-          <p>5787 Ohio 63<br> Lebanon, OH 45036 (
+          <p class="soft-quarter-top">5787 Ohio 63<br> Lebanon, OH 45036 (
             <a href="https://www.google.com/maps/place/Warren+Correctional+Institution/@39.4342293,-84.3078695,15z/data=!4m5!3m4!1s0x0:0x3afe109724ea9eda!8m2!3d39.4342293!4d-84.3078695" target="_blank">Map</a>)
           </p>
           <p>


### PR DESCRIPTION
Added class="soft-quarter-top" to happening card and location card, and also added them to the hard coded prison locations in locaitons-grid