### PR TITLE
DE6830 sitemap exclusions

### DIFF
--- a/_plugins/hooks/sitemap.rb
+++ b/_plugins/hooks/sitemap.rb
@@ -1,0 +1,9 @@
+require 'pry'
+
+Jekyll::Hooks.register :documents, :pre_render do |doc|
+
+  if doc.collection.label == 'pages'
+    doc.data['sitemap'] = !doc.data['search_excluded']
+  end
+  
+end


### PR DESCRIPTION
## Problem
pages which are excluded from search are showing up in the sitemap.xml

## Solution
added hook to exclude pages from sitemap when search_excluded is true

### Corresponding Branch
*Add link to crdschurch/repo-name-here#issue-number (if applicable). This helps the code reviewer know that corresponding work exists and where to find it.*

## Testing
*Include information on how to test your work here (if applicable).*
