### PR TITLE
[CYP] Skips tests dependent on media-snippets

### DIFF
--- a/cypress/integration/homepage/home_page_current_series_spec.js
+++ b/cypress/integration/homepage/home_page_current_series_spec.js
@@ -18,7 +18,7 @@ describe("Testing the Current Series on the Homepage", function () {
         ElementValidator.elementHasImgixImageAndLink(cy.get('[data-automation-id="series-image"]'), currentSeries.imageId, seriesLink);
     })
 
-    it('Tests Watch Latest Service button link', function(){
+    it.skip('Tests Watch Latest Service button link', function(){
         const seriesLink = `${Cypress.env('CRDS_MEDIA_ENDPOINT')}/series/${currentSeries.slug}`;
 
         //Desktop version

--- a/cypress/integration/sharedHeader/media_dropdown_current_series_spec.js
+++ b/cypress/integration/sharedHeader/media_dropdown_current_series_spec.js
@@ -10,7 +10,7 @@ describe("Testing the Current Series in the Shared Header/Media dropdown", funct
         cy.get('a[data-automation-id="sh-media"]').click();
     })
 
-    it('Tests Current Series image and link', function() {
+    it.skip('Tests Current Series image and link', function() {
         cy.get('li[data-automation-id="sh-currentseries"]').as('currentSeriesImage').should('be.visible');
 
         //Skip in demo - shared header points to prod


### PR DESCRIPTION
## Problem
*Media snippets aren't reporting the correct Current Series after the Contentful reconfig. DE6276 has been opened for this issue.*

## Solution
*Until the defect is fixed, we should skip the 2 automated tests affected so builds won't fail due to a know issue.
When the defect is fixed, we will begin running these tests again.*
