### PR TITLE
DE6073 - Current series logic

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -66,7 +66,7 @@ collections:
     output: true
     permalink: /:slug
   series:
-    filename: "{{ starts_at | date: '%Y-%m-%d' }}-{{ slug }}"
+    filename: "{{ published_at | date: '%Y-%m-%d' }}-{{ slug }}"
     output: false
     has_many:
       - videos


### PR DESCRIPTION
## Problem
Current series is defined by when it starts rather than when it's published. This creates an issue where upcoming series aren't publicized before they begin.

## Solution
Change series sort to `published_at` instead of `starts_at`. Checked with BSO and they say this doesn't impact them.

### Corresponding Branch
crdschurch/crds-media-snippets#14
crdschurch/crds-media#431

## Testing
Check /series and media landing (series section) to make sure the most recently published series shows first.