### PR TITLE
[hotfix] Topic Cards Aren't Clickable (release)

### DIFF
--- a/_assets/stylesheets/components/_cards.scss
+++ b/_assets/stylesheets/components/_cards.scss
@@ -353,6 +353,7 @@
 
 .topic-card-content {
   position: relative;
+  z-index: 10;
 }
 
 .topic-card-link {


### PR DESCRIPTION
## Problem
Following a recent update, the topic cards on the homepage of cr.net are no longer clickable.

## Solution
Add z-index to the element containing the content so it shows up above the overlay. 