### PR TITLE
US15273 Redirect Contexts

### DIFF
--- a/lib/crds/redirect_writer.rb
+++ b/lib/crds/redirect_writer.rb
@@ -1,6 +1,5 @@
 require_relative '../utils/colorized_string'
 require 'csv'
-require 'pry'
 
 module CRDS
   class RedirectWriter

--- a/lib/crds/redirect_writer.rb
+++ b/lib/crds/redirect_writer.rb
@@ -29,10 +29,10 @@ module CRDS
       @redirs.each do |redir|
         if redir.context_included?
           printf colorized_s, redir.path, redir.dest, redir.status if @debug
+          @output.puts(redir.to_s)
         else
           log "\s\s#{redir.error}", :red
         end
-        @output.puts(redir.to_s)
         @total += 1
       end
       @output.close
@@ -79,8 +79,11 @@ module CRDS
         end
 
         def deployment_context
-          if ENV['CONTEXT'].nil? || %w(production deploy-preview).include?(ENV['CONTEXT'])
+          if ENV['CONTEXT'].nil? || ENV['CONTEXT'] == 'production'
             ENV['BRANCH'].nil? ? self.class.git_branch : ENV['BRANCH']
+          elsif ENV['CONTEXT'] == 'deploy-preview'
+            # If deploy preview, build against 'development' branch
+            'development'
           else
             ENV['CONTEXT']
           end

--- a/lib/crds/redirect_writer.rb
+++ b/lib/crds/redirect_writer.rb
@@ -1,44 +1,53 @@
 require_relative '../utils/colorized_string'
 require 'csv'
+require 'pry'
 
 module CRDS
   class RedirectWriter
 
-    attr_accessor :output, :src, :csv, :debug
+    attr_accessor :output, :src, :dest, :csv, :debug, :redirs
 
     def initialize(dest_dir=nil)
       FileUtils.mkdir_p dest_dir unless dest_dir.nil?
-      @output = File.new(File.join(dest_dir || Dir.pwd, '_redirects'), "w")
+      @dest = File.join(dest_dir || Dir.pwd, '_redirects')
       @src = File.join(Dir.pwd, 'redirects.csv')
+      @redirs = []
       @total = 0
       @debug = true
+      setup()
+    end
+
+    def setup
+      @csv = CSV.read(src)
+      @redirs = @csv.collect do |row|
+        Redirect.new(row)
+      end
     end
 
     def write!
       log "Writing _redirects...", :green
-      @csv = CSV.read(src)
-      @csv.map{|row| parse_row(row) }
+      @output = File.new(@dest, "w")
+      @redirs.each do |redir|
+        if redir.context_included?
+          printf colorized_s, redir.path, redir.dest, redir.status if @debug
+        else
+          log "\s\s#{redir.error}", :red
+        end
+        @output.puts(redir.to_s)
+        @total += 1
+      end
       @output.close
       log "#{@total} rows written to _redirects file", :green
     end
 
     private
 
-      def parse_row(row)
-        path, dest, status = row
-        path = replace(path)
-        dest = replace(dest)
-        printf colorized_s, path, dest, status if @debug
-        @output.puts("#{path}\t#{dest}\t#{status}")
-        @total += 1
-      end
-
       # Returns the length of the longest lines in our CSV
       # so we can format the build output real nice
       def tabs
         [
-          replace(@csv.collect(&:first).max_by(&:length)).length + 3,
-          replace(@csv.collect{|row| row.drop(1).each_slice(2).map(&:first) }.flatten.max_by(&:length)).length + 3
+          Redirect.replace(@csv.collect(&:first).max_by(&:length)).length + 3,
+          Redirect.replace(@csv.collect{|row| row.drop(1).each_slice(2).map(&:first) }.flatten.max_by(&:length)).length + 15
         ]
       end
 
@@ -46,21 +55,62 @@ module CRDS
         ColorizedString.new("\s\s%-#{tabs[0]}s %-#{tabs[1]}s %s\n").send(:yellow)
       end
 
-      def replace(str)
-        if matches = str.match(/(\$\{env\:(.*)})/)
-          str.gsub matches[1], ENV[matches[2]]
-        else
-          str
-        end
-      rescue
-        str
-      end
-
       def log(str, color=nil)
         if @debug
           STDOUT.write color ? ColorizedString.new(str).send(color) : str
           STDOUT.write("\n")
         end
+      end
+
+      class Redirect
+        attr_accessor :path, :dest, :status, :context
+
+        def initialize(csv)
+          @path, @dest, @status, @context = csv
+        end
+
+        def to_s
+          path = self.class.replace(@path)
+          dest = self.class.replace(@dest)
+          "#{path}\t#{dest}\t#{@status}"
+        end
+
+        def context_included?
+          @context.nil? || @context.split(',').include?(deployment_context)
+        end
+
+        def deployment_context
+          if ENV['CONTEXT'].nil? || %w(production deploy-preview).include?(ENV['CONTEXT'])
+            ENV['BRANCH'].nil? ? self.class.git_branch : ENV['BRANCH']
+          else
+            ENV['CONTEXT']
+          end
+        end
+
+        def error
+          unless context_included?
+            if deployment_context.nil?
+              "#{@path} specified context but none was defined."
+            else
+              "#{@path} did not match context '#{deployment_context}'."
+            end
+          end
+        end
+
+        def self.replace(str)
+          if matches = str.match(/(\$\{env\:(.*)})/)
+            str.gsub matches[1], ENV[matches[2]]
+          else
+            str
+          end
+        rescue
+          str
+        end
+
+        def self.git_branch
+          `git rev-parse --abbrev-ref HEAD | tr -d '\n'`
+        end
+
       end
 
   end

--- a/redirects.csv
+++ b/redirects.csv
@@ -1,7 +1,7 @@
 http://${env:CRDS_APP_DOMAIN}/*,https://${env:CRDS_APP_DOMAIN}/:splat,301!
 /undivided-training,https://undivided.netlify.com,301
 /people/*,https://crdspeople.netlify.com/:splat,200!,"development,release"
-/map/*,https://crdsmap.netlify.com/:splat,200!,development
+/map/*,https://crdsmap.netlify.com/:splat,200!,"development,release"
 /thechaser,${env:CRDS_MEDIA_ENDPOINT}/the-chaser,302
 /the-chaser,${env:CRDS_MEDIA_ENDPOINT}/the-chaser,302
 /proxy/content/*,${env:CRDS_CMS_ENDPOINT}/:splat,200!

--- a/redirects.csv
+++ b/redirects.csv
@@ -1,7 +1,7 @@
 http://${env:CRDS_APP_DOMAIN}/*,https://${env:CRDS_APP_DOMAIN}/:splat,301!
 /undivided-training,https://undivided.netlify.com,301
-/people/*,https://crdspeople.netlify.com/:splat,200!
-/map/*,https://crdsmap.netlify.com/:splat,200!
+/people/*,https://crdspeople.netlify.com/:splat,200!,"development,release"
+/map/*,https://crdsmap.netlify.com/:splat,200!,development
 /thechaser,${env:CRDS_MEDIA_ENDPOINT}/the-chaser,302
 /the-chaser,${env:CRDS_MEDIA_ENDPOINT}/the-chaser,302
 /proxy/content/*,${env:CRDS_CMS_ENDPOINT}/:splat,200!

--- a/spec/unit/redirect_writer_spec.rb
+++ b/spec/unit/redirect_writer_spec.rb
@@ -1,6 +1,77 @@
 require 'spec_helper'
 require 'crds/redirect_writer'
 
+describe CRDS::RedirectWriter::Redirect do
+
+  before do
+    src = "/undivided-training,https://undivided.netlify.com,301"
+    @redirect = CRDS::RedirectWriter::Redirect.new(src.split(','))
+  end
+
+  it 'should do string replacements' do
+    ENV['JEKYLL_REDIR_TEST'] = 'lebowski'
+    expect(CRDS::RedirectWriter::Redirect.send(:replace, 'jeff/${env:JEKYLL_REDIR_TEST}/dude')).to eq('jeff/lebowski/dude')
+  end
+
+  it 'should return redirect rule via to_s method' do
+    expect(@redirect.to_s).to eq("/undivided-training\thttps://undivided.netlify.com\t301")
+  end
+
+  context 'evaluating current context' do
+
+    it 'should return env value for CONTEXT' do
+      ENV['CONTEXT'] = 'release'
+      expect(@redirect.deployment_context).to eq('release')
+    end
+
+    context 'when CONTEXT is nil' do
+      it 'should return BRANCH' do
+        ENV['CONTEXT'] = nil
+        ENV['BRANCH'] = 'some-branch'
+        expect(@redirect.deployment_context).to eq('some-branch')
+      end
+    end
+
+    context 'when CONTEXT and BRANCH are both nil' do
+      it 'should return current git branch from system' do
+        ENV['CONTEXT'] = nil
+        ENV['BRANCH'] = nil
+        branch = @redirect.class.git_branch
+        expect(@redirect.deployment_context).to eq(branch)
+      end
+    end
+
+    context 'when CONTEXT is production or deploy-preview' do
+      it 'should default to current git branch when context is production or deploy-preview' do
+        branch = @redirect.class.git_branch
+        ENV['CONTEXT'] = 'production'
+        expect(@redirect.deployment_context).to eq(branch)
+        ENV['CONTEXT'] = 'deploy-preview'
+        expect(@redirect.deployment_context).to eq(branch)
+      end
+    end
+  end
+
+  it 'should include rules with context specified' do
+    src = "/undivided-training,https://undivided.netlify.com,301,release"
+    @redirect = CRDS::RedirectWriter::Redirect.new(src.split(','))
+    ENV['CONTEXT'] = 'release'
+    expect(@redirect.context_included?).to be_truthy
+  end
+
+  it 'should exclude rules that do not match current context' do
+    src = %w(/zzz https://undivided.netlify.com 301 zzz,release)
+    @redirect = CRDS::RedirectWriter::Redirect.new(src)
+    ENV['CONTEXT'] = 'zzz'
+    expect(@redirect.context_included?).to be_truthy
+    ENV['CONTEXT'] = 'release'
+    expect(@redirect.context_included?).to be_truthy
+    ENV['CONTEXT'] = 'production'
+    expect(@redirect.context_included?).to be_falsey
+  end
+
+end
+
 describe CRDS::RedirectWriter do
 
   before do
@@ -9,22 +80,22 @@ describe CRDS::RedirectWriter do
   end
 
   it 'should populate some instance variables' do
-    expect(@redir.output).to be_a(File)
-    expect(@redir.output.to_path).to eq(File.join(Dir.pwd, 'tmp', '_redirects'))
+    expect(@redir.dest).to eq(File.join(Dir.pwd, 'tmp', '_redirects'))
     expect(@redir.src).to eq(File.join(Dir.pwd, 'redirects.csv'))
   end
 
-  it 'should do string replacements' do
-    ENV['JEKYLL_REDIR_TEST'] = 'lebowski'
-    expect(@redir.send(:replace, 'jeff/${env:JEKYLL_REDIR_TEST}/dude')).to eq('jeff/lebowski/dude')
+  it 'should instantiate Redirect objects for each line in src' do
+    @redir.setup()
+    expect(@redir.redirs.all?{|obj| obj.is_a?(CRDS::RedirectWriter::Redirect) }).to be_truthy
   end
 
   it 'should write _redirects' do
     FileUtils.rm_r File.join(Dir.pwd, 'tmp', '_redirects')
-    expect(File.exist?(@redir.output.to_path)).to be(false)
     @redir = CRDS::RedirectWriter.new(@dest_dir)
     @redir.debug = false
     @redir.write!
+    expect(@redir.output).to be_a(File)
+    expect(@redir.output.to_path).to eq(File.join(Dir.pwd, 'tmp', '_redirects'))
     expect(File.exist?(@redir.output.to_path)).to be(true)
   end
 

--- a/spec/unit/redirect_writer_spec.rb
+++ b/spec/unit/redirect_writer_spec.rb
@@ -41,16 +41,23 @@ describe CRDS::RedirectWriter::Redirect do
       end
     end
 
-    context 'when CONTEXT is production or deploy-preview' do
-      it 'should default to current git branch when context is production or deploy-preview' do
+    context 'when CONTEXT is production' do
+      it 'should default to current git branch' do
         branch = @redirect.class.git_branch
         ENV['CONTEXT'] = 'production'
         expect(@redirect.deployment_context).to eq(branch)
+      end
+    end
+
+    context 'when CONTEXT is deploy-preview' do
+      it 'should default to development' do
         ENV['CONTEXT'] = 'deploy-preview'
-        expect(@redirect.deployment_context).to eq(branch)
+        expect(@redirect.deployment_context).to eq('development')
       end
     end
   end
+
+
 
   it 'should include rules with context specified' do
     src = "/undivided-training,https://undivided.netlify.com,301,release"

--- a/spec/unit/redirect_writer_spec.rb
+++ b/spec/unit/redirect_writer_spec.rb
@@ -90,7 +90,8 @@ describe CRDS::RedirectWriter do
   end
 
   it 'should write _redirects' do
-    FileUtils.rm_r File.join(Dir.pwd, 'tmp', '_redirects')
+    dest = File.join(Dir.pwd, 'tmp', '_redirects')
+    FileUtils.rm(dest) if File.exist?(dest)
     @redir = CRDS::RedirectWriter.new(@dest_dir)
     @redir.debug = false
     @redir.write!


### PR DESCRIPTION
**tldr;**  

When adding redirect rules into `redirects.csv` you can now define a 4th column for 'context' that determines which branches the rules will be deployed. If that column doesn't exist for a given row, the rule will be deployed everywhere. 

---

This PR adds contexts to `redirects.csv` so you can target different environments with your rules. This allows us to include certain redirects/proxies in INT (during feature development) while excluding them from PROD. 

This concept of "context" is largely driven by Netlify's idea of [deployment-context](https://www.netlify.com/docs/continuous-deployment/#deploy-contexts) albeit with some nuance not worth explaining here. For practical purposes, we can use this new feature by defining the target branch(es) as our context, for example...

```
/people/*,https://crdspeople.netlify.com/:splat,200!,"development,release"
```

...will parse and deploy the above rule for any builds against the `development` or `release` branch (note the 4th column, multiple branches need to be wrap in quotes). When the build is tied to a deployment preview, it will assume `development` as the context. 

Rules excluded will be logged to the build output... 

<img width="741" alt="screenshot 2018-10-16 22 44 43" src="https://user-images.githubusercontent.com/50378/47058939-3687c580-d195-11e8-802a-3c53778a90b8.png">
