### PR TITLE
[CYP] Removed running on dashboard

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ node_js: 10
 cache: npm
 install: npm ci
 script:
-  - "$(npm bin)/cypress run $reportToDashboardCommand -c baseUrl=$baseURL --env CONTENTFUL_SPACE_ID=$contentfulSpaceId,CONTENTFUL_ENV=$contentfulEnv,CONTENTFUL_ACCESS_TOKEN=$contentfulToken,CRDS_MEDIA_ENDPOINT=$mediaEndpoint,CRDS_ENV=$crdsEnv,FRED_FLINTSTONE_PW=$FRED_FLINTSTONE_PW"
+  - "$(npm bin)/cypress run -c baseUrl=$baseURL --env CONTENTFUL_SPACE_ID=$contentfulSpaceId,CONTENTFUL_ENV=$contentfulEnv,CONTENTFUL_ACCESS_TOKEN=$contentfulToken,CRDS_MEDIA_ENDPOINT=$mediaEndpoint,CRDS_ENV=$crdsEnv,FRED_FLINTSTONE_PW=$FRED_FLINTSTONE_PW"
 notifications:
   slack:
     rooms:


### PR DESCRIPTION
Trying to pass in a full CLI command as a Travis envvar didn't work. Here's the lazy way of avoiding the Cypress dashboard that will require manually adding the command back.
