### PR TITLE
DE6358 Environments

### DIFF
--- a/_assets/javascripts/config.js
+++ b/_assets/javascripts/config.js
@@ -25,6 +25,7 @@ module.exports = [
       "lib/location-finder",
       "lib/distance-sorter",
       "lib/data-tracker",
+      "lib/environment",
       "lib/card-filters",
       "lib/height-watcher",
       "lib/smooth-scroller",

--- a/_assets/javascripts/lib/environment.js
+++ b/_assets/javascripts/lib/environment.js
@@ -1,0 +1,40 @@
+window.CRDS = window.CRDS || {};
+
+CRDS.Environment = class Environment {
+  constructor() {
+    this.debug = false;
+    this.links();
+  }
+
+  links() {
+    this.log("links()");
+    if (this.env() == "int" || this.env() == "demo") {
+      $("a[data-href-int], a[data-href-demo]").each(
+        function(i, el) {
+          const href = $(el).data(`href-${this.env()}`);
+          $(el).attr("href", href);
+        }.bind(this)
+      );
+    }
+  }
+
+  env() {
+    const mappings = {
+      development: "int",
+      int: "int",
+      demo: "demo",
+      release: "demo"
+    };
+    return mappings[CRDS.env["environment"]];
+  }
+
+  log(str) {
+    if (this.debug) {
+      console.log(str);
+    }
+  }
+};
+
+$(document).ready(function() {
+  new CRDS.Environment();
+});

--- a/_assets/javascripts/lib/environment.js
+++ b/_assets/javascripts/lib/environment.js
@@ -9,9 +9,9 @@ CRDS.Environment = class Environment {
   links() {
     this.log("links()");
     if (this.env() == "int" || this.env() == "demo") {
-      $("a[data-href-int], a[data-href-demo]").each(
+      $("a[data-href-" + this.env() + "]").each(
         function(i, el) {
-          const href = $(el).data(`href-${this.env()}`);
+          const href = $(el).data("href-" + this.env());
           $(el).attr("href", href);
         }.bind(this)
       );

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -21,6 +21,7 @@
       streamspotKey: '{{ site.streamspotKey }}',
       streamspotPlayerId: '{{ site.streamspotPlayerId }}',
       env: {
+        environment: '{{ site.jekyll_env }}',
         "gatewayServerEndpoint": '{{ site.gateway_server_endpoint }}'
       }
     };


### PR DESCRIPTION
This PR adds support for environmentally specific hrefs. 

Now, you can specify a `data-href-int="..."` or `data-href-demo="..."` attributes on any `<a>` tag. When run in the INT or DEMO environment, the link's `href` will be swapped out for the corresponding value, client-side. 

Here's an example... 

```
<a href="/production" data-href-int="/int" data-href-demo="/demo">Link</a>
```

Let me know if you have any questions. Thanks!