### PR TITLE
push jekyll contentful output to dev/null to improve netlify logging

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -5,7 +5,7 @@
     ./bin/contentful-redirects &&
     ./bin/netlify-redirector &&
     bundle exec jekyll crds &&
-    bundle exec jekyll contentful -f &&
+    bundle exec jekyll contentful 2>&1 > /dev/null -f &&
     bundle exec jekyll build -- --update-search-index &&
     bash ./cypress/kickOffCypress.sh &&
     ./bin/health-check.sh "we are crossroads"


### PR DESCRIPTION
## Problem
logging on Netlify is not great right now

## Solution
Nullify logging on contentful for the time being as it's the highest logging task during the build. Also the most well understood.

### Corresponding Branch
*Add link to crdschurch/repo-name-here#issue-number (if applicable). This helps the code reviewer know that corresponding work exists and where to find it.*

## Testing
*Include information on how to test your work here (if applicable).*
