### PR TITLE
Defect/de6773 redirects to build

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
-[submodule "_assets/stylesheets/crds-styles"]
+[submodule "_assets/stylesheets/crds-styles"] 
 	path = _assets/stylesheets/crds-styles
 	url = https://github.com/crdschurch/crds-styles.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
-[submodule "_assets/stylesheets/crds-styles"] 
+[submodule "_assets/stylesheets/crds-styles"]
 	path = _assets/stylesheets/crds-styles
 	url = https://github.com/crdschurch/crds-styles.git

--- a/_config.yml
+++ b/_config.yml
@@ -11,8 +11,8 @@ markdown: kramdown
 
 include:
   - .aws
+  - _redirects
   - _pages
-
 
 exclude:
   - bin

--- a/_config.yml
+++ b/_config.yml
@@ -11,6 +11,7 @@ markdown: kramdown
 
 include:
   - .aws
+  - _redirects
   - _pages
 
 exclude:
@@ -29,6 +30,7 @@ exclude:
   - README.md
   - vendor
   - buildlog.txt
+  - collections
 
 contentful:
   article:

--- a/_config.yml
+++ b/_config.yml
@@ -11,7 +11,6 @@ markdown: kramdown
 
 include:
   - .aws
-  - _redirects
   - _pages
 
 exclude:

--- a/_config.yml
+++ b/_config.yml
@@ -13,6 +13,7 @@ include:
   - .aws
   - _pages
 
+
 exclude:
   - bin
   - cypress.json

--- a/_config.yml
+++ b/_config.yml
@@ -9,6 +9,7 @@ image: "https://crds-cms-uploads.imgix.net/content/images/cr-social-sharing-stil
 permalink: pretty
 markdown: kramdown
 
+
 include:
   - .aws
   - _pages

--- a/_config.yml
+++ b/_config.yml
@@ -9,7 +9,6 @@ image: "https://crds-cms-uploads.imgix.net/content/images/cr-social-sharing-stil
 permalink: pretty
 markdown: kramdown
 
-
 include:
   - .aws
   - _pages


### PR DESCRIPTION
lol. We were including "_redirects" trying to make the build include the _redirects file, but Jekyll was also searching for any directory with that name as well which made it grab the _redirects directory from the collections directory. Added collections to the excludes seems to have solved the issue. 