### PR TITLE
Feature/us16242 add meta to system pages

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -20,6 +20,7 @@ group :jekyll_plugins do
 end
 
 group :test do
+  gem 'rb-readline'
   gem 'rspec'
   gem 'guard-rspec'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -196,6 +196,7 @@ GEM
     rb-fsevent (0.10.3)
     rb-inotify (0.10.0)
       ffi (~> 1.0)
+    rb-readline (0.5.5)
     rouge (3.3.0)
     rspec (3.8.0)
       rspec-core (~> 3.8.0)
@@ -248,6 +249,7 @@ DEPENDENCIES
   netlify-redirector!
   paging-mister-hyde!
   rack (>= 2.0.6)
+  rb-readline
   rspec
   tzinfo-data
   vcr
@@ -255,4 +257,4 @@ DEPENDENCIES
   webmock
 
 BUNDLED WITH
-   1.17.3
+   2.0.1

--- a/_config.yml
+++ b/_config.yml
@@ -45,7 +45,6 @@ contentful:
     - album
     - migration
     - sign_off
-    - system_page
 
 collections_dir: collections
 
@@ -97,6 +96,8 @@ collections:
     output: false
   videos:
     output: false
+  system_pages:
+    output: true
 
 defaults:
   - scope:

--- a/_plugins/filters/html_and_meta_util_filter.rb
+++ b/_plugins/filters/html_and_meta_util_filter.rb
@@ -8,10 +8,9 @@ module CRDS
       # Priority:
       # 1) page meta object image
       # 2) system page meta image
-      # 3) page
-      # 4) page background image
-      # 5) page content for 1st image
-      # 6) site variable's image
+      # 3) page background image
+      # 4) page content for 1st image
+      # 5) site variable's image
       # method for getting the url for the <meta name="image" content="{{ meta_image }}"> tag in the head of a SSG html page
       def get_meta_image(page, site)
         ::Utils::MetaUtil.get_meta_image_url(

--- a/_plugins/filters/html_and_meta_util_filter.rb
+++ b/_plugins/filters/html_and_meta_util_filter.rb
@@ -6,8 +6,8 @@ module CRDS
     module HtmlAndMetaUtilFilter
 
       # Priority:
-      # 1) page meta image
-      # 2) page image
+      # 1) page meta object image
+      # 2) system page meta image
       # 3) page background image
       # 4) page content for 1st image
       # 5) site variable's image
@@ -15,7 +15,7 @@ module CRDS
       def get_meta_image(page, site)
         ::Utils::MetaUtil.get_meta_image_url(
           (page['meta'].nil? || page['meta']['image'].nil?) ? nil : page['meta']['image']['url'],
-          page['meta_image'].nil? ? nil : page['meta_image']['url'],
+          (match_system_page(page['url'],'image').nil?) ? nil : match_system_page(page['url'], 'image')['url'],
           page['image'].nil? ? nil : page['image']['url'],
           page['bg_image'].nil? ? nil : page['bg_image']['url'],
           page['description'].nil? ? page['body'] : page['description'],
@@ -32,7 +32,7 @@ module CRDS
       def get_meta_description(page, site)
         ::Utils::MetaUtil.get_first_item_with_value(
           page['meta'].nil? ? nil : page['meta']['description'],
-          page['meta_description'],
+          (match_system_page(page['url'],'description').nil?) ? nil : match_system_page(page['url'], 'description'),
           page['excerpt'],
           page['description'],
           page['body'],
@@ -48,6 +48,7 @@ module CRDS
       def get_meta_title(page, site)
         ::Utils::MetaUtil.get_first_item_with_value(
           page['meta'].nil? ? nil : page['meta']['title'],
+          (match_system_page(page['url'],'title').nil?) ? nil : match_system_page(page['url'], 'title'),
           page['title'],
           site['title']
         )
@@ -62,6 +63,14 @@ module CRDS
           page['meta']['title'].to_s.strip
         else
          ::Utils::HtmlUtil.get_title(page['title'], site['title'])
+        end
+      end
+
+      private
+
+      def match_system_page(url, field)
+        if(system_page = site.collections['system_pages'].docs.detect { |e| e.data['url'].chomp('/') == url.chomp('/') })
+          return system_page[field] if system_page[field].present?
         end
       end
 

--- a/_plugins/filters/html_and_meta_util_filter.rb
+++ b/_plugins/filters/html_and_meta_util_filter.rb
@@ -8,15 +8,15 @@ module CRDS
       # Priority:
       # 1) page meta object image
       # 2) system page meta image
-      # 3) page background image
-      # 4) page content for 1st image
-      # 5) site variable's image
+      # 3) page
+      # 4) page background image
+      # 5) page content for 1st image
+      # 6) site variable's image
       # method for getting the url for the <meta name="image" content="{{ meta_image }}"> tag in the head of a SSG html page
       def get_meta_image(page, site)
         ::Utils::MetaUtil.get_meta_image_url(
           (page['meta'].nil? || page['meta']['image'].nil?) ? nil : page['meta']['image']['url'],
-          (match_system_page(page['url'],'image').nil?) ? nil : match_system_page(page['url'], 'image')['url'],
-          page['image'].nil? ? nil : page['image']['url'],
+          (match_system_page(page['url'],'image').nil?) ? nil : imgix(match_system_page(page['url'], 'image')['url'], site.config),
           page['bg_image'].nil? ? nil : page['bg_image']['url'],
           page['description'].nil? ? page['body'] : page['description'],
           site['image']
@@ -25,7 +25,7 @@ module CRDS
 
       # Priority:
       # 1) Page meta object description (Meta content model)
-      # 2) Page meta description (Page content model)
+      # 2) system page description
       # 3) Page description
       # 4) Site description
       # method for getting the text for the <meta name="description" content="{{ meta_description }}"> tag in the head of a SSG html page
@@ -42,8 +42,9 @@ module CRDS
 
       # Priority:
       # 1) page meta object title (Meta content model)
-      # 2) page title (Page content model)
-      # 3) site title
+      # 2) system page meta title
+      # 3) page title (Page content model)
+      # 4) site title
       # method for getting the text for the <meta name="title" content="{{ meta_title }}"> tag in the head of a SSG html page
       def get_meta_title(page, site)
         ::Utils::MetaUtil.get_first_item_with_value(

--- a/lib/utils/meta_util.rb
+++ b/lib/utils/meta_util.rb
@@ -3,11 +3,11 @@
   module Utils
     class MetaUtil
 
-      def self.get_meta_image_url(page_meta, page_image, page_bg_image, page_content, site_image)
+      def self.get_meta_image_url(page_meta, system_page_image, page_bg_image, page_content, site_image)
         # returns the first image url in the array that has a value
         image_url = [
           page_meta,
-          page_image,
+          system_page_image,
           page_bg_image,
           search_for_first_image_in_content(page_content),
           site_image

--- a/lib/utils/meta_util.rb
+++ b/lib/utils/meta_util.rb
@@ -3,11 +3,10 @@
   module Utils
     class MetaUtil
 
-      def self.get_meta_image_url(page_meta, page_meta_image, page_image, page_bg_image, page_content, site_image)
+      def self.get_meta_image_url(page_meta, page_image, page_bg_image, page_content, site_image)
         # returns the first image url in the array that has a value
         image_url = [
           page_meta,
-          page_meta_image,
           page_image,
           page_bg_image,
           search_for_first_image_in_content(page_content),

--- a/spec/unit/meta_util_spec.rb
+++ b/spec/unit/meta_util_spec.rb
@@ -9,40 +9,15 @@ describe 'Html Meta Util' do
     expect(
       Utils::MetaUtil.get_meta_image_url(
         'https://page-meta.jpg',
-        'https://page-meta-image.jpg',
         'https://page-image.jpg',
         'https://page-bg-image.jpg',
         '<p><div>Some text and stuff</div><div>< img src="https://page-content-image.jpg"></div><div><img src="https://page-content-image-2.jpg"></div></p>',
         'https://site-image.jpg')).to eq 'https://page-meta.jpg'
   end
 
-  it 'should return the page meta_image url when there are no other valid values' do
-    expect(
-      Utils::MetaUtil.get_meta_image_url(
-        'https://page-meta.jpg',
-        nil,
-        '',
-        "     \t\r\n   ",
-        '',
-        nil)).to eq 'https://page-meta.jpg'
-  end
-
-  it 'should return the page meta_image url' do
-    expect(
-      Utils::MetaUtil.get_meta_image_url(
-        nil,
-        'https://page-meta-image.jpg',
-        'https://page-image.jpg',
-        'https://page-bg-image.jpg',
-        '<p><div>Some text and stuff</div><div>< img src="https://page-content-image.jpg"></div><div><img src="https://page-content-image-2.jpg"></div></p>',
-        'https://site-image.jpg')).to eq 'https://page-meta-image.jpg'
-  end
-
-
   it 'should return the page image url' do
     expect(
       Utils::MetaUtil.get_meta_image_url(
-        nil,
         nil,
         'https://page-image.jpg',
         'https://page-bg-image.jpg',
@@ -54,7 +29,6 @@ describe 'Html Meta Util' do
   it 'should return the page background image url' do
     expect(
       Utils::MetaUtil.get_meta_image_url(
-        nil,
         nil,
         nil,
         'https://page-bg-image.jpg',
@@ -69,7 +43,6 @@ describe 'Html Meta Util' do
         nil,
         nil,
         nil,
-        nil,
         '<p><div>Some text and stuff</div><div>< img src="https://page-content-image.jpg"></div><div><img src="https://page-content-image-2.jpg"></div></p>',
         'https://site-image.jpg')).to eq 'https://page-content-image.jpg'
   end
@@ -78,7 +51,6 @@ describe 'Html Meta Util' do
   it 'should return the 1st image in the page content with single quotes' do
     expect(
       Utils::MetaUtil.get_meta_image_url(
-        nil,
         nil,
         nil,
         nil,
@@ -93,7 +65,6 @@ describe 'Html Meta Util' do
         nil,
         nil,
         nil,
-        nil,
         '<p><div>Some text and stuff</div><div>< img src=  https://page-content-image.jpg  ></div><div><img src="https://page-content-image-2.jpg"></div></p>',
         'https://site-image.jpg')).to eq 'https://page-content-image.jpg'
   end
@@ -105,7 +76,6 @@ describe 'Html Meta Util' do
         nil,
         nil,
         nil,
-        nil,
         '<p><div>Some text and stuff</div><div></div><div></div></p>',
         'https://site-image.jpg')).to eq 'https://site-image.jpg'
   end
@@ -114,7 +84,6 @@ describe 'Html Meta Util' do
   it 'should parse and return the markdownified image url' do
     expect(
       Utils::MetaUtil.get_meta_image_url(
-        nil,
         nil,
         nil,
         nil,
@@ -130,7 +99,6 @@ describe 'Html Meta Util' do
         nil,
         nil,
         nil,
-        nil,
         'https://site-image.jpg')).to eq 'https://site-image.jpg'
   end
 
@@ -138,7 +106,6 @@ describe 'Html Meta Util' do
   it 'should return the site image url when all other options are empty strings' do
     expect(
       Utils::MetaUtil.get_meta_image_url(
-        '',
         '',
         '',
         '',
@@ -154,7 +121,6 @@ describe 'Html Meta Util' do
         nil,
         nil,
         nil,
-        nil,
         'http://site-image.jpg')).to eq 'https://site-image.jpg'
   end
 
@@ -162,7 +128,6 @@ describe 'Html Meta Util' do
   it 'should return the site image url with https: prepended' do
     expect(
       Utils::MetaUtil.get_meta_image_url(
-        nil,
         nil,
         nil,
         nil,
@@ -178,7 +143,6 @@ describe 'Html Meta Util' do
         nil,
         nil,
         nil,
-        nil,
         '/site-image.jpg')).to eq '/site-image.jpg'
   end
 
@@ -186,7 +150,6 @@ describe 'Html Meta Util' do
   it 'should return the site image url when all other options are white space' do
     expect(
       Utils::MetaUtil.get_meta_image_url(
-        "     \t\r\n   ",
         "     \t\r\n   ",
         "     \t\r\n   ",
         "     \t\r\n   ",


### PR DESCRIPTION
## Problem
Layout pages have no way to have their meta data managed

## Solution
Leverage the system pages content model to match up and use meta data from matching records

### Corresponding Branch
https://github.com/crdschurch/crds-media/pull/577

## Testing
*Include information on how to test your work here (if applicable).*
