### PR TITLE
give /app namespace class

### DIFF
--- a/_assets/stylesheets/pages/_app.scss
+++ b/_assets/stylesheets/pages/_app.scss
@@ -1,4 +1,4 @@
-
+.app-page-styles {
 
 /* iPhone X & Pixel 2 XL */
 @media (max-height: 896px) and (max-width: 414px) {
@@ -215,6 +215,6 @@ p a:hover {
   text-decoration: none;
   opacity: 0.6;
 }
-
+}
 
 /* !important is used explicitly for the purpose of overriding styling of existing Crossroads classes */


### PR DESCRIPTION
## Problem
The stylesheet for /app currently uses global style overrides which will impact other pages in crds-net.

## Solution
Create a namespace class in order to scope these style overrides to only /app.