### PR TITLE
[CYP] Run cypress tests without recording

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ node_js: 10
 cache: npm
 install: npm ci
 script:
-  - "$(npm bin)/cypress run --record --key $cypressDashboard -c baseUrl=$baseURL --env CONTENTFUL_SPACE_ID=$contentfulSpaceId,CONTENTFUL_ENV=$contentfulEnv,CONTENTFUL_ACCESS_TOKEN=$contentfulToken,CRDS_MEDIA_ENDPOINT=$mediaEndpoint"
+  - "$(npm bin)/cypress run -c baseUrl=$baseURL --env CONTENTFUL_SPACE_ID=$contentfulSpaceId,CONTENTFUL_ENV=$contentfulEnv,CONTENTFUL_ACCESS_TOKEN=$contentfulToken,CRDS_MEDIA_ENDPOINT=$mediaEndpoint"
 notifications:
   slack:
     rooms:


### PR DESCRIPTION
- We've run out of space on the Cypress Dashboard for December. This turns of the Dashboard reporting so tests should start passing again.

TODO
- Undo this change in ~8 hours