### PR TITLE
[CYP] Fixed time zones in queries

### DIFF
--- a/cypress/Contentful/ImageDisplayValidator.js
+++ b/cypress/Contentful/ImageDisplayValidator.js
@@ -33,16 +33,10 @@ export class ImageDisplayValidator {
   jumbotronShouldHaveImages(foregroundImageAsset, backgroundImageAsset) {
     cy.get(`@${this._alias}`).first().scrollIntoView();
 
-    if (backgroundImageAsset !== undefined) {
-      if (backgroundImageAsset.isPublished) {
-        cy.get(`@${this._alias}`).should('have.attr', 'style').and('contain', backgroundImageAsset.id);
-      }
-    }
-
-    if (foregroundImageAsset !== undefined) {
-      if (foregroundImageAsset.isPublished) {
-        cy.get(`@${this._alias}`).find('div').should('have.attr', 'style').and('contain', foregroundImageAsset.id);
-      }
+    if (backgroundImageAsset !== undefined && backgroundImageAsset.isPublished) {
+      cy.get(`@${this._alias}`).should('have.attr', 'style').and('contain', backgroundImageAsset.id);
+    } else if (foregroundImageAsset !== undefined && foregroundImageAsset.isPublished) {
+      cy.get(`@${this._alias}`).find('div').should('have.attr', 'style').and('contain', foregroundImageAsset.id);
     }
   }
 }

--- a/cypress/Contentful/QueryManagers/MessageQueryManager.js
+++ b/cypress/Contentful/QueryManagers/MessageQueryManager.js
@@ -36,7 +36,7 @@ export class MessageQueryManager {
     return this._query_result;
   }
   get _requiredQueryParameters() {
-    const now = Cypress.moment(Date.now()).format();
+    const now = Cypress.moment(Date.now()).utc().format();
     return `content_type=message&fields.published_at[lte]=${now}`;
   }
 }

--- a/cypress/Contentful/QueryManagers/PromoQueryManager.js
+++ b/cypress/Contentful/QueryManagers/PromoQueryManager.js
@@ -42,7 +42,7 @@ export class PromoQueryManager {
   }
 
   get _requiredQueryParameters() {
-    const now = Cypress.moment(Date.now()).format();
+    const now = Cypress.moment(Date.now()).utc().format();
     return `content_type=promo&fields.published_at[lte]=${now}`;
   }
 }

--- a/cypress/Contentful/QueryManagers/SeriesQueryManager.js
+++ b/cypress/Contentful/QueryManagers/SeriesQueryManager.js
@@ -27,7 +27,7 @@ export class SeriesQueryManager {
   }
 
   get _requiredQueryParameters() {
-    const now = Cypress.moment(Date.now()).format();
+    const now = Cypress.moment(Date.now()).utc().format();
     return `content_type=series&fields.published_at[lte]=${now}`;
   }
 }


### PR DESCRIPTION
## Problem
- Contentful queries were using incompatible date formats when running on Travis.
- Jumbotron image validation logic was converted incorrectly for image not published/missing scenario.

## Solution
- Converted dates to UTC before formatting
- Fixed jumbotron image logic