### PR TITLE
[CYP] - Correct current message/series relationship & other bug fixes

### DIFF
--- a/cypress/Contentful/ContentfulApi.js
+++ b/cypress/Contentful/ContentfulApi.js
@@ -58,7 +58,6 @@ export class ContentfulApi {
       failOnStatusCode: false
     })
       .then((response) => {
-        cy.log(`response status ${response.status}`);
         const jsonResponse = JSON.parse(response.body);
         responseWrapper.responseBody = jsonResponse;
       });

--- a/cypress/Contentful/ContentfulElementValidator.js
+++ b/cypress/Contentful/ContentfulElementValidator.js
@@ -31,7 +31,6 @@ export class ContentfulElementValidator {
 
     if (imageFieldObject.isRequiredOrHasContent) {
       cy.get(`@${alias}`).should('have.attr', 'src').and('contain', imageFieldObject.id);
-      //TODO below
     }
   }
 
@@ -48,7 +47,6 @@ export class ContentfulElementValidator {
 
     if (imageFieldObject.isRequiredOrHasContent) {
       cy.get('@image').should('have.attr', 'src').and('contain', imageFieldObject.id);
-      //TODO if has no content should it still have an image?
     }
   }
 }

--- a/cypress/Contentful/ContentfulElementValidator.js
+++ b/cypress/Contentful/ContentfulElementValidator.js
@@ -21,22 +21,34 @@ export class ContentfulElementValidator {
   }
 
   static shouldHaveImgixImage(alias, imageFieldObject) {
-    cy.get(`@${alias}`).scrollIntoView();
-    cy.get(`@${alias}`).should('be.visible').and('have.attr', 'srcset');
+    cy.get(`@${alias}`).first().scrollIntoView();
+    cy.get(`@${alias}`).should('be.visible');
+
+    //A default image will not be displayed if the asset is unpublished
+    if (!imageFieldObject.isUnpublished) {
+      cy.get(`@${alias}`).should('have.attr', 'srcset');
+    }
 
     if (imageFieldObject.isRequiredOrHasContent) {
       cy.get(`@${alias}`).should('have.attr', 'src').and('contain', imageFieldObject.id);
+      //TODO below
     }
   }
 
   //scrollIntoView is not always able to target the 'img' level, so this scrolls to a higher level element before testing the 'img' content
   static shouldHaveImgixImageFindImg(alias, imageFieldObject) {
-    cy.get(`@${alias}`).scrollIntoView();
+    cy.get(`@${alias}`).first().scrollIntoView();
     cy.get(`@${alias}`).find('img').as('image');
-    cy.get('@image').should('be.visible').and('have.attr', 'srcset');
+    cy.get('@image').should('be.visible');
+
+    //A default image will not be displayed if the asset is unpublished
+    if (!imageFieldObject.isUnpublished) {
+      cy.get('@image').should('have.attr', 'srcset');
+    }
 
     if (imageFieldObject.isRequiredOrHasContent) {
       cy.get('@image').should('have.attr', 'src').and('contain', imageFieldObject.id);
+      //TODO if has no content should it still have an image?
     }
   }
 }

--- a/cypress/Contentful/Fields/ImageField.js
+++ b/cypress/Contentful/Fields/ImageField.js
@@ -13,12 +13,15 @@ export class ImageField extends ContentfulField {
     return this.hasContent ? this._content : '';
   }
 
+  //Known defect in Contentful where an unpublished asset can still be linked to a required field
+  get isUnpublished(){
+    return this._is_unpublished === undefined ? false : this._is_unpublished;
+  }
+
   _setContentToImageId(image) {
     if (image === undefined)
       this._content = undefined;
     else {
-      cy.log(`image id ${image.sys.id}`);
-      //If the image asset was unpublished, it will still have an id but will not be displayed on crds.net
       const imageAsset = ContentfulApi.getSingleAsset(image.sys.id);
       cy.wrap({ imageAsset }).its('imageAsset.responseReady').should('be.true').then(() => {
         const responseType = imageAsset.responseBody.sys.type;
@@ -26,7 +29,9 @@ export class ImageField extends ContentfulField {
           this._content = image.sys.id;
         }
         else {
+          //An unpublished asset will still have an id, but may be displayed differently than a missing asset
           this._content = undefined;
+          this._is_unpublished = true;
         }
       });
     }

--- a/cypress/Contentful/Models/MessageModel.js
+++ b/cypress/Contentful/Models/MessageModel.js
@@ -92,4 +92,13 @@ export class MessageModel {
   get publishedAt() {
     return this._published_at;
   }
+
+  //null if the series is unpublished or does not exist
+  get series(){
+    return this._series;
+  }
+
+  set series(seriesModel){
+    this._series = seriesModel;
+  }
 }

--- a/cypress/Contentful/Models/PromoModel.js
+++ b/cypress/Contentful/Models/PromoModel.js
@@ -41,7 +41,6 @@ export class PromoManager {
 
   //Sorted by date then title
   getSortedPromosInAudience(audience) {
-    cy.log(`promos in audience ${this._promos_by_audience[audience].length}`);
     return this._promos_by_audience[audience].sort((a, b) => {
       let diff = a.publishedAt.ignoreTimeZone().compare(b.publishedAt.ignoreTimeZone());
       return diff === 0 ? a.title.compare(b.title) : diff;

--- a/cypress/Contentful/Models/SeriesModel.js
+++ b/cypress/Contentful/Models/SeriesModel.js
@@ -21,26 +21,6 @@ export class SeriesManager {
       });
     });
   }
-  //TODO remove
-  saveMessageSeriesOLD(messageId) {
-    const seriesList = ContentfulApi.getEntryCollection('content_type=series&select=sys.id,fields.published_at,fields.videos&order=-fields.starts_at&limit=5');
-    cy.wrap({ seriesList }).its('seriesList.responseReady').should('be.true').then(() => {
-      const responseList = seriesList.responseBody.items;
-
-      const seriesWithMessage = responseList.find(s => {
-        let videoList = s.fields.videos;
-        if (videoList !== undefined)
-          return videoList.find(v => v.sys.id === messageId) !== undefined;
-        return false;
-      });
-      expect(seriesWithMessage).to.not.be.undefined;
-
-      const seriesFullEntry = ContentfulApi.getSingleEntry(seriesWithMessage.sys.id);
-      cy.wrap({ seriesFullEntry }).its('seriesFullEntry.responseReady').should('be.true').then(() => {
-        this._current_message_series = new SeriesModel(seriesFullEntry.responseBody.fields);
-      });
-    });
-  }
 
   saveMessageSeries(messageModel) {
     const seriesList = ContentfulApi.getEntryCollection('content_type=series&select=sys.id,fields.published_at,fields.videos&order=-fields.starts_at&limit=5');

--- a/cypress/Contentful/Models/SeriesModel.js
+++ b/cypress/Contentful/Models/SeriesModel.js
@@ -21,15 +21,15 @@ export class SeriesManager {
       });
     });
   }
-
-  saveCurrentMessageSeries(messageId) {
+  //TODO remove
+  saveMessageSeriesOLD(messageId) {
     const seriesList = ContentfulApi.getEntryCollection('content_type=series&select=sys.id,fields.published_at,fields.videos&order=-fields.starts_at&limit=5');
     cy.wrap({ seriesList }).its('seriesList.responseReady').should('be.true').then(() => {
       const responseList = seriesList.responseBody.items;
 
       const seriesWithMessage = responseList.find(s => {
         let videoList = s.fields.videos;
-        if(videoList !== undefined)
+        if (videoList !== undefined)
           return videoList.find(v => v.sys.id === messageId) !== undefined;
         return false;
       });
@@ -42,12 +42,33 @@ export class SeriesManager {
     });
   }
 
-  get currentSeries() {
-    return this._current_series;
+  saveMessageSeries(messageModel) {
+    const seriesList = ContentfulApi.getEntryCollection('content_type=series&select=sys.id,fields.published_at,fields.videos&order=-fields.starts_at&limit=5');
+    cy.wrap({ seriesList }).its('seriesList.responseReady').should('be.true').then(() => {
+      const responseList = seriesList.responseBody.items;
+
+      const seriesWithMessage = responseList.find(s => {
+        let videoList = s.fields.videos;
+        if (videoList !== undefined)
+          return videoList.find(v => v.sys.id === messageModel.id) !== undefined;
+        return false;
+      });
+
+      //Handle if the series is unpublished
+      if (seriesWithMessage !== undefined) {
+        const seriesFullEntry = ContentfulApi.getSingleEntry(seriesWithMessage.sys.id);
+        cy.wrap({ seriesFullEntry }).its('seriesFullEntry.responseReady').should('be.true').then(() => {
+          messageModel.series = new SeriesModel(seriesFullEntry.responseBody.fields);
+        });
+      }
+      else {
+        messageModel.series = null;
+      }
+    });
   }
 
-  get currentMessageSeries() {
-    return this._current_message_series;
+  get currentSeries() {
+    return this._current_series;
   }
 }
 

--- a/cypress/integration/homepage/home_page_latest_message_spec.js
+++ b/cypress/integration/homepage/home_page_latest_message_spec.js
@@ -8,13 +8,18 @@ describe('Testing the Current Message on the Homepage:', function () {
   before(function () {
     const messageManager = new MessageManager();
     messageManager.saveCurrentMessage();
-    const seriesManager = new SeriesManager();
 
     cy.wrap({ messageManager }).its('messageManager.currentMessage').should('not.be.undefined').then(() => {
       currentMessage = messageManager.currentMessage;
-      seriesManager.saveCurrentMessageSeries(currentMessage.id);
-      cy.wrap({ seriesManager }).its('seriesManager.currentMessageSeries').should('not.be.undefined').then(() => {
-        messageURL = `${Cypress.env('CRDS_MEDIA_ENDPOINT')}/series/${seriesManager.currentMessageSeries.slug.text}/${currentMessage.slug.text}`;
+      new SeriesManager().saveMessageSeries(currentMessage);
+
+      cy.wrap({ currentMessage }).its('currentMessage.series').should('not.be.undefined').then(() => {
+        if(currentMessage.series === null){
+          messageURL = `${Cypress.env('CRDS_MEDIA_ENDPOINT')}/series/${currentMessage.slug.text}`;
+        }
+        else{
+          messageURL = `${Cypress.env('CRDS_MEDIA_ENDPOINT')}/series/${currentMessage.series.slug.text}/${currentMessage.slug.text}`;
+        }
       });
     });
 

--- a/cypress/integration/live/live_latest_message_spec.js
+++ b/cypress/integration/live/live_latest_message_spec.js
@@ -14,8 +14,9 @@ function check_message_card_content(index, message) {
   cy.get('@messageCard').find('[data-automation-id="recent-message-image-link"]').as('messageURL');
   cy.get('@messageURL').should('have.attr', 'href').and('contain', message.slug.text);
 
-  cy.get('@messageCard').find('[data-automation-id="recent-message-image"]').as('messageImage');
+  cy.get('@messageCard').find('img[data-automation-id="recent-message-image"]').as('messageImage');
   cy.get('@messageImage').should('have.attr', 'alt').and('contain', message.title.text);
+  //cy.get('@messageImage').first().scrollIntoView();
   Element.shouldHaveImgixImage('messageImage', message.image);
 }
 
@@ -41,17 +42,17 @@ describe('Testing the Past Weekends section on the Live page:', function () {
     check_message_card_content(index, messageManager.getRecentMessageByIndex(index));
   });
 
-  it('Second most recent message card should containtitle, image, description and link', function () {
+  it('Second most recent message card should contain title, image, description and link', function () {
     const index = 1;
     check_message_card_content(index, messageManager.getRecentMessageByIndex(index));
   });
 
-  it('Third most recent message card should containtitle, image, description and link', function () {
+  it('Third most recent message card should contain title, image, description and link', function () {
     const index = 2;
     check_message_card_content(index, messageManager.getRecentMessageByIndex(index));
   });
 
-  it('Fourth most recent message card should containtitle, image, description and link', function () {
+  it('Fourth most recent message card should contain title, image, description and link', function () {
     const index = 3;
     check_message_card_content(index, messageManager.getRecentMessageByIndex(index));
   });

--- a/cypress/integration/live/live_latest_message_spec.js
+++ b/cypress/integration/live/live_latest_message_spec.js
@@ -14,9 +14,8 @@ function check_message_card_content(index, message) {
   cy.get('@messageCard').find('[data-automation-id="recent-message-image-link"]').as('messageURL');
   cy.get('@messageURL').should('have.attr', 'href').and('contain', message.slug.text);
 
-  cy.get('@messageCard').find('img[data-automation-id="recent-message-image"]').as('messageImage');
+  cy.get('@messageCard').find('[data-automation-id="recent-message-image"]').as('messageImage');
   cy.get('@messageImage').should('have.attr', 'alt').and('contain', message.title.text);
-  //cy.get('@messageImage').first().scrollIntoView();
   Element.shouldHaveImgixImage('messageImage', message.image);
 }
 

--- a/cypress/integration/locations/locations_search_spec.js
+++ b/cypress/integration/locations/locations_search_spec.js
@@ -71,7 +71,7 @@ describe('Testing the Locations page without searching:', function () {
   });
 });
 
-describe.skip('Testing the search functionality on the Locations page:', function () {
+describe('Testing the search functionality on the Locations page:', function () {
   before(function () {
     cy.visit('/locations');
   });

--- a/cypress/integration/sharedHeader/crossroads_logo_redirect_authspec.js
+++ b/cypress/integration/sharedHeader/crossroads_logo_redirect_authspec.js
@@ -12,6 +12,13 @@ describe('As a signed-in user, clicking the Crossroads logo from a non-Netlify p
   });
 
   it('(DE6319) Starting from /corkboard', function () {
+    //TODO test this on Travis - does this catch the cross-origin issue?
+    cy.on('uncaught:exception', (err, runnable) => {
+      expect(err.message).to.include('TODO');
+      done();
+      return false;
+    });
+
     cy.visit('/corkboard', { timeout: 20000 });
 
     clickCrossroadsLogoAndConfirmNetlifyHomepageLoads();

--- a/cypress/integration/sharedHeader/crossroads_logo_redirect_authspec.js
+++ b/cypress/integration/sharedHeader/crossroads_logo_redirect_authspec.js
@@ -14,7 +14,7 @@ describe('As a signed-in user, clicking the Crossroads logo from a non-Netlify p
   it('(DE6319) Starting from /corkboard', function () {
     //TODO test this on Travis - does this catch the cross-origin issue?
     cy.on('uncaught:exception', (err, runnable) => {
-      expect(err.message).to.include('TODO');
+      expect(err.message).to.include('TODO: replace once error is hit');
       done();
       return false;
     });

--- a/cypress/integration/sharedHeader/crossroads_logo_redirect_spec.js
+++ b/cypress/integration/sharedHeader/crossroads_logo_redirect_spec.js
@@ -16,7 +16,7 @@ describe('Clicking the Crossroads logo from a non-Netlify page should load the N
   it('(DE6319) Starting from /corkboard', function () {
     //TODO test this on Travis - does this catch the cross-origin issue?
     cy.on('uncaught:exception', (err, runnable) => {
-      expect(err.message).to.include('TODO');
+      expect(err.message).to.include('TODO: replace once error is hit');
       done();
       return false;
     });

--- a/cypress/integration/sharedHeader/crossroads_logo_redirect_spec.js
+++ b/cypress/integration/sharedHeader/crossroads_logo_redirect_spec.js
@@ -1,4 +1,5 @@
 import { RouteValidator } from '../../support/RouteValidator';
+import { doesNotReject } from 'assert';
 
 function clickCrossroadsLogoAndConfirmNetlifyHomepageLoads() {
   cy.get('#crds-shared-header-logo').as('crossroadsLogo').click();
@@ -13,6 +14,13 @@ describe('Clicking the Crossroads logo from a non-Netlify page should load the N
   });
 
   it('(DE6319) Starting from /corkboard', function () {
+    //TODO test this on Travis - does this catch the cross-origin issue?
+    cy.on('uncaught:exception', (err, runnable) => {
+      expect(err.message).to.include('TODO');
+      done();
+      return false;
+    });
+
     cy.visit('/corkboard', { timeout: 20000 });
 
     clickCrossroadsLogoAndConfirmNetlifyHomepageLoads();


### PR DESCRIPTION
## Test fixes & improvements
- Fixed the logic for finding the series that the current message belongs to. The same logic can also be used to find the series for any message, which was not possible before.
- Handles the scenario when an image asset is unpublished, but not removed from the Series/Message/whatever in Contentful.
- Removed debug log statements
- Turning on /location search tests - defect has been fixed

## TODO
- Attempted to gracefully handle the /corkboard cross-origin errors that randomly happen. Unfortunately I couldn't reproduce them so the two blocks catching the 'uncaught:exception' are untested, but don't impact the passing test. Will continue to monitor this problem and update the fix.