### PR TITLE
US15900 Add Monetate Page Type to CRDS.net homepage

### DIFF
--- a/_includes/_head.html
+++ b/_includes/_head.html
@@ -7,6 +7,7 @@
   {% endif %}
 
   {% include _gtm-head.html %}
+  {% include _monetate-head.html %}
 
   <meta name="Netlify" content="This page was rendered with Netlify">
   <meta charset="UTF-8">

--- a/_includes/_monetate-body.html
+++ b/_includes/_monetate-body.html
@@ -1,0 +1,6 @@
+<!-- send data to Monetate -->
+{% if page.url == '/' %}
+<script>
+  window.monetateQ.push(["trackData"]);
+</script>
+{% endif %}

--- a/_includes/_monetate-body.html
+++ b/_includes/_monetate-body.html
@@ -1,5 +1,5 @@
 <!-- send data to Monetate -->
-{% if page.url == '/' %}
+{% if page.monetate_page_type %}
 <script>
   window.monetateQ.push(["trackData"]);
 </script>

--- a/_includes/_monetate-head.html
+++ b/_includes/_monetate-head.html
@@ -1,0 +1,6 @@
+{% if page.url == '/' %}
+<script>
+  window.monetateQ = window.monetateQ || [];
+  window.monetateQ.push(["setPageType", "index-main"]);
+</script>
+{% endif %}

--- a/_includes/_monetate-head.html
+++ b/_includes/_monetate-head.html
@@ -1,6 +1,6 @@
-{% if page.url == '/' %}
+{% if page.monetate_page_type %}
 <script>
   window.monetateQ = window.monetateQ || [];
-  window.monetateQ.push(["setPageType", "index-main"]);
+  window.monetateQ.push(["setPageType", "{{ page.monetate_page_type }}"]);
 </script>
 {% endif %}

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -8,6 +8,7 @@
     {% include _preloader.html %}
   {% endif %}
   {{ content }}
+  {% include _monetate-body.html %}
   <script>
     var CRDS = {
       media: {

--- a/index.html
+++ b/index.html
@@ -1,5 +1,6 @@
 ---
 layout: default
+monetate_page_type: index-main
 paginate:
   articles:
     per: 15


### PR DESCRIPTION
## Problem
Allows Monetate editors to target just the homepage

## Solution
adds monetate pagetype code to head and body on homepage only

For the `monetateQ` and `trackData` method, it is important they are implemented as follows:

`monetateQ`: Implement this method at the top of the page template, just below the Monetate tag in the `<header>` of your site, to ensure the object is initialized when calling further API methods.
`trackData`: Implement this method at the bottom of the page template after all the content has been loaded.

The Monetate tag is currently being implemented through GTM

### Corresponding Branch
No corresponding PRs

## Testing
Unfortunately, Monetate is tied to the URL, so you can't test this through the deploy preview.

On int and local builds, you can tell the Monetate API calls are working correctly by using the Monetate Inspector tool.

In order to install the inspector tool:

> Open the Inspector [Install Page](https://marketer.monetate.net/site_media/static/inspector/install.html) in every browser that you use for testing. Once the page loads, drag the “Inspector” button to your Bookmarks Bar. Inspector is now installed.
> 
> Navigate to your site and then press the link in your Bookmarks Bar to show the Monetate Inspector.

You will need to be logged into Monetate for the inspector tool to work

On https://int.crossroads.net/  or at http://localhost:4000/ You will see `Page Type: index-main`
