### PR TITLE
shenney/CYP - Smarter Travis configs

### DIFF
--- a/cypress/kickOffCypress.sh
+++ b/cypress/kickOffCypress.sh
@@ -1,15 +1,27 @@
 #!/usr/bin/env bash
 
-body="{\"request\": { \"branch\":\"$HEAD\", \"config\": {\"env\": { \"baseURL\": \"$DEPLOY_URL\", \"contentfulSpaceId\": \"$CONTENTFUL_SPACE_ID\", \"contentfulEnv\": \"$CONTENTFUL_ENV\", \"contentfulToken\": \"$CONTENTFUL_ACCESS_TOKEN\", \"mediaEndpoint\": \"$CRDS_MEDIA_ENDPOINT\"}}}}"
-
-#Run Cypress tests against Netlify's preview build unless we're deploying to Prod
-if [ "$CRDS_APP_DOMAIN" != "www.crossroads.net" ]
+#Skip testing in Prod
+#TODO will this work with $URL too?
+if [[ "$CRDS_APP_DOMAIN" == *"www.crossroads.net" ]]
 then
-    curl -s -X POST \
-    -H "Content-Type: application/json" \
-    -H "Accept: application/json" \
-    -H "Travis-API-Version: 3" \
-    -H "Authorization: token $TRAVIS_CI" \
-    -d "$body" \
-    https://api.travis-ci.org/repo/crdschurch%2Fcrds-net/requests
- fi
+    exit 0
+fi
+
+#Test the live site if we're deploying to it, else test Netlify's preview
+if ["$CONTEXT" == "production"]
+then
+    test_this_URL = "$URL" #TODO is this int on branch?
+else
+    test_this_URL = "$DEPLOY_URL"
+fi
+
+body="{\"request\": { \"branch\":\"$HEAD\", \"config\": {\"env\": { \"baseURL\": \"$test_this_URL\", \"contentfulSpaceId\": \"$CONTENTFUL_SPACE_ID\", \"contentfulEnv\": \"$CONTENTFUL_ENV\", \"contentfulToken\": \"$CONTENTFUL_ACCESS_TOKEN\", \"mediaEndpoint\": \"$CRDS_MEDIA_ENDPOINT\"}}}}"
+
+
+curl -s -X POST \
+-H "Content-Type: application/json" \
+-H "Accept: application/json" \
+-H "Travis-API-Version: 3" \
+-H "Authorization: token $TRAVIS_CI" \
+-d "$body" \
+https://api.travis-ci.org/repo/crdschurch%2Fcrds-net/requests

--- a/cypress/kickOffCypress.sh
+++ b/cypress/kickOffCypress.sh
@@ -2,17 +2,17 @@
 
 #Skip testing in Prod
 #TODO will this work with $URL too?
-if [[ "$CRDS_APP_DOMAIN" == *"www.crossroads.net" ]]
+if [[ $CRDS_APP_DOMAIN == *"www.crossroads.net" ]]
 then
     exit 0
 fi
 
 #Test the live site if we're deploying to it, else test Netlify's preview
-if ["$CONTEXT" == "production"]
+if [$CONTEXT == "production"]
 then
-    test_this_URL = "$URL" #TODO is this int on branch?
+    test_this_URL=$URL #TODO is this int on branch?
 else
-    test_this_URL = "$DEPLOY_URL"
+    test_this_URL=$DEPLOY_URL
 fi
 
 body="{\"request\": { \"branch\":\"$HEAD\", \"config\": {\"env\": { \"baseURL\": \"$test_this_URL\", \"contentfulSpaceId\": \"$CONTENTFUL_SPACE_ID\", \"contentfulEnv\": \"$CONTENTFUL_ENV\", \"contentfulToken\": \"$CONTENTFUL_ACCESS_TOKEN\", \"mediaEndpoint\": \"$CRDS_MEDIA_ENDPOINT\"}}}}"

--- a/cypress/kickOffCypress.sh
+++ b/cypress/kickOffCypress.sh
@@ -8,14 +8,14 @@ then
 fi
 
 #Test the live site if we're deploying to it, else test Netlify's preview
-if [$CONTEXT != "production"]#should be ==
+if [$CONTEXT == "production"]#this isn't working - what is Context's value?
 then
-    test_this_URL=$CRDS_APP_CLIENT_ENDPOINT #TODO is this int on branch?
+    test_this_URL=$CRDS_APP_CLIENT_ENDPOINT
 else
-    test_this_URL=$DEPLOY_URL
+    test_this_URL=$CRDS_APP_CLIENT_ENDPOINT #DEPLOY_URL
 fi
 
-body="{\"request\": { \"branch\":\"$HEAD\", \"config\": {\"env\": { \"baseURL\": \"$test_this_URL\", \"contentfulSpaceId\": \"$CONTENTFUL_SPACE_ID\", \"contentfulEnv\": \"$CONTENTFUL_ENV\", \"contentfulToken\": \"$CONTENTFUL_ACCESS_TOKEN\", \"mediaEndpoint\": \"$CRDS_MEDIA_ENDPOINT\"}}}}"
+body="{\"request\": { \"branch\":\"$HEAD\", \"config\": {\"env\": { \"baseURL\": \"$test_this_URL\", \"contentfulSpaceId\": \"$CONTENTFUL_SPACE_ID\", \"contentfulEnv\": \"$CONTENTFUL_ENV\", \"contentfulToken\": \"$CONTENTFUL_ACCESS_TOKEN\", \"mediaEndpoint\": \"$CRDS_MEDIA_ENDPOINT\", \"TEMPnetlifyContext\": \"$CONTEXT\"}}}}"
 
 
 curl -s -X POST \

--- a/cypress/kickOffCypress.sh
+++ b/cypress/kickOffCypress.sh
@@ -1,22 +1,20 @@
 #!/usr/bin/env bash
 
 #Skip testing in Prod
-#TODO will this work with $CRDS_APP_CLIENT_ENDPOINT too?
-if [[ "$CRDS_APP_CLIENT_ENDPOINT" = *"www.crossroads.net" ]];
+if [[ "$CRDS_APP_CLIENT_ENDPOINT" = *"int.crossroads.net" ]];
 then
     exit 0
 fi
 
 #Test the live site if we're deploying to it, else test Netlify's preview
-if [ "$CONTEXT" != "production" ];#try again with better syntax
+if [ "$CONTEXT" == "production" ];
 then
     test_this_URL=$CRDS_APP_CLIENT_ENDPOINT
 else
     test_this_URL=$DEPLOY_URL
 fi
 
-body="{\"request\": { \"branch\":\"$HEAD\", \"config\": {\"env\": { \"baseURL\": \"$test_this_URL\", \"contentfulSpaceId\": \"$CONTENTFUL_SPACE_ID\", \"contentfulEnv\": \"$CONTENTFUL_ENV\", \"contentfulToken\": \"$CONTENTFUL_ACCESS_TOKEN\", \"mediaEndpoint\": \"$CRDS_MEDIA_ENDPOINT\", \"NetlifyContext\": \"$CONTEXT\"}}}}"
-
+body="{\"request\": { \"branch\":\"$HEAD\", \"config\": {\"env\": { \"baseURL\": \"$test_this_URL\", \"contentfulSpaceId\": \"$CONTENTFUL_SPACE_ID\", \"contentfulEnv\": \"$CONTENTFUL_ENV\", \"contentfulToken\": \"$CONTENTFUL_ACCESS_TOKEN\", \"mediaEndpoint\": \"$CRDS_MEDIA_ENDPOINT\", \"DEBUG_NetlifyContext\": \"$CONTEXT\"}}}}"
 
 curl -s -X POST \
 -H "Content-Type: application/json" \

--- a/cypress/kickOffCypress.sh
+++ b/cypress/kickOffCypress.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 
 #Skip testing in Prod
-#TODO will this work with $URL too?
-if [[ $CRDS_APP_DOMAIN == *"www.crossroads.net" ]]
+#TODO will this work with $CRDS_APP_CLIENT_ENDPOINT too?
+if [[ $CRDS_APP_CLIENT_ENDPOINT == *"www.crossroads.net" ]]
 then
     exit 0
 fi
@@ -10,7 +10,7 @@ fi
 #Test the live site if we're deploying to it, else test Netlify's preview
 if [$CONTEXT != "production"]#should be ==
 then
-    test_this_URL=$URL #TODO is this int on branch?
+    test_this_URL=$CRDS_APP_CLIENT_ENDPOINT #TODO is this int on branch?
 else
     test_this_URL=$DEPLOY_URL
 fi

--- a/cypress/kickOffCypress.sh
+++ b/cypress/kickOffCypress.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
-#Skip testing in Prod
-if [[ "$CRDS_APP_CLIENT_ENDPOINT" = *"int.crossroads.net" ]];
+#Skip all testing in Prod
+if [[ "$CRDS_APP_CLIENT_ENDPOINT" = *"www.crossroads.net" ]];
 then
     exit 0
 fi

--- a/cypress/kickOffCypress.sh
+++ b/cypress/kickOffCypress.sh
@@ -8,7 +8,7 @@ then
 fi
 
 #Test the live site if we're deploying to it, else test Netlify's preview
-if [$CONTEXT == "production"]
+if [$CONTEXT != "production"]#should be ==
 then
     test_this_URL=$URL #TODO is this int on branch?
 else

--- a/cypress/kickOffCypress.sh
+++ b/cypress/kickOffCypress.sh
@@ -2,20 +2,20 @@
 
 #Skip testing in Prod
 #TODO will this work with $CRDS_APP_CLIENT_ENDPOINT too?
-if [[ $CRDS_APP_CLIENT_ENDPOINT == *"www.crossroads.net" ]]
+if [[ "$CRDS_APP_CLIENT_ENDPOINT" = *"www.crossroads.net" ]];
 then
     exit 0
 fi
 
 #Test the live site if we're deploying to it, else test Netlify's preview
-if [$CONTEXT == "production"]#this isn't working - what is Context's value?
+if [ "$CONTEXT" != "production" ];#try again with better syntax
 then
     test_this_URL=$CRDS_APP_CLIENT_ENDPOINT
 else
-    test_this_URL=$CRDS_APP_CLIENT_ENDPOINT #DEPLOY_URL
+    test_this_URL=$DEPLOY_URL
 fi
 
-body="{\"request\": { \"branch\":\"$HEAD\", \"config\": {\"env\": { \"baseURL\": \"$test_this_URL\", \"contentfulSpaceId\": \"$CONTENTFUL_SPACE_ID\", \"contentfulEnv\": \"$CONTENTFUL_ENV\", \"contentfulToken\": \"$CONTENTFUL_ACCESS_TOKEN\", \"mediaEndpoint\": \"$CRDS_MEDIA_ENDPOINT\", \"TEMPnetlifyContext\": \"$CONTEXT\"}}}}"
+body="{\"request\": { \"branch\":\"$HEAD\", \"config\": {\"env\": { \"baseURL\": \"$test_this_URL\", \"contentfulSpaceId\": \"$CONTENTFUL_SPACE_ID\", \"contentfulEnv\": \"$CONTENTFUL_ENV\", \"contentfulToken\": \"$CONTENTFUL_ACCESS_TOKEN\", \"mediaEndpoint\": \"$CRDS_MEDIA_ENDPOINT\", \"NetlifyContext\": \"$CONTEXT\"}}}}"
 
 
 curl -s -X POST \


### PR DESCRIPTION
- Fixed Travis config so tests will run against Netlify's preview url on a new PR, and against the live site once the PR is merged. Currently it will not run against Prod, either preview or live site.
- Make it easier to 'turn on' testing in production