### PR TITLE
[CYP] - Series for current message fix

### DIFF
--- a/cypress/Contentful/ContentfulApi.js
+++ b/cypress/Contentful/ContentfulApi.js
@@ -21,7 +21,7 @@ export class ContentfulApi {
 
   retrieveSeriesManager() {
     const seriesManager = new SeriesManager();
-    cy.request('GET', `https://cdn.contentful.com/spaces/${Cypress.env('CONTENTFUL_SPACE_ID')}/environments/${Cypress.env('CONTENTFUL_ENV')}/entries?access_token=${Cypress.env('CONTENTFUL_ACCESS_TOKEN')}&content_type=series&select=fields.title,fields.slug,fields.published_at,fields.starts_at,fields.ends_at,fields.youtube_url,fields.image,fields.background_image,fields.description&order=-fields.starts_at&include=3`)
+    cy.request('GET', `https://cdn.contentful.com/spaces/${Cypress.env('CONTENTFUL_SPACE_ID')}/environments/${Cypress.env('CONTENTFUL_ENV')}/entries?access_token=${Cypress.env('CONTENTFUL_ACCESS_TOKEN')}&content_type=series&select=fields.title,fields.slug,fields.published_at,fields.starts_at,fields.ends_at,fields.youtube_url,fields.image,fields.background_image,fields.description,fields.videos&order=-fields.starts_at&include=3`)
       .then((response) => {
         const jsonResponse = JSON.parse(response.body);
         seriesManager.storeCurrentSeries(jsonResponse);

--- a/cypress/Contentful/Models/SeriesModel.js
+++ b/cypress/Contentful/Models/SeriesModel.js
@@ -3,20 +3,56 @@ import { ImageField } from '../Fields/ImageField';
 import { DateField } from '../Fields/DateField';
 
 export class SeriesManager {
+  // storeCurrentSeries2(response) {
+  //   const itemList = response.items;
+  //   const assetList = response.includes.Asset;//TODO trickle down and add to other models
+
+  //   const currentSeries = itemList.find(s => {
+  //     return (Date.now() >= new Date(s.fields.published_at));
+  //   });
+
+  //   this._current_series = new SeriesModel(currentSeries.fields, assetList);
+  // }
+
+  // //This is the series for the current message (messages are in the videos property)
+  // storeRecentSeriesWithMessage(response) {
+  //   const itemList = response.items;
+  //   const assetList = response.includes.Asset;//TODO trickle down and add to other models
+
+  //   const publishedSeries = itemList.find(s => {
+  //     let isPublished = (Date.now() >= new Date(s.fields.published_at));
+  //     let hasVideoMessage = s.fields.videos === undefined ? false : true;
+  //     return isPublished && hasVideoMessage;
+  //   });
+
+  //   this._current_series = new SeriesModel(publishedSeries.fields, assetList);
+  // }
+
+  //Stores the current series and the most recent series with a message
   storeCurrentSeries(response) {
     const itemList = response.items;
-    const assetList = response.includes.Asset;//TODO trickle down and add ot other models
+    const assetList = response.includes.Asset;//TODO trickle down and add to other models
 
-    //Get series most recently started
-    const currentSeriesResponse = itemList.find(s => {
+    const currentSeries = itemList.find(s => {
       return (Date.now() >= new Date(s.fields.published_at));
     });
 
-    this._current_series = new SeriesModel(currentSeriesResponse.fields, assetList);
+    const messageSeries = itemList.find(s => {
+      let isPublished = (Date.now() >= new Date(s.fields.published_at));
+      let hasVideoMessage = s.fields.videos === undefined ? false : true;
+      return isPublished && hasVideoMessage;
+    });
+
+    this._current_series = new SeriesModel(currentSeries.fields, assetList);
+    this._current_message_series = new SeriesModel(messageSeries.fields, assetList);
   }
 
   get currentSeries() {
     return this._current_series;
+  }
+
+  get currentMessageSeries(){
+    return this._current_message_series;
   }
 }
 

--- a/cypress/Contentful/Models/SeriesModel.js
+++ b/cypress/Contentful/Models/SeriesModel.js
@@ -3,31 +3,6 @@ import { ImageField } from '../Fields/ImageField';
 import { DateField } from '../Fields/DateField';
 
 export class SeriesManager {
-  // storeCurrentSeries2(response) {
-  //   const itemList = response.items;
-  //   const assetList = response.includes.Asset;//TODO trickle down and add to other models
-
-  //   const currentSeries = itemList.find(s => {
-  //     return (Date.now() >= new Date(s.fields.published_at));
-  //   });
-
-  //   this._current_series = new SeriesModel(currentSeries.fields, assetList);
-  // }
-
-  // //This is the series for the current message (messages are in the videos property)
-  // storeRecentSeriesWithMessage(response) {
-  //   const itemList = response.items;
-  //   const assetList = response.includes.Asset;//TODO trickle down and add to other models
-
-  //   const publishedSeries = itemList.find(s => {
-  //     let isPublished = (Date.now() >= new Date(s.fields.published_at));
-  //     let hasVideoMessage = s.fields.videos === undefined ? false : true;
-  //     return isPublished && hasVideoMessage;
-  //   });
-
-  //   this._current_series = new SeriesModel(publishedSeries.fields, assetList);
-  // }
-
   //Stores the current series and the most recent series with a message
   storeCurrentSeries(response) {
     const itemList = response.items;

--- a/cypress/integration/homepage/home_page_latest_message_spec.js
+++ b/cypress/integration/homepage/home_page_latest_message_spec.js
@@ -3,7 +3,7 @@ import { ContentfulElementValidator as Element } from '../../Contentful/Contentf
 
 describe('Testing the Current Message on the Homepage:', function () {
   let currentMessage;
-  let currentSeries;
+  let currentMessageSeries;
   let messageURL;
   before(function () {
     const content = new ContentfulApi();
@@ -12,9 +12,9 @@ describe('Testing the Current Message on the Homepage:', function () {
 
     cy.wrap({messageList}).its('messageList.currentMessage').should('not.be.undefined').then(() => {
       currentMessage = messageList.currentMessage;
-      cy.wrap({seriesManager}).its('seriesManager.currentSeries').should('not.be.undefined').then(() => {
-        currentSeries = seriesManager.currentSeries;
-        messageURL = `${Cypress.env('CRDS_MEDIA_ENDPOINT')}/series/${currentSeries.slug.text}/${currentMessage.slug.text}`;
+      cy.wrap({seriesManager}).its('seriesManager.currentMessageSeries').should('not.be.undefined').then(() => {
+        currentMessageSeries = seriesManager.currentMessageSeries;
+        messageURL = `${Cypress.env('CRDS_MEDIA_ENDPOINT')}/series/${currentMessageSeries.slug.text}/${currentMessage.slug.text}`;
       });
     });
 


### PR DESCRIPTION
## Problem
If the current series does not have a message, automated tests will calculate the current message's slug incorrectly.

## Solution
Store the series for the current message separately from the current series. The fix here is the quick & dirty version, a smarter fix will be implemented in US16618.
