### PR TITLE
update for gemlock file

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,9 +9,9 @@ group :jekyll_plugins do
   # gem 'crds-styles', git: 'https://github.com/crdschurch/crds-styles.git', branch: 'development'
   gem 'crds-styles', git: 'https://github.com/crdschurch/crds-styles.git', tag: 'v3.0.6'
   gem "jekyll-contentful", git: 'https://github.com/crdschurch/jekyll-contentful.git', tag: '1.1.0'
-  gem "jekyll-crds", "~> 0.0.1", git: 'https://github.com/crdschurch/jekyll-crds.git', branch: 'master'
-  gem "jekyll-placeholders", "~> 0.0.1", github: 'ample/jekyll-placeholders'
-  gem "jekyll-cloudsearch", "~> 0.0.1", github: 'crdschurch/jekyll-cloudsearch'
+  gem "jekyll-crds", git: 'https://github.com/crdschurch/jekyll-crds.git', tag: '0.0.1'
+  gem "jekyll-placeholders", "~> 0.0.1", git: 'https://github.com/ample/jekyll-placeholders'
+  gem "jekyll-cloudsearch", git: 'https://github.com/crdschurch/jekyll-cloudsearch.git', tag: '0.0.1'
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,20 +1,10 @@
 GIT
-  remote: git://github.com/ample/jekyll-placeholders.git
+  remote: https://github.com/ample/jekyll-placeholders
   revision: 503eef68d21b020b8d611025ab7029c80e569186
   specs:
     jekyll-placeholders (0.0.1)
       activesupport
       jekyll
-
-GIT
-  remote: git://github.com/crdschurch/jekyll-cloudsearch.git
-  revision: 7e36695f47eb07a3848343fd5b0a1d9aa77b5238
-  specs:
-    jekyll-cloudsearch (0.0.2)
-      aws-sdk-cloudsearchdomain
-      contentful-management (~> 1.10.1)
-      jekyll
-      nokogiri
 
 GIT
   remote: https://github.com/crdschurch/crds-styles.git
@@ -24,6 +14,17 @@ GIT
     crds-styles (3.0.6)
       bootstrap-sass (~> 3.3)
       sass (~> 3.2)
+
+GIT
+  remote: https://github.com/crdschurch/jekyll-cloudsearch.git
+  revision: 7e36695f47eb07a3848343fd5b0a1d9aa77b5238
+  tag: 0.0.1
+  specs:
+    jekyll-cloudsearch (0.0.2)
+      aws-sdk-cloudsearchdomain
+      contentful-management (~> 1.10.1)
+      jekyll
+      nokogiri
 
 GIT
   remote: https://github.com/crdschurch/jekyll-contentful.git
@@ -39,8 +40,8 @@ GIT
 
 GIT
   remote: https://github.com/crdschurch/jekyll-crds.git
-  revision: 160c8c2a32f63a96deeb2e1fa8f3d773bc20411a
-  branch: master
+  revision: 9e7ea6ae39adef8a4e30d82baba43e4339137e15
+  tag: 0.0.1
   specs:
     jekyll-crds (0.0.1)
       activesupport
@@ -239,9 +240,9 @@ DEPENDENCIES
   guard-rspec
   jekyll (~> 3.7.4)
   jekyll-assets
-  jekyll-cloudsearch (~> 0.0.1)!
+  jekyll-cloudsearch!
   jekyll-contentful!
-  jekyll-crds (~> 0.0.1)!
+  jekyll-crds!
   jekyll-placeholders (~> 0.0.1)!
   rspec
   tzinfo-data

--- a/_includes/_shared_global_header.html
+++ b/_includes/_shared_global_header.html
@@ -54,22 +54,22 @@
 </ul></li>
 <li class="col-sm-3 ">
 <ul><li class="dropdown-header">Media Categories</li>
-<li><a href="//mediaint.crossroads.net" data-automation-id="sh-allmedia">All Media</a></li>
-<li><a href="//mediaint.crossroads.net/series" data-automation-id="sh-series">Series</a></li>
-<li><a href="//mediaint.crossroads.net/music" data-automation-id="sh-music">Music</a></li>
-<li><a href="//mediaint.crossroads.net/videos" data-automation-id="sh-videos">Videos</a></li>
-<li><a href="//mediaint.crossroads.net/articles" data-automation-id="sh-articles">Articles</a></li>
-<li><a href="//mediaint.crossroads.net/podcasts" ui-sref="mediaint.podcasts" data-automation-id="sh-podcasts">Podcasts</a></li>
-<li><a href="//int.crossroads.net/live" target="_blank" data-automation-id="sh-livestreaming">Live Streaming</a></li>
+<li><a href="//media.crossroads.net" data-automation-id="sh-allmedia">All Media</a></li>
+<li><a href="//media.crossroads.net/series" data-automation-id="sh-series">Series</a></li>
+<li><a href="//media.crossroads.net/music" data-automation-id="sh-music">Music</a></li>
+<li><a href="//media.crossroads.net/videos" data-automation-id="sh-videos">Videos</a></li>
+<li><a href="//media.crossroads.net/articles" data-automation-id="sh-articles">Articles</a></li>
+<li><a href="//media.crossroads.net/podcasts" ui-sref="media.podcasts" data-automation-id="sh-podcasts">Podcasts</a></li>
+<li><a href="//www.crossroads.net/live" target="_blank" data-automation-id="sh-livestreaming">Live Streaming</a></li>
 <li><a href="https://www.youtube.com/crdschurch" target="_blank" data-automation-id="sh-youtube">YouTube Channel</a></li>
 </ul></li>
 <li class="col-sm-3">
 <ul><li class="dropdown-header">Podcasts</li>
-<li><a href="https://mediaint.crossroads.net/podcasts/spirit-stories" data-exclude-mobile="">Spirit Stories</a></li>
-<li><a href="https://mediaint.crossroads.net/podcasts/ikr" data-exclude-mobile="">IKR</a></li>
-<li><a href="https://mediaint.crossroads.net/podcasts/too-long-didnt-read" data-exclude-mobile="">Too Long; Didn't Read</a></li>
-<li><a href="https://mediaint.crossroads.net/podcasts/messages" data-exclude-mobile="">Weekend Message Podcast</a></li>
-<li><a href="https://mediaint.crossroads.net/podcasts/kids-club" data-exclude-mobile="">Kids' Club Podcast</a></li>
+<li><a href="https://media.crossroads.net/podcasts/spirit-stories" data-exclude-mobile="">Spirit Stories</a></li>
+<li><a href="https://media.crossroads.net/podcasts/ikr" data-exclude-mobile="">IKR</a></li>
+<li><a href="https://media.crossroads.net/podcasts/too-long-didnt-read" data-exclude-mobile="">Too Long; Didn't Read</a></li>
+<li><a href="https://media.crossroads.net/podcasts/messages" data-exclude-mobile="">Weekend Message Podcast</a></li>
+<li><a href="https://media.crossroads.net/podcasts/kids-club" data-exclude-mobile="">Kids' Club Podcast</a></li>
 </ul></li>
 </ul></li>
 <li><a href="/giving/" data-automation-id="sh-giving">Give</a></li>


### PR DESCRIPTION
changed jekyll-placeholders to use git instead of github (was complaining about it being insecure)

changed jekyll-cloudsearch to use tag instead of master branch, also changed to "git:" instead of "github:"