### PR TITLE
US15701 - removing maestro redirect

### DIFF
--- a/redirects.csv
+++ b/redirects.csv
@@ -32,5 +32,3 @@ http://${env:CRDS_APP_DOMAIN}/*,https://${env:CRDS_APP_DOMAIN}/:splat,301!
 /waivers/*,https://${env:CRDS_ANGULAR_ENDPOINT}/waivers/:splat,200!
 /give,${env:PUSHPAY_GIVE_ENDPOINT},301
 /givinghistory,/me/giving,301
-/*,${env:CRDS_MAESTRO_CLIENT_ENDPOINT}/:splat,200
- 

--- a/spec/fixtures/redirects.csv
+++ b/spec/fixtures/redirects.csv
@@ -123,4 +123,3 @@ https://int.crossroads.net/jake,https://google.com,302
 /undividednext/,/undivided/undivided-next-steps/,302
 /projects/,/marketing/,302
 /goindianewsletter/,https://share.hsforms.com/1WmumtknWQTarFpvcqoGNsA2dls1,302
-/*,${env:CRDS_MAESTRO_CLIENT_ENDPOINT}/:splat,200


### PR DESCRIPTION
## Problem
Maestro is bad

## Solution
Netlify is good

### Corresponding Branch
*Add link to crdschurch/crds-net/US15701-Remove-Maestro

## Testing
Make sure all previously rendered pages by Maestro are still working appropriately
