### PR TITLE
US16238 meta data issues

### DIFF
--- a/_includes/_head.html
+++ b/_includes/_head.html
@@ -71,4 +71,6 @@
   {% endif %}
 
   {% stylesheet_link_tag application %}
+
+  <script> window.prerenderReady = true; </script>
 </head>


### PR DESCRIPTION
## Problem
prerender.io is waiting for page to load completely before capturing meta data, allowing third-party apps to interfere unintentionally with meta data

## Solution
added variable prerender looks for so that it immediately captures meta data before any js is loaded

### Corresponding Branch
*Add link to crdschurch/repo-name-here#issue-number (if applicable). This helps the code reviewer know that corresponding work exists and where to find it.*

## Testing
*Include information on how to test your work here (if applicable).*
