### PR TITLE
US16586 Health Check

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -1,39 +1,33 @@
 <!DOCTYPE html>
 <html lang="en">
-{% include _head.html %}
+  {% include _head.html %}
 
-<body class="crds-styles">
-  {% include _gtm-body.html %}
-  {% if page.requires_auth %}
-  {% include _preloader.html %}
-  {% endif %}
-  {{ content }}
-  {% include _monetate-body.html %}
-  <script>
-    var CRDS = {
-      media: {
-        cms: '{{ site.shared_header.cms }}',
-        app: '{{ site.shared_header.app }}',
-        img: '{{ site.shared_header.img }}',
-        prefix: '{{ site.shared_header.prefix }}'
-      },
-      streamspotId: '{{ site.streamspotId }}',
-      streamspotKey: '{{ site.streamspotKey }}',
-      streamspotPlayerId: '{{ site.streamspotPlayerId }}',
-      env: {
-        "gatewayServerEndpoint": '{{ site.gateway_server_endpoint }}'
-      }
-    };
-  </script>
-  {% javascript_link_tag application %}
-  {% javascript_link_tag application_deferred async %}
-  {% if page.masonry_js %}
-  {% javascript_link_tag masonry_deferred async %}
-  {% endif %}
+  <body class="crds-styles">
+    {% include _gtm-body.html %} {% if page.requires_auth %} {% include
+    _preloader.html %} {% endif %}
+    {{ content }}
+    {% include _monetate-body.html %}
+    <script>
+      var CRDS = {
+        media: {
+          cms: "{{ site.shared_header.cms }}",
+          app: "{{ site.shared_header.app }}",
+          img: "{{ site.shared_header.img }}",
+          prefix: "{{ site.shared_header.prefix }}"
+        },
+        streamspotId: "{{ site.streamspotId }}",
+        streamspotKey: "{{ site.streamspotKey }}",
+        streamspotPlayerId: "{{ site.streamspotPlayerId }}",
+        env: {
+          gatewayServerEndpoint: "{{ site.gateway_server_endpoint }}"
+        }
+      };
+    </script>
+    {% javascript_link_tag application %} {% javascript_link_tag
+    application_deferred async %} {% if page.masonry_js %} {%
+    javascript_link_tag masonry_deferred async %} {% endif %} {% if page.title
+    == "Atrium Events" %} {% javascript_link_tag events async %} {% endif %}
 
-  {% if page.title == "Atrium Events" %}
-    {% javascript_link_tag events async %}
-  {% endif %}
-</body>
-
+    <!-- we are crossroads -->
+  </body>
 </html>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -1,33 +1,39 @@
 <!DOCTYPE html>
 <html lang="en">
-  {% include _head.html %}
+{% include _head.html %}
 
-  <body class="crds-styles">
-    {% include _gtm-body.html %} {% if page.requires_auth %} {% include
-    _preloader.html %} {% endif %}
-    {{ content }}
-    {% include _monetate-body.html %}
-    <script>
-      var CRDS = {
-        media: {
-          cms: "{{ site.shared_header.cms }}",
-          app: "{{ site.shared_header.app }}",
-          img: "{{ site.shared_header.img }}",
-          prefix: "{{ site.shared_header.prefix }}"
-        },
-        streamspotId: "{{ site.streamspotId }}",
-        streamspotKey: "{{ site.streamspotKey }}",
-        streamspotPlayerId: "{{ site.streamspotPlayerId }}",
-        env: {
-          gatewayServerEndpoint: "{{ site.gateway_server_endpoint }}"
-        }
-      };
-    </script>
-    {% javascript_link_tag application %} {% javascript_link_tag
-    application_deferred async %} {% if page.masonry_js %} {%
-    javascript_link_tag masonry_deferred async %} {% endif %} {% if page.title
-    == "Atrium Events" %} {% javascript_link_tag events async %} {% endif %}
+<body class="crds-styles">
+  {% include _gtm-body.html %}
+  {% if page.requires_auth %}
+  {% include _preloader.html %}
+  {% endif %}
+  {{ content }}
+  {% include _monetate-body.html %}
+  <script>
+    var CRDS = {
+      media: {
+        cms: '{{ site.shared_header.cms }}',
+        app: '{{ site.shared_header.app }}',
+        img: '{{ site.shared_header.img }}',
+        prefix: '{{ site.shared_header.prefix }}'
+      },
+      streamspotId: '{{ site.streamspotId }}',
+      streamspotKey: '{{ site.streamspotKey }}',
+      streamspotPlayerId: '{{ site.streamspotPlayerId }}',
+      env: {
+        "gatewayServerEndpoint": '{{ site.gateway_server_endpoint }}'
+      }
+    };
+  </script>
+  {% javascript_link_tag application %}
+  {% javascript_link_tag application_deferred async %}
+  {% if page.masonry_js %}
+  {% javascript_link_tag masonry_deferred async %}
+  {% endif %}
 
-    <!-- we are crossroads -->
-  </body>
+  {% if page.title == "Atrium Events" %}
+    {% javascript_link_tag events async %}
+  {% endif %}
+</body>
+
 </html>

--- a/bin/health-check.sh
+++ b/bin/health-check.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+set -e
+PATH_TO_FILE='./_site/index.html'
+
+if [ $# -eq 0 ]
+then
+  echo "Please specify argument containing string to search for."
+else
+  NEEDLE=$1
+fi
+
+if grep -Fq "$NEEDLE" $PATH_TO_FILE
+then
+  exit 0
+else
+  echo "${NEEDLE} not found in ${PATH_TO_FILE}"
+  exit 1
+fi

--- a/index.html
+++ b/index.html
@@ -443,3 +443,5 @@ paginate:
     c.getStreamspotStatus();
   });
 </script>
+
+<!-- we are crossroads -->

--- a/netlify.toml
+++ b/netlify.toml
@@ -8,7 +8,7 @@
     bundle exec jekyll contentful -f &&
     bundle exec jekyll build -- --update-search-index &&
     bash ./cypress/kickOffCypress.sh &&
-    ./bin/health-check.sh "<\!-- we are crossroads. -->"
+    ./bin/health-check.sh "we are crossroads"
   '''
 
 [context.branch-deploy.environment]

--- a/netlify.toml
+++ b/netlify.toml
@@ -7,7 +7,8 @@
     bundle exec jekyll crds &&
     bundle exec jekyll contentful -f &&
     bundle exec jekyll build -- --update-search-index &&
-    bash ./cypress/kickOffCypress.sh
+    bash ./cypress/kickOffCypress.sh &&
+    ./bin/health-check.sh "<\!-- we are crossroads. -->"
   '''
 
 [context.branch-deploy.environment]


### PR DESCRIPTION
## Problem
Intermittent build failures sometimes result in a zero-length index.html file. 

## Solution
This PR adds a new bash script to the end of our build command that looks for the presence of a string in `_site/index.html` and if it is not present, throws a non-zero exit code which will cause the build to fail. 

## Testing
The first build on this PR was designed to fail. You can review [the log output](https://app.netlify.com/sites/int-crds-net/deploys/5c74365a04672f00086c6d6f) but it basically reports this... 

```1:40:40 PM: <\!-- we are crossroads. --> not found in ./_site/index.html```

This messaged was logged (and the build failed) due to the trailing period which does not exist in `_site/index.html`. The subsequent build corrects the string we're looking for, thus the build should pass. 
