### PR TITLE
USXXXX: Remove Search From 404

### DIFF
--- a/.env-sample
+++ b/.env-sample
@@ -12,6 +12,7 @@ STREAMSPOT_ID=
 CRDS_CMS_ENDPOINT=https://contentint.crossroads.net
 CRDS_GATEWAY_ENDPOINT=https://gatewayint.crossroads.net/gateway
 CRDS_MEDIA_ENDPOINT=https://mediaint.crossroads.net
+CRDS_SEARCH_ENDPOINT=https://int-crds-search.netlify.com
 AWS_ACCESS_KEY_ID=
 AWS_SECRET_ACCESS_KEY=
 AWS_CLOUDSEARCH_ENDPOINT=

--- a/404.html
+++ b/404.html
@@ -9,21 +9,7 @@ permalink: /404.html
     <h2 class="tagline push-bottom">We're sorry. This page doesn't seem to exist.</h2>
   </div>
   <div class="col-sm-6">
-    <p>Please use the navigation above or search here.</p>
-    <form role="form" action="{{ site.search_domain }}/search">
-      <div class="form-group">
-        <div class="input-group input-group-lg">
-          <input class="form-control input-lg" placeholder="Search..." type="search" name="q" data-automation-id="404-search-field">
-          <span class="input-group-btn">
-            <button type="submit" class="btn btn-blue">
-              <svg class="icon icon-1" viewbox="0 0 256 256">
-                <use xlink:href="/assets/svgs/icons.svg#search"></use>
-              </svg>
-            </button>
-          </span>
-        </div>
-      </div>
-    </form>
+    <a class="full-width btn btn-primary" href="/search">Search Crossroads.net</a>
     <p class="push-top">
       <strong>Still need help?</strong>
       <br />Browse our

--- a/redirects.csv
+++ b/redirects.csv
@@ -29,7 +29,7 @@ http://${env:CRDS_APP_DOMAIN}/*,https://${env:CRDS_APP_DOMAIN}/:splat,301!
 /volunteer-sign-up/*,https://${env:CRDS_ANGULAR_ENDPOINT}/volunteer-sign-up/:splat,200!
 /volunteer-application/*,https://${env:CRDS_ANGULAR_ENDPOINT}/volunteer-application/:splat,200!
 /leaveyourmark,https://${env:CRDS_ANGULAR_ENDPOINT}/leaveyourmark,200!
-/search*,https://${env:CRDS_ANGULAR_ENDPOINT}/search:splat,200!
+/search,https://${env:CRDS_SEARCH_ENDPOINT},200!
 /serve-signup,https://${env:CRDS_SERVE_ENDPOINT},301
 /sign-up/*,https://${env:CRDS_ANGULAR_ENDPOINT}/sign-up/:splat,200!
 /trips/*,https://${env:CRDS_ANGULAR_ENDPOINT}/trips/:splat,200!


### PR DESCRIPTION
## Problem
Our new search isn't able to be search via query params (for now).

## Solution
Remove search input on 404 in favor of a button that links to search

### Corresponding Branch
N/A

## Testing
Is there a button there? Does it link me to search?
