### PR TITLE
[hotfix] DE6590 Imgix (master)

### DIFF
--- a/_assets/javascripts/components/images.js
+++ b/_assets/javascripts/components/images.js
@@ -1,3 +1,18 @@
-$(document).ready(function(params) {
+$(document).ready(function() {
   new Imgix.Optimizer();
+
+  var n = setInterval(function(){
+    var imgs = $('[data-imgix-img-processed]'),
+        bgs = $('[data-imgix-bg-processed]');
+
+    if(imgs.length == 0 && bgs.length == 0) {
+      $(window).trigger('resize');
+    } else {
+      clearInterval(n);
+    }
+  }.bind(this), 250);
+
+  setTimeout(function(){
+    clearInterval(n);
+  }.bind(this), 3000);
 });


### PR DESCRIPTION
## Problem
On rare occasion, ImgixOptimizer will fail to process images which results in a bunch of fuzzy low-res artwork that never clears up. This could be a race-condition thing or a bug in the ImgixOptimizer or Imgix.js libraries. 

## Solution
Check every 250ms that imgix has been initialized and if so, trigger a resize event on the window object which causes Imgix to reevaluate the images on the page. 