### PR TITLE
[CYP] feature/US15755 - Travis Caching

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,3 +11,7 @@ notifications:
     on_success: always
     on_failure: always
     on_pull_requests: false
+#block running on pull requests
+branches:
+  except:
+  - /.*/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,7 @@
 language: node_js
-node_js:
-  - 10
-cache:
-  directories:
-  - "~/.npm"
-  - "~/.cache"
-install:
-  - npm ci
+node_js: 10
+cache: npm
+install: npm ci
 script:
   - "$(npm bin)/cypress run --record --key $cypressDashboard -c baseUrl=$baseURL --env CONTENTFUL_SPACE_ID=$contentfulSpaceId,CONTENTFUL_ENV=$contentfulEnv,CONTENTFUL_ACCESS_TOKEN=$contentfulToken,CRDS_MEDIA_ENDPOINT=$mediaEndpoint"
 notifications:

--- a/cypress/kickOffCypress.sh
+++ b/cypress/kickOffCypress.sh
@@ -21,7 +21,7 @@ fi
 # fi
 
 test_this_URL=$CRDS_APP_CLIENT_ENDPOINT
-body="{\"request\": { \"branch\":\"$HEAD\", \"config\": {\"env\": { \"baseURL\": \"$test_this_URL\", \"contentfulSpaceId\": \"$CONTENTFUL_SPACE_ID\", \"contentfulEnv\": \"$CONTENTFUL_ENV\", \"contentfulToken\": \"$CONTENTFUL_ACCESS_TOKEN\", \"mediaEndpoint\": \"$CRDS_MEDIA_ENDPOINT\", \"DEBUG_NetlifyContext\": \"$CONTEXT\"}}}}"
+body="{\"request\": { \"branch\":\"$HEAD\", \"config\": {\"env\": { \"baseURL\": \"$test_this_URL\", \"contentfulSpaceId\": \"$CONTENTFUL_SPACE_ID\", \"contentfulEnv\": \"$CONTENTFUL_ENV\", \"contentfulToken\": \"$CONTENTFUL_ACCESS_TOKEN\", \"mediaEndpoint\": \"$CRDS_MEDIA_ENDPOINT\"}}}}"
 
 curl -s -X POST \
 -H "Content-Type: application/json" \


### PR DESCRIPTION
PLEASE tell me before you merge this - I need to set the configuration in Travis.
- Changed caching instructions for travis-ci

Travis says you need to enable their "build pushed branches" option for caching to work, but we don't want to do this for various reasons. To allow caching on their side without actually running builds when we don't want them to, I've configured Travis not to build any branches. We explicitly kick off Travis builds when we want them so I'm hoping the "ignore branches" config will only apply for automatic builds, and we'll still be running tests when we do now. Unfortunately, there's no way to test this theory until this PR is merged. 😄 If it doesn't work, I'll undo the config and we'll just not be able to use the cache.
