### PR TITLE
DE6603 - Featured Media Links

### DIFF
--- a/_includes/media/_overlay-card.html
+++ b/_includes/media/_overlay-card.html
@@ -11,8 +11,11 @@
     {% assign image_source = item.image.url %}
 {% endcase %}
 
-{% assign doc = item | get_doc %}
-{% assign url = doc.url %}
+{% assign url = item.url %}
+{% unless url %}
+  {% assign doc = item | get_doc %}
+  {% assign url = doc.url %}
+{% endunless %}
 
 <a href="{{ url }}" class="overlay-card{% if include.size == 'xl' %} overlay-card-xl{% endif %}">
   <div class="bg-overlay"></div>


### PR DESCRIPTION
Only call `get_doc` for featured items if url property is not already there.

These guys are not pointing to the correct URLs, but there are redirects in place that make it work. However, it is using the paths that come from Jekyll, so I feel like it is a reasonable approach (for now).