### PR TITLE
[CYP] Fixes test failures and corrects Travis configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ node_js: 10
 cache: npm
 install: npm ci
 script:
-  - "$(npm bin)/cypress run --record --key $cypressDashboard -c baseUrl=$baseURL --env CONTENTFUL_SPACE_ID=$contentfulSpaceId,CONTENTFUL_ENV=$contentfulEnv,CONTENTFUL_ACCESS_TOKEN=$contentfulToken,CRDS_MEDIA_ENDPOINT=$mediaEndpoint,TEST_USER_PW=$testUserPw"
+  - "$(npm bin)/cypress run --record --key $cypressDashboard -c baseUrl=$baseURL --env CONTENTFUL_SPACE_ID=$contentfulSpaceId,CONTENTFUL_ENV=$contentfulEnv,CONTENTFUL_ACCESS_TOKEN=$contentfulToken,CRDS_MEDIA_ENDPOINT=$mediaEndpoint,CRDS_ENV=$crdsEnv,FRED_FLINTSTONE_PW=$FRED_FLINTSTONE_PW"
 notifications:
   slack:
     rooms:

--- a/cypress/Contentful/ContentfulApi.js
+++ b/cypress/Contentful/ContentfulApi.js
@@ -52,7 +52,7 @@ export class ContentfulApi {
 
   static retrieveRedirectList() {
     const redirectList = new RedirectList();
-    cy.request('GET', `https://cdn.contentful.com/spaces/${Cypress.env('CONTENTFUL_SPACE_ID')}/environments/${Cypress.env('CONTENTFUL_ENV')}/entries?access_token=${Cypress.env('CONTENTFUL_ACCESS_TOKEN')}&content_type=redirect&&select=fields.from,fields.to`)
+    cy.request('GET', `https://cdn.contentful.com/spaces/${Cypress.env('CONTENTFUL_SPACE_ID')}/environments/${Cypress.env('CONTENTFUL_ENV')}/entries?access_token=${Cypress.env('CONTENTFUL_ACCESS_TOKEN')}&content_type=redirect&&select=fields.from,fields.to&limit=1000`)
       .then((response) => {
         const jsonResponse = JSON.parse(response.body);
         redirectList.storeRedirectItems(jsonResponse);

--- a/cypress/README.md
+++ b/cypress/README.md
@@ -1,3 +1,48 @@
+# Cypress
+## Environment setup
+
+Environment variables needed to run locally:
+```bash
+CYPRESS_CONTENTFUL_ACCESS_TOKEN
+CYPRESS_CONTENTFUL_SPACE_ID
+CYPRESS_CONTENTFUL_ENV
+CYPRESS_CRDS_MEDIA_ENDPOINT #mediaint or mediademo
+CYPRESS_CRDS_ENV #int or demo
+```
+
+
+Environment variables set in Netlify to run Cypress through Travis.ci:
+```bash
+CONTENTFUL_ACCESS_TOKEN
+CONTENTFUL_SPACE_ID
+CONTENTFUL_ENV
+CRDS_MEDIA_ENDPOINT #mediaint or mediademo
+CRDS_ENV #int or demo
+RUN_CYPRESS #true/false
+TRAVIS_CI #Travis's API Authentication token
+CYPRESS_INSTALL_BINARY = 0
+```
+
+## Run Locally
+
+After defining local environment variables, run the Cypress UI with:
+
+```bash
+npm run cypress:open
+```
+
+or headless with:
+
+```bash
+npm run cypress:runLocal
+```
+
+For more predefined npm scripts to run Cypress see the scripts section of the package.json file.
+
+To customize a Cypress run beyond what's defined, check out their documentation [here](https://docs.cypress.io/guides/guides/command-line.html).
+
+//old
+
 ## Setup
 
 Create a cypress.env.json file with the following content (Contentful values can be found directly in Contentful):
@@ -9,6 +54,7 @@ Create a cypress.env.json file with the following content (Contentful values can
     "CONTENTFUL_ACCESS_TOKEN": "...",
     "CRDS_MEDIA_ENDPOINT": "mediaint"
     "TEST_USER_PW": "..."
+    "CRDS_ENV": "int"
 }
 ```
 

--- a/cypress/README.md
+++ b/cypress/README.md
@@ -8,8 +8,12 @@ CYPRESS_CONTENTFUL_SPACE_ID
 CYPRESS_CONTENTFUL_ENV
 CYPRESS_CRDS_MEDIA_ENDPOINT #mediaint or mediademo
 CYPRESS_CRDS_ENV #int or demo
+CYPRESS_FRED_FLINTSTONE_PW
 ```
 
+Cypress has a couple different ways to handle environment variable setup found [here](https://docs.cypress.io/guides/guides/environment-variables.html#Setting).
+The above variables assume you're using [Option #3](https://docs.cypress.io/guides/guides/environment-variables.html#Option-3-CYPRESS).
+If you decide to use another method, please be sure these variables are *not* checked into github.
 
 Environment variables set in Netlify to run Cypress through Travis.ci:
 ```bash
@@ -23,6 +27,12 @@ TRAVIS_CI #Travis's API Authentication token
 CYPRESS_INSTALL_BINARY = 0
 ```
 
+Environment variables to set in Travis.ci:
+```bash
+cypressDashboard #Cypress's dashboard record key for this repo
+FRED_FLINTSTONE_PW
+```
+
 ## Run Locally
 
 After defining local environment variables, run the Cypress UI with:
@@ -33,43 +43,6 @@ npm run cypress:open
 
 or headless with:
 
-```bash
-npm run cypress:runLocal
-```
-
-For more predefined npm scripts to run Cypress see the scripts section of the package.json file.
-
-To customize a Cypress run beyond what's defined, check out their documentation [here](https://docs.cypress.io/guides/guides/command-line.html).
-
-//old
-
-## Setup
-
-Create a cypress.env.json file with the following content (Contentful values can be found directly in Contentful):
-
-```bash
-{
-    "CONTENTFUL_SPACE_ID": "...",
-    "CONTENTFUL_ENV": "...",
-    "CONTENTFUL_ACCESS_TOKEN": "...",
-    "CRDS_MEDIA_ENDPOINT": "mediaint"
-    "TEST_USER_PW": "..."
-    "CRDS_ENV": "int"
-}
-```
-
-cypress.env.json must be in the same folder as cypress.json. Do NOT store this file in git.
-
-Alternaively you can add these to your system's environment variables, but in this case they'd need to be prefixed with 'CYPRESS_' to be recognized.
-
-## Run Tests
-
-To open the Cypress interface for running tests:
-```bash
-npm run cypress:open
-```
-
-To run all Cypress test suites headless:
 ```bash
 npm run cypress:runLocal
 ```

--- a/cypress/fixtures/test_users.js
+++ b/cypress/fixtures/test_users.js
@@ -1,4 +1,4 @@
 export const fred_flintstone = {
   email: 'mpcrds+auto+fredflintstone@gmail.com',
-  password: Cypress.env('TEST_USER_PW')
+  password: Cypress.env('FRED_FLINTSTONE_PW')
 };

--- a/cypress/integration/infrastructure/redirect_regression_spec.js
+++ b/cypress/integration/infrastructure/redirect_regression_spec.js
@@ -2,7 +2,7 @@ import { ContentfulApi } from '../../Contentful/ContentfulApi';
 import { RouteValidator } from '../../support/RouteValidator';
 
 describe('Testing navigation between pages:', function () {
-  it.only('(DE6321) Navigating to a location with a known redirect should land on the redirected page served by Netlify', function () {
+  it('(DE6321) Navigating to a location with a known redirect should land on the redirected page served by Netlify', function () {
     //Make sure this redirect still exists
     const redirectList = ContentfulApi.retrieveRedirectList();
     cy.wrap({redirectList}).its('redirectList.listReady').should('not.be.undefined').then(() => {

--- a/cypress/integration/sharedHeader/crossroads_logo_redirect_authspec.js
+++ b/cypress/integration/sharedHeader/crossroads_logo_redirect_authspec.js
@@ -10,13 +10,13 @@ describe('As a signed-in user, clicking the Crossroads logo from a non-Netlify p
     cy.login('mpcrds+auto+fredflintstone@gmail.com', Cypress.env('TEST_USER_PW'));
   });
 
-  it.skip('(DE6319) Starting from /corkboard', function (){
-    cy.visit('corkboard/');
+  it('(DE6319) Starting from /corkboard', function (){
+    cy.visit('corkboard/', { timeout: 10000 });
 
     clickCrossroadsLogoAndConfirmNetlifyHomepageLoads();
   });
 
-  it.skip('Starting from /childcare', function (){
+  it('Starting from /childcare', function (){
     cy.visit('childcare/');
 
     clickCrossroadsLogoAndConfirmNetlifyHomepageLoads();

--- a/cypress/integration/sharedHeader/crossroads_logo_redirect_spec.js
+++ b/cypress/integration/sharedHeader/crossroads_logo_redirect_spec.js
@@ -5,7 +5,7 @@ function clickCrossroadsLogoAndConfirmNetlifyHomepageLoads() {
   RouteValidator.pageFoundAndFromNetlify(`${Cypress.config().baseUrl}/`);
 }
 
-describe('Clicking the Crossroads logo from a non-Netlify page should load the Netlify homepage:', function () {
+describe.only('Clicking the Crossroads logo from a non-Netlify page should load the Netlify homepage:', function () {
   it('(DE6317) Starting from /search', function () {
     cy.visit('search/');
 
@@ -33,8 +33,8 @@ describe('Clicking the Crossroads logo from a Netlify page should load the Netli
     clickCrossroadsLogoAndConfirmNetlifyHomepageLoads();
   });
 
-  it.skip('Starting from /live', function () {
-    cy('live/');
+  it('Starting from /live', function () {
+    cy.visit('live/');
     RouteValidator.pageShouldBeFromNetlify();
 
     clickCrossroadsLogoAndConfirmNetlifyHomepageLoads();

--- a/cypress/integration/sharedHeader/crossroads_logo_redirect_spec.js
+++ b/cypress/integration/sharedHeader/crossroads_logo_redirect_spec.js
@@ -6,19 +6,19 @@ function clickCrossroadsLogoAndConfirmNetlifyHomepageLoads() {
 }
 
 describe('Clicking the Crossroads logo from a non-Netlify page should load the Netlify homepage:', function () {
-  it.skip('(DE6317) Starting from /search', function () {
+  it('(DE6317) Starting from /search', function () {
     cy.visit('search/');
 
     clickCrossroadsLogoAndConfirmNetlifyHomepageLoads();
   });
 
-  it.skip('(DE6319) Starting from /corkboard', function () {
-    cy.visit('corkboard/');
+  it('(DE6319) Starting from /corkboard', function () {
+    cy.visit('corkboard/', { timeout: 10000 });
 
     clickCrossroadsLogoAndConfirmNetlifyHomepageLoads();
   });
 
-  it.skip('Starting from /leaveyourmark', function () {
+  it('Starting from /leaveyourmark', function () {
     cy.visit('leaveyourmark/');
 
     clickCrossroadsLogoAndConfirmNetlifyHomepageLoads();
@@ -33,15 +33,15 @@ describe('Clicking the Crossroads logo from a Netlify page should load the Netli
     clickCrossroadsLogoAndConfirmNetlifyHomepageLoads();
   });
 
-  it('Starting from /live', function () {
-    cy.visit('live/');
+  it.skip('Starting from /live', function () {
+    cy('live/');
     RouteValidator.pageShouldBeFromNetlify();
 
     clickCrossroadsLogoAndConfirmNetlifyHomepageLoads();
   });
 
-  it('Starting from /camps', function () {
-    cy.visit('camps/');
+  it('Starting from /giving', function () {
+    cy.visit('giving/');
     RouteValidator.pageShouldBeFromNetlify();
 
     clickCrossroadsLogoAndConfirmNetlifyHomepageLoads();

--- a/cypress/kickOffCypress.sh
+++ b/cypress/kickOffCypress.sh
@@ -29,7 +29,7 @@ fi
 # fi
 
 test_this_URL=$CRDS_APP_CLIENT_ENDPOINT
-body="{\"request\": { \"branch\":\"$HEAD\", \"config\": {\"env\": { \"baseURL\": \"$test_this_URL\", \"contentfulSpaceId\": \"$CONTENTFUL_SPACE_ID\", \"contentfulEnv\": \"$CONTENTFUL_ENV\", \"contentfulToken\": \"$CONTENTFUL_ACCESS_TOKEN\", \"mediaEndpoint\": \"$CRDS_MEDIA_ENDPOINT\", \"testUserPw\": \"$TEST_USER_PW\", \"DEBUG_NetlifyContext\": \"$CONTEXT\"}}}}"
+body="{\"request\": { \"branch\":\"$HEAD\", \"config\": {\"env\": { \"baseURL\": \"$test_this_URL\", \"contentfulSpaceId\": \"$CONTENTFUL_SPACE_ID\", \"contentfulEnv\": \"$CONTENTFUL_ENV\", \"contentfulToken\": \"$CONTENTFUL_ACCESS_TOKEN\", \"mediaEndpoint\": \"$CRDS_MEDIA_ENDPOINT\", \"crdsEnv\": \"$CRDS_ENV\", \"DEBUG_NetlifyContext\": \"$CONTEXT\"}}}}"
 
 curl -s -X POST \
 -H "Content-Type: application/json" \


### PR DESCRIPTION
## Problem
*I can't set up environment variables. (Not all variables to authenticate a user were passed to Travis.)*
*A redirect-related test was failing because Contentful limits their responses to 100 entries.*
*Corkboard tests were failing because the page took too long to load.*
*A redirect test was failing because a modal was added to Camps.*

## Solution
*Set up environment variables until I finally get it right. (Sent all the environment variables to Travis).*
*Upped the response limit to 1000 (max possible) for that request.*
*Increased timeout when navigating to Corkboard to 10s.*
*Changed the redirect test to start from Giving. The test covers the same scenario with less effort.*

## New test coverage & improvements
*User password will be pulled from Travis, not Netlify, since Netlify isn't running the tests.*
*Improved the Readme to include necessary environment variables for local, Netlify & Travis.*
*Un-skipped tests covering defects that have been fixed. All tests in the suite should be running now.*