### PR TITLE
DE67245 Horizontal Scroll

### DIFF
--- a/_assets/stylesheets/pages/_community-store.scss
+++ b/_assets/stylesheets/pages/_community-store.scss
@@ -182,7 +182,7 @@
 
   .card-container {
     .carousel {
-      left: 15px;
+      left: 0;
     }
   }
 }

--- a/_assets/stylesheets/pages/_community-store.scss
+++ b/_assets/stylesheets/pages/_community-store.scss
@@ -109,6 +109,9 @@
   .group-cells {
     .container {
       margin-bottom: 44px;
+      .row {
+        margin: 0;
+      }
       .group-cell {
         .media {
           padding-top: 1rem;
@@ -179,7 +182,7 @@
 
   .card-container {
     .carousel {
-      left: 30px;
+      left: 15px;
     }
   }
 }


### PR DESCRIPTION
## Problem
Mobile devices can scroll right and expose a few extra pixels to the right of the fluid containers on the page. 

## Solution
This PR removes a little extra margin to the left of the carousel component. 
