### PR TITLE
hotfix - remove live stream title

### DIFF
--- a/index.html
+++ b/index.html
@@ -49,10 +49,7 @@ paginate:
     <div class="col-md-12">
       <div class="media featured">
         <div class="media-body">
-          <h5 class="component-header flush-ends">
-            <a href="/live/stream/" data-automation-id="live-message-title">{{ messages.title }}</a>
-          </h5>
-          <div class="soft-quarter-top font-size-small flush-bottom" data-automation-id="live-message-description">
+          <div class="soft-quarter-top font-size-base flush-bottom" data-automation-id="live-message-description">
             Join the live stream hourly, on the hour, from 8am-10pm (EST).
           </div>
           <a href="/live/stream/" class="btn btn-primary btn-sm push-half-top" data-automation-id="live-watch-message-button">Watch now</a>
@@ -463,4 +460,3 @@ paginate:
 </script>
 
 <!-- we are crossroads -->
-


### PR DESCRIPTION
It was wrong 50% of the weekend because it pulls the current message
title from what is published. And since we don’t publish the new
message til Sunday, it was showing the incorrect message on Saturday
and Sunday morning (during those streams)