### PR TITLE
US15275: Update Jekyll Contentful

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,11 +8,10 @@ group :jekyll_plugins do
   # gem 'crds-styles', path: File.join(File.dirname(__FILE__), '../crds-styles')
   # gem 'crds-styles', git: 'https://github.com/crdschurch/crds-styles.git', branch: 'development'
   gem 'crds-styles', git: 'https://github.com/crdschurch/crds-styles.git', tag: 'v3.0.6'
-  gem "jekyll-contentful", git: 'https://github.com/crdschurch/jekyll-contentful.git', tag: '1.0.4'
+  gem "jekyll-contentful", git: 'https://github.com/crdschurch/jekyll-contentful.git', tag: '1.1.0'
   gem "jekyll-crds", "~> 0.0.1", git: 'https://github.com/crdschurch/jekyll-crds.git', branch: 'master'
   gem "jekyll-placeholders", "~> 0.0.1", github: 'ample/jekyll-placeholders'
   gem "jekyll-cloudsearch", "~> 0.0.1", github: 'crdschurch/jekyll-cloudsearch'
-  
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -27,10 +27,10 @@ GIT
 
 GIT
   remote: https://github.com/crdschurch/jekyll-contentful.git
-  revision: d945dbeeb4d0dd96b2c91f37c76b257236b2e686
-  tag: 1.0.4
+  revision: 3289cffead190c35af3be63218447f9f887082d7
+  tag: 1.1.0
   specs:
-    jekyll-contentful (1.0.4)
+    jekyll-contentful (1.1.0)
       activesupport
       contentful (>= 2.6.0)
       contentful-management (~> 1.10.1)

--- a/_config.yml
+++ b/_config.yml
@@ -33,10 +33,10 @@ exclude:
 contentful:
   message:
     limit: 4
-    order: published_at
+    order: 'published_at desc'
   series:
     limit: 4
-    order: published_at
+    order: 'published_at desc'
   exclude:
     - album
     - article

--- a/_config.yml
+++ b/_config.yml
@@ -31,10 +31,17 @@ exclude:
   - netlify.toml
 
 contentful:
+  message:
+    limit: 4
+    order: published_at
+  series:
+    limit: 4
+    order: published_at
   exclude:
     - album
     - article
     - author
+    - category
     - commentary
     - discussion
     - discussion_question

--- a/_config.yml
+++ b/_config.yml
@@ -30,6 +30,23 @@ exclude:
   - vendor
   - netlify.toml
 
+contentful:
+  exclude:
+    - album
+    - article
+    - author
+    - commentary
+    - discussion
+    - discussion_question
+    - episode
+    - featured_media
+    - migration
+    - perspective
+    - podcast
+    - sign_off
+    - song
+    - video
+
 collections_dir: collections
 
 collections:

--- a/_config.yml
+++ b/_config.yml
@@ -75,8 +75,6 @@ collections:
   promos:
     filename: "{{ published_at | date: '%Y-%m-%d-%H:%M:%S' }}-{{ title | slugify }}-{{ slug }}"
     output: false
-  discussions:
-    output: false
 
 defaults:
   - scope:

--- a/netlify.toml
+++ b/netlify.toml
@@ -4,8 +4,6 @@
     bundle exec rspec &&
     ruby lib/bin/redirects.rb &&
     bundle exec jekyll crds &&
-    bundle exec jekyll contentful --collections pages,promos,locations && 
-    bundle exec jekyll contentful --collections series --limit 2 &&
-    bundle exec jekyll contentful --collections messages --limit 4 &&
+    bundle exec jekyll contentful -f &&
     bundle exec jekyll build -- --cloudsearch
   '''


### PR DESCRIPTION
What this does:
- updates us to jekyll-contentful 1.1.0
- uses new exclusions via config file
- grabs the 4 most recently (by `published_at`) messages and series