### PR TITLE
DE6168: Remove Sitetree links

### DIFF
--- a/_pages/baptism.html
+++ b/_pages/baptism.html
@@ -5,41 +5,46 @@ permalink: /baptism/
 ---
 
 <p>
-  <img data-src="//crds-cms-uploads.imgix.net/content/images/crossroads-baptisms2.jpg" class="imgix-fluid img-responsive" alt="" title=""></p><div class="row push-top">
-<div class="col-md-12">
-<h1 class="page-header">Baptism</h1>
-<h2 class="subtitle">a public declaration of an inward reality</h2>
-</div>
-<div class="col-sm-8 col-md-7 push-ends">
-<p class="lead">Baptism is when you tell the world "I belong to Jesus." It's an outward expression of an inward transformation that has already taken place through personal faith in Jesus Christ as Lord and Savior. People who follow Jesus choose to be baptized because Jesus commanded it. It's like a wedding ring—a symbol that represents a commitment you've made.</p>
-<div class="push-top">
-<p class="font-size-base"><strong>Do you dedicate or baptize infants?</strong><br>Parents have the most influence in the lives of their children and dedicating or baptizing your infant child is a way to commit to modeling what it means to follow Jesus. If you would like to have your infant dedicated or baptized, or just have questions:</p>
-<p class="font-size-base"><a href="/baptism/infant-baptism-and-dedication/">Register for Infant Dedication or Baptism</a><br><br><strong>Questions about Infant Dedication or Baptism?<br>Email your site below</strong>:</p>
-<p class="font-size-base"><a href="mailto:kcandover@crossroads.net">Andover<br></a><a href="mailto:mark.wiesmann@crossroads.net">Dayton</a><br><a href="mailto:eastsideinfants@crossroads.net">East Side</a><br><a href="mailto:florenceinfants@crossroads.net">Florence</a><br><a href="mailto:kcgeorgetown@crossroads.net">Georgetown</a><br><a href="mailto:masoninfants@crossroads.net">Mason</a><br><a href="mailto:infants@crossroads.net">Oakley</a><br><a href="mailto:richmondinfants@crossroads.net">Richmond</a><br><a href="mailto:kcwestside@crossroads.net">West Side</a></p>
-</div>
-</div>
-<div class="col-sm-4 col-md-5 push-ends">
-<div class="bg-gray soft">
-<p class="font-family-condensed-extra font-size-h5 push-quarter-bottom text-uppercase">Upcoming Baptisms</p>
-<p class="font-size-small">The next baptisms are schedule for the weekend of November 10-11. Sign up below.</p>
-<a class="font-size-small" href="https://crossroads.net/baptism/baptism-sign-up-k-8/" target="_blank">K - 8th graders</a><br><a class="font-size-small" href="/baptism/baptism-sign-up-teens-and-adults/">Teens and Adults<br></a><hr style="border-color: #a9a9a9;"><p class="font-family-condensed-extra font-size-h5 push-quarter-bottom text-uppercase">Other Questions?</p>
-<a class="font-size-small" href="/baptism/baptism-faq/">View Baptism FAQ</a>
-<p class="font-size-small">Email <a href="https://crossroads.net/%5Bsitetree_link,id=%5Dmailto:baptism@crossroads.net" target="_blank">baptism@crossroads.net</a></p>
-<!--<hr style="border-color: #a9a9a9;" /><p class="font-family-condensed-extra font-size-h5 push-quarter-bottom text-uppercase"><strong>Upcoming Baptism Information Sessions</strong></p>
-<div class="gmail_default">
-<p class="font-size-small"><strong>Andover:&nbsp;</strong><span class="aBn" data-term="goog_1564102226" tabindex="0"><span class="aQJ">Octob</span></span><span class="aBn" data-term="goog_1564102226" tabindex="0"><span class="aQJ">er</span></span><span class="aBn" data-term="goog_1564102226" tabindex="0"><span class="aQJ">&nbsp;28 after each service in the Connect Lounge</span></span></p>
-<p class="font-size-small"><strong>Dayton:&nbsp;</strong><span class="aBn" data-term="goog_1564102226" tabindex="0">Octob</span><span class="aBn" data-term="goog_1564102226" tabindex="0">er</span><span class="aBn" data-term="goog_1564102226" tabindex="0">&nbsp;14 at 11:15am</span>&nbsp;in the BHS Band Room</p>
-<p class="font-size-small"><strong>East Side:</strong>&nbsp;<span class="aBn" data-term="goog_1564102227" tabindex="0"><span class="aQJ">October 13 at 6:45pm</span></span>&nbsp;and&nbsp;<span class="aBn" data-term="goog_1564102228" tabindex="0"><span class="aQJ">October 14 at 10:15am and 12:15pm</span></span>&nbsp;in Meeting Room C</p>
-<p class="font-size-small"><strong>Florence:</strong>&nbsp;<span class="aBn" data-term="goog_1564102229" tabindex="0"><span class="aQJ">October 13 and&nbsp;</span></span><span class="aBn" data-term="goog_1564102230" tabindex="0"><span class="aQJ">14 after each service&nbsp;</span></span>in the Office Area</p>
-<p class="font-size-small"><strong>Georgetown:</strong>&nbsp;<span class="aBn" data-term="goog_1564102231" tabindex="0"><span class="aQJ">October 28 at 10:30am and 12:15pm</span></span>&nbsp;in the Auditorium</p>
-<p class="font-size-small"><strong>Mason:</strong>&nbsp;<span class="aBn" data-term="goog_1564102232" tabindex="0"><span class="aQJ">October 27 at 6:15pm</span></span>&nbsp;and&nbsp;<span class="aBn" data-term="goog_1564102233" tabindex="0"><span class="aQJ">October 28 at 10:30am and 12:30pm</span></span>&nbsp;in Meeting Room C</p>
-<p class="font-size-small"><strong>Oakley:&nbsp;</strong><span class="aBn" data-term="goog_1564102234" tabindex="0"><span class="aQJ">October 13 at 3pm</span></span>&nbsp;in Meeting Room C and&nbsp;<span class="aBn" data-term="goog_1564102235" tabindex="0"><span class="aQJ">October 14 at 10:00am</span></span>,&nbsp;<span class="aBn" data-term="goog_1564102236" tabindex="0"><span class="aQJ">11:30am and 1pm</span></span>&nbsp;in Meeting Room B</p>
-<p class="font-size-small"><strong>Richmond:</strong>&nbsp;October 28 after each service in the Orange Room</p>
-<p class="font-size-small"><strong></strong><span class="aBn" data-term="goog_1564102235" tabindex="0"></span><strong>Uptown:&nbsp;</strong>Email&nbsp;<a href="mailto:uptown@crossroads.net" target="_blank">uptown@crossroads.net</a>&nbsp;for more info</p>
-<p class="font-size-small"><strong>West Side: </strong>October 13 and 14 after each service at the Info Center</p>
-</div>--></div>
-</div>
-<div class="row">
-<div class="col-sm-12"><img data-src="//crds-cms-uploads.imgix.net/content/images/crossroads-baptism-collage.jpg" class="imgix-fluid img-responsive" alt="" title="" style="color: #333333;"></div>
-</div>
+  <img data-src="//crds-cms-uploads.imgix.net/content/images/crossroads-baptisms2.jpg" class="imgix-fluid img-responsive"
+    alt="" title=""></p>
+<div class="row push-top">
+  <div class="col-md-12">
+    <h1 class="page-header">Baptism</h1>
+    <h2 class="subtitle">a public declaration of an inward reality</h2>
+  </div>
+  <div class="col-sm-8 col-md-7 push-ends">
+    <p class="lead">Baptism is when you tell the world "I belong to Jesus." It's an outward expression of an inward
+      transformation that has already taken place through personal faith in Jesus Christ as Lord and Savior. People who
+      follow Jesus choose to be baptized because Jesus commanded it. It's like a wedding ring—a symbol that represents
+      a commitment you've made.</p>
+    <div class="push-top">
+      <p class="font-size-base"><strong>Do you dedicate or baptize infants?</strong><br>Parents have the most influence
+        in the lives of their children and dedicating or baptizing your infant child is a way to commit to modeling
+        what it means to follow Jesus. If you would like to have your infant dedicated or baptized, or just have
+        questions:</p>
+      <p class="font-size-base"><a href="/baptism/infant-baptism-and-dedication/">Register for Infant Dedication or
+          Baptism</a><br><br><strong>Questions about Infant Dedication or Baptism?<br>Email your site below</strong>:</p>
+      <p class="font-size-base"><a href="mailto:kcandover@crossroads.net">Andover<br></a><a href="mailto:mark.wiesmann@crossroads.net">Dayton</a><br><a
+          href="mailto:eastsideinfants@crossroads.net">East Side</a><br><a href="mailto:florenceinfants@crossroads.net">Florence</a><br><a
+          href="mailto:kcgeorgetown@crossroads.net">Georgetown</a><br><a href="mailto:masoninfants@crossroads.net">Mason</a><br><a
+          href="mailto:infants@crossroads.net">Oakley</a><br><a href="mailto:richmondinfants@crossroads.net">Richmond</a><br><a
+          href="mailto:kcwestside@crossroads.net">West Side</a></p>
+    </div>
+  </div>
+  <div class="col-sm-4 col-md-5 push-ends">
+    <div class="bg-gray soft">
+      <p class="font-family-condensed-extra font-size-h5 push-quarter-bottom text-uppercase">Upcoming Baptisms</p>
+      <p class="font-size-small">The next baptisms are schedule for the weekend of November 10-11. Sign up below.</p>
+      <a class="font-size-small" href="https://crossroads.net/baptism/baptism-sign-up-k-8/" target="_blank">K - 8th
+        graders</a><br><a class="font-size-small" href="/baptism/baptism-sign-up-teens-and-adults/">Teens and Adults<br></a>
+      <hr style="border-color: #a9a9a9;">
+      <p class="font-family-condensed-extra font-size-h5 push-quarter-bottom text-uppercase">Other Questions?</p>
+      <a class="font-size-small" href="/baptism/baptism-faq/">View Baptism FAQ</a>
+      <p class="font-size-small">Email <a href="mailto:baptism@crossroads.net" target="_blank">baptism@crossroads.net</a></p>
+    </div>
+  </div>
+  <div class="row">
+    <div class="col-sm-12"><img data-src="//crds-cms-uploads.imgix.net/content/images/crossroads-baptism-collage.jpg"
+        class="imgix-fluid img-responsive" alt="" title="" style="color: #333333;"></div>
+  </div>
 </div>

--- a/_pages/leader-update.html
+++ b/_pages/leader-update.html
@@ -5,38 +5,48 @@ permalink: /groups/leader/leader-update/
 ---
 
 <div class="container">
-<div class="jumbotron jumbotron-xl row" style="background-image: url(&#039;//crds-cms-uploads.imgix.net/content/images/crossroads-group-leader-update.jpg&#039;);">
-<div class="row">
-<div class="soft col-sm-8 col-sm-offset-2 text-center"><img data-src="//crds-cms-uploads.imgix.net/content/images/crossroads-group-leader-project.png" class="imgix-fluid img-full-width" alt="" title=""></div>
-</div>
-</div>
-<div class="row">
-<div class="col-md-10 col-md-offset-1 soft-bottom soft-sides text-center">
-<p class="lead push-bottom"><span id="docs-internal-guid-83bdbcc2-2f7a-2a0c-a1ab-222d379c8f4a"><span>Sometimes the hardest part of leading is deciding what to do next with your group. We have a ton of </span><a href="https://www.crossroads.net/groups/resources/"><span>resources available to you</span></a><span>, but here are two new guides in the Crossroads app for your group to use. </span></span></p>
-<hr class="push-ends"></div>
-</div>
-<div class="row">
-<div class="col-sm-6 push-bottom">
-<div class="row">
-<div class="col-sm-6 push-bottom"><a href="sitetree_link,id=267]"><img data-src="//crds-cms-uploads.imgix.net/content/images/crossroads-golocal.jpg" class="imgix-fluid img-responsive img-full-width" alt="" title="" mce_advimageresize_id="Form_EditForm_Content_mce_15"></a></div>
-<div class="col-sm-6 push-bottom">
-<div class="card-block hard-left hard-top">
-<h4 class="card-title text-uppercase font-family-condensed-extra">GO Local Guide</h4>
-<p class="card-text">Plan on using this one-time guide this week to debrief GO Local. Even if you didn't get to serve as a group, start the conversation on how you can have a regular impact in your network or neighborhood through serving. It's available now in the Crossroads App.</p>
-</div>
-</div>
-</div>
-</div>
-<div class="col-sm-6 push-bottom">
-<div class="row">
-<div class="col-sm-6 push-bottom"><img data-src="//crds-cms-uploads.imgix.net/content/images/crossroads-the-chaser2.jpg" class="imgix-fluid img-responsive img-full-width" alt="" title=""></div>
-<div class="col-sm-6 push-bottom">
-<div class="card-block hard-left hard-top">
-<h4 class="card-title text-uppercase font-family-condensed-extra">The Chaser: POST-WEEKEND CONVO STARTERS</h4>
-<p class="card-text">Three questions to help you and your friends get the most out of the last week's message.</p>
-</div>
-</div>
-</div>
-</div>
-</div>
+  <div class="jumbotron jumbotron-xl row" style="background-image: url(&#039;//crds-cms-uploads.imgix.net/content/images/crossroads-group-leader-update.jpg&#039;);">
+    <div class="row">
+      <div class="soft col-sm-8 col-sm-offset-2 text-center"><img data-src="//crds-cms-uploads.imgix.net/content/images/crossroads-group-leader-project.png"
+          class="imgix-fluid img-full-width" alt="" title=""></div>
+    </div>
+  </div>
+  <div class="row">
+    <div class="col-md-10 col-md-offset-1 soft-bottom soft-sides text-center">
+      <p class="lead push-bottom"><span id="docs-internal-guid-83bdbcc2-2f7a-2a0c-a1ab-222d379c8f4a"><span>Sometimes
+            the hardest part of leading is deciding what to do next with your group. We have a ton of </span><a href="https://www.crossroads.net/groups/resources/"><span>resources
+              available to you</span></a><span>, but here are two new guides in the Crossroads app for your group to
+            use. </span></span></p>
+      <hr class="push-ends">
+    </div>
+  </div>
+  <div class="row">
+    <div class="col-sm-6 push-bottom">
+      <div class="row">
+        <div class="col-sm-6 push-bottom"><a href="/golocal"><img data-src="//crds-cms-uploads.imgix.net/content/images/crossroads-golocal.jpg"
+              class="imgix-fluid img-responsive img-full-width" alt="" title="" mce_advimageresize_id="Form_EditForm_Content_mce_15"></a></div>
+        <div class="col-sm-6 push-bottom">
+          <div class="card-block hard-left hard-top">
+            <h4 class="card-title text-uppercase font-family-condensed-extra">GO Local Guide</h4>
+            <p class="card-text">Plan on using this one-time guide this week to debrief GO Local. Even if you didn't
+              get to serve as a group, start the conversation on how you can have a regular impact in your network or
+              neighborhood through serving. It's available now in the Crossroads App.</p>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div class="col-sm-6 push-bottom">
+      <div class="row">
+        <div class="col-sm-6 push-bottom"><img data-src="//crds-cms-uploads.imgix.net/content/images/crossroads-the-chaser2.jpg"
+            class="imgix-fluid img-responsive img-full-width" alt="" title=""></div>
+        <div class="col-sm-6 push-bottom">
+          <div class="card-block hard-left hard-top">
+            <h4 class="card-title text-uppercase font-family-condensed-extra">The Chaser: POST-WEEKEND CONVO STARTERS</h4>
+            <p class="card-text">Three questions to help you and your friends get the most out of the last week's
+              message.</p>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
 </div>

--- a/_pages/student-ministry.html
+++ b/_pages/student-ministry.html
@@ -5,65 +5,85 @@ permalink: /studentministry/
 ---
 
 <div class="row">
-<div class="jumbotron" style="background-image: url(&#039;//crds-cms-uploads.imgix.net/content/images/crossroads-student-ministry-header2.jpg&#039;);">
-<div class="container-fluid">
-<div class="row push-ends soft-sides soft-ends">
-<div class="col-md-offset-2 col-md-8 text-center push-top push-bottom">
-<h1 class="title">student ministry</h1>
-<h3 class="font-family-condensed-extra text-uppercase" style="color: white;">Purpose. Fun. No pressure.</h3>
+  <div class="jumbotron" style="background-image: url(&#039;//crds-cms-uploads.imgix.net/content/images/crossroads-student-ministry-header2.jpg&#039;);">
+    <div class="container-fluid">
+      <div class="row push-ends soft-sides soft-ends">
+        <div class="col-md-offset-2 col-md-8 text-center push-top push-bottom">
+          <h1 class="title">student ministry</h1>
+          <h3 class="font-family-condensed-extra text-uppercase" style="color: white;">Purpose. Fun. No pressure.</h3>
+        </div>
+      </div>
+    </div>
+  </div>
 </div>
-</div>
-</div>
-</div>
-</div><div class="container">
-<div class="row bg-gray push-bottom soft-bottom">
-<div class="col-sm-4 soft"><img alt="friends giving" class="img-responsive imgix-fluid" data-src="//crds-cms-uploads.imgix.net/content/images/crossroads-friendsgiving-2018-img1.jpg" title="friendsgiving"></div>
-<div class="col-sm-8">
-<h2 class="section-header flush-bottom">Friendsgiving</h2>
-<h4 class="component-header">Celebrate the holidays with other students at Crossroads.</h4>
-<p class="font-size-base">Join us as we feast on free food, celebrate what we are thankful for and have tons of fun. Friendsgiving will happen during normal weekly times during the week of November 11–19 (for most sites...click on the link below to find out if your site’s normal weekly time will be affected by Friendsgiving.)</p>
-<a href="/highschool/" class="btn btn-sm btn-primary">View High School weekly times</a>   <a href="/middleschool/" class="btn btn-sm btn-primary">View Middle School weekly times</a></div>
-</div>
-<div class="row">
-<div class="card col-sm-4"><img alt="Card image caption" class="img-full-width imgix-fluid" data-src="//crds-cms-uploads.imgix.net/content/images/crossroads-student-ministry-weekly2.jpg" title=""><div class="card-block">
-<h4 class="card-title card-title--overlap text-uppercase">The Weekly</h4>
-<p class="card-text">Be yourself, make friends and have authentic conversations about God.</p>
-<hr><p>6-8th grade students <a href="/middleschool/">Check out MSM</a></p>
-<p>9-12th grade students <a href="/highschool/">Check out HS</a></p>
-<div class="push-top col-sm-12 bg-gray soft">
-<p>Current series: <strong>WOKE LIKE JESUS</strong><b><br></b></p>
-<p><a href="https://youtu.be/NiXlfxHuptk">Part 1</a></p>
-<p><a href="https://youtu.be/9qlaI2K8Oms">Part 2</a></p>
-<p><a href="https://youtu.be/1AgJDkuiFK4">Part 3</a></p>
-<p><a href="https://youtu.be/3cr8JbhUUDw">Part 4</a></p>
-<p></p>
-<p>Click <a href="/studentministry/weekly-lessons/">HERE</a> for Weekly lessons.</p>
-</div>
-</div>
-</div>
-<div class="card col-sm-4"><a href="https://www.youtube.com/channel/UCHpWI1liDspGqKMFWGpFi1w" target="_blank"> <img data-src="//crds-cms-uploads.imgix.net/content/images/student-ministry-youtube.jpg" alt="" title="" class="imgix-fluid"></a>
-<div class="card-block" mce_advimageresize_id="Form_EditForm_Content_mce_10">
-<h4 class="card-title card-title--overlap text-uppercase">Youtube</h4>
-<p class="card-text"><a href="https://www.youtube.com/channel/UCHpWI1liDspGqKMFWGpFi1w" target="_blank"><strong>Subscribe to our YouTube Channel</strong></a></p>
-</div>
-</div>
-<div class="card col-sm-4"><a href="/summercamp/"> <img alt="Card image caption" class="img-full-width imgix-fluid" data-src="//crds-cms-uploads.imgix.net/content/images/crossroads-student-ministry-camps.jpg" title="" mce_advimageresize_id="Form_EditForm_Content_mce_1"></a>
-<div class="card-block">
-<h4 class="card-title card-title--overlap text-uppercase">Camps</h4>
-<p class="card-text">High-energy, crazy-fun, life-changing summer opportunity for students. MSM Camp is for 5-7th graders. HS Camp is for 8-12th graders. Get more info at <a href="/summercamp/">crossroads.net/SummerCamp.</a> <strong>Registration is closed.</strong></p>
-</div>
-</div>
-</div>
-<hr class="push-ends"><div class="row push-ends">
-<div class="col-md-6">
-<p class="component-header">Volunteer!</p>
-<p>Interested in creating a fun and safe environment for students to connect with others and explore God? Click <a href="/serve/">here</a><a href="[sitetree_link,id=]"></a> to sign up. For more info about serving in student ministry you can also <a href="https://s3.amazonaws.com/crds-cms-uploads/content/documents/hs-msvolapplication-adults.pdf" target="_blank">download the application</a>. </p>
-</div>
-<div class="col-md-6">
-<p class="component-header">Stay Connected:</p>
-<p><a href="https://docs.google.com/forms/d/1IhIkU-UdKCL3bpdIEj4YmWNk8WBvKAjM5X4UPOwrtvY/viewform" target="_blank">Share your info</a> with us to stay up-to-date on weekly activities and special events.</p>
-<p class="component-header">Parent Resources:</p>
-<p>Check out more resources <a href="/studentministryserve/parent-resources/" target="_blank">here</a>. </p>
-</div>
-</div>
+<div class="container">
+  <div class="row bg-gray push-bottom soft-bottom">
+    <div class="col-sm-4 soft"><img alt="friends giving" class="img-responsive imgix-fluid" data-src="//crds-cms-uploads.imgix.net/content/images/crossroads-friendsgiving-2018-img1.jpg"
+        title="friendsgiving"></div>
+    <div class="col-sm-8">
+      <h2 class="section-header flush-bottom">Friendsgiving</h2>
+      <h4 class="component-header">Celebrate the holidays with other students at Crossroads.</h4>
+      <p class="font-size-base">Join us as we feast on free food, celebrate what we are thankful for and have tons of
+        fun. Friendsgiving will happen during normal weekly times during the week of November 11–19 (for most
+        sites...click on the link below to find out if your site’s normal weekly time will be affected by
+        Friendsgiving.)</p>
+      <a href="/highschool/" class="btn btn-sm btn-primary">View High School weekly times</a>   <a href="/middleschool/"
+        class="btn btn-sm btn-primary">View Middle School weekly times</a>
+    </div>
+  </div>
+  <div class="row">
+    <div class="card col-sm-4"><img alt="Card image caption" class="img-full-width imgix-fluid" data-src="//crds-cms-uploads.imgix.net/content/images/crossroads-student-ministry-weekly2.jpg"
+        title="">
+      <div class="card-block">
+        <h4 class="card-title card-title--overlap text-uppercase">The Weekly</h4>
+        <p class="card-text">Be yourself, make friends and have authentic conversations about God.</p>
+        <hr>
+        <p>6-8th grade students <a href="/middleschool/">Check out MSM</a></p>
+        <p>9-12th grade students <a href="/highschool/">Check out HS</a></p>
+        <div class="push-top col-sm-12 bg-gray soft">
+          <p>Current series: <strong>WOKE LIKE JESUS</strong><b><br></b></p>
+          <p><a href="https://youtu.be/NiXlfxHuptk">Part 1</a></p>
+          <p><a href="https://youtu.be/9qlaI2K8Oms">Part 2</a></p>
+          <p><a href="https://youtu.be/1AgJDkuiFK4">Part 3</a></p>
+          <p><a href="https://youtu.be/3cr8JbhUUDw">Part 4</a></p>
+          <p></p>
+          <p>Click <a href="/studentministry/weekly-lessons/">HERE</a> for Weekly lessons.</p>
+        </div>
+      </div>
+    </div>
+    <div class="card col-sm-4"><a href="https://www.youtube.com/channel/UCHpWI1liDspGqKMFWGpFi1w" target="_blank"> <img
+          data-src="//crds-cms-uploads.imgix.net/content/images/student-ministry-youtube.jpg" alt="" title="" class="imgix-fluid"></a>
+      <div class="card-block" mce_advimageresize_id="Form_EditForm_Content_mce_10">
+        <h4 class="card-title card-title--overlap text-uppercase">Youtube</h4>
+        <p class="card-text"><a href="https://www.youtube.com/channel/UCHpWI1liDspGqKMFWGpFi1w" target="_blank"><strong>Subscribe
+              to our YouTube Channel</strong></a></p>
+      </div>
+    </div>
+    <div class="card col-sm-4"><a href="/summercamp/"> <img alt="Card image caption" class="img-full-width imgix-fluid"
+          data-src="//crds-cms-uploads.imgix.net/content/images/crossroads-student-ministry-camps.jpg" title=""
+          mce_advimageresize_id="Form_EditForm_Content_mce_1"></a>
+      <div class="card-block">
+        <h4 class="card-title card-title--overlap text-uppercase">Camps</h4>
+        <p class="card-text">High-energy, crazy-fun, life-changing summer opportunity for students. MSM Camp is for
+          5-7th graders. HS Camp is for 8-12th graders. Get more info at <a href="/summercamp/">crossroads.net/SummerCamp.</a>
+          <strong>Registration is closed.</strong></p>
+      </div>
+    </div>
+  </div>
+  <hr class="push-ends">
+  <div class="row push-ends">
+    <div class="col-md-6">
+      <p class="component-header">Volunteer!</p>
+      <p>Interested in creating a fun and safe environment for students to connect with others and explore God? Click
+        <a href="/serve/">here</a> to sign up. For more info about serving in student ministry you can also <a href="https://s3.amazonaws.com/crds-cms-uploads/content/documents/hs-msvolapplication-adults.pdf"
+          target="_blank">download the application</a>. </p>
+    </div>
+    <div class="col-md-6">
+      <p class="component-header">Stay Connected:</p>
+      <p><a href="https://docs.google.com/forms/d/1IhIkU-UdKCL3bpdIEj4YmWNk8WBvKAjM5X4UPOwrtvY/viewform" target="_blank">Share
+          your info</a> with us to stay up-to-date on weekly activities and special events.</p>
+      <p class="component-header">Parent Resources:</p>
+      <p>Check out more resources <a href="/studentministryserve/parent-resources/" target="_blank">here</a>. </p>
+    </div>
+  </div>
 </div>


### PR DESCRIPTION
includes: 
- reformatting HTML
- removing all refs to `sitetree` which is an SS convention.

This looks a lot bigger than it actually is because of HTML reformatting.