### PR TITLE
shenney/CYP - Run tests after merge, not as PR check

### DIFF
--- a/cypress/kickOffCypress.sh
+++ b/cypress/kickOffCypress.sh
@@ -5,14 +5,22 @@ then
     exit 0
 fi
 
-#Test the live site if we're deploying to it, else test Netlify's preview
-if [ "$CONTEXT" == "production" ];
+#Skip all testing against preview branches
+if [ "$CONTEXT" != "production" ];
 then
-    test_this_URL=$CRDS_APP_CLIENT_ENDPOINT
-else
-    test_this_URL=$DEPLOY_URL
+    exit 0
 fi
 
+#Below is temporarily disabled until tests are more stable
+#Test the live site if we're deploying to it, else test Netlify's preview
+# if [ "$CONTEXT" == "production" ];
+# then
+#     test_this_URL=$CRDS_APP_CLIENT_ENDPOINT
+# else
+#     test_this_URL=$DEPLOY_URL
+# fi
+
+test_this_URL=$CRDS_APP_CLIENT_ENDPOINT
 body="{\"request\": { \"branch\":\"$HEAD\", \"config\": {\"env\": { \"baseURL\": \"$test_this_URL\", \"contentfulSpaceId\": \"$CONTENTFUL_SPACE_ID\", \"contentfulEnv\": \"$CONTENTFUL_ENV\", \"contentfulToken\": \"$CONTENTFUL_ACCESS_TOKEN\", \"mediaEndpoint\": \"$CRDS_MEDIA_ENDPOINT\", \"DEBUG_NetlifyContext\": \"$CONTEXT\"}}}}"
 
 curl -s -X POST \


### PR DESCRIPTION
- Only run tests after code is merged into int or demo, not as a PR check, so we don't block merges because of bugs in the test, not the new code