### PR TITLE
[CYP] Handle some slow loading elements better

### DIFF
--- a/cypress/integration/external_repo_media/current_series_page_spec.js
+++ b/cypress/integration/external_repo_media/current_series_page_spec.js
@@ -1,18 +1,18 @@
 import { ContentfulApi } from '../../Contentful/ContentfulApi';
 import { ContentfulElementValidator as Element } from '../../Contentful/ContentfulElementValidator';
 
-describe('Tesing the Media/Series/[Current Series] page:', function(){
+describe('Tesing the Media/Series/[Current Series] page:', function () {
   let currentSeries;
-  before(function() {
+  before(function () {
     const seriesList = new ContentfulApi().retrieveSeriesManager();
 
-    cy.wrap({seriesList}).its('seriesList.currentSeries').should('not.be.undefined').then(() => {
+    cy.wrap({ seriesList }).its('seriesList.currentSeries').should('not.be.undefined').then(() => {
       currentSeries = seriesList.currentSeries;
       cy.visit(`${Cypress.env('CRDS_MEDIA_ENDPOINT')}/series/${currentSeries.slug.text}`);
     });
   });
 
-  it('The jumbotron image and background image should match Contentful', function() {
+  it('The jumbotron image and background image should match Contentful', function () {
     //Current series image
     cy.get('.jumbotron-content').as('currentSeries');
     Element.shouldHaveImgixImageFindImg('currentSeries', currentSeries.image);
@@ -20,12 +20,11 @@ describe('Tesing the Media/Series/[Current Series] page:', function(){
     //Large jumbotron image
     cy.get('.jumbotron').as('jumbotron');
     cy.get('@jumbotron').should('be.visible');
-    cy.get('@jumbotron').then(($jumbotronBackground) => {
-      if(currentSeries.backgroundImage.isRequiredOrHasContent){
-        expect($jumbotronBackground).to.have.attr('style').contains(currentSeries.backgroundImage.id);
-      } else if (currentSeries.image.isRequiredOrHasContent){
-        expect($jumbotronBackground.find('div')).to.have.attr('style').contains(currentSeries.image.id);
-      }
-    });
+
+    if (currentSeries.backgroundImage.isRequiredOrHasContent) {
+      cy.get('@jumbotron').should('have.attr', 'style').and('contain', currentSeries.backgroundImage.id);
+    } else if (currentSeries.image.isRequiredOrHasContent) {
+      cy.get('@jumbotron').find('div').should('have.attr', 'style').and('contain', currentSeries.image.id);
+    }
   });
 });

--- a/cypress/integration/sharedHeader/profile_dropdown_link_authspec.js
+++ b/cypress/integration/sharedHeader/profile_dropdown_link_authspec.js
@@ -4,8 +4,8 @@ import { openProfileClickLinkAndConfirmLoad, forceOpenProfileDropdown } from './
 
 describe('As a signed-in user, the links in the My Profile menu should load pages', function () {
   beforeEach(function () {
-    cy.login(fred_flintstone.email, fred_flintstone.password);
     cy.visit('/');
+    cy.login(fred_flintstone.email, fred_flintstone.password);
   });
 
   it('Tests "My Profile" loads expected page when clicked', function () {

--- a/cypress/integration/sharedHeader/support/my_profile_menu.js
+++ b/cypress/integration/sharedHeader/support/my_profile_menu.js
@@ -1,9 +1,11 @@
 import { RouteValidator } from '../../../support/RouteValidator';
 
-export function forceOpenProfileDropdown(){
-  cy.get('#crds-shared-header-desktop-toggle').parent().as('myProfileMenu');
+export function forceOpenProfileDropdown() {
+  cy.get('#crds-shared-header-desktop-toggle').find('.profile-picture').as('myProfileIcon');
+  cy.get('@myProfileIcon').should('be.visible');
 
-  cy.get('@myProfileMenu').invoke('attr', 'class').then(($classValues) =>{
+  cy.get('#crds-shared-header-desktop-toggle').parent().as('myProfileMenu');
+  cy.get('@myProfileMenu').invoke('attr', 'class').then(($classValues) => {
     let newClass = `${$classValues} open`;
     cy.get('@myProfileMenu').invoke('attr', 'class', newClass);
   });
@@ -11,7 +13,7 @@ export function forceOpenProfileDropdown(){
   cy.get('#crds-shared-header-desktop-toggle').invoke('attr', 'aria-expanded', 'true');
 }
 
-export function openProfileClickLinkAndConfirmLoad(alias){
+export function openProfileClickLinkAndConfirmLoad(alias) {
   forceOpenProfileDropdown();
   cy.get(`@${alias}`).should('be.visible').and('have.attr', 'href').and('not.be.empty');
   cy.get(`@${alias}`).click();


### PR DESCRIPTION
## Test fixes & improvements
*Changed the way a certain jumbotron image is being verified to wait until it's fully loaded before verifying.*
*Attempted to fix an intermittent issue where a My Profile menu dropdown link couldn't be found before it was clicked.*