### PR TITLE
DE6922 - Watch latest service button href not from media snippets anymore

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -4,7 +4,7 @@
         "amd": true,
         "node": true
     },
-    "extends": "eslint:recommended",
+    "extends": ["plugin:prettier/recommended"],
     "parserOptions": {
         "sourceType": "module"
     },
@@ -24,6 +24,7 @@
         "semi": [
             "error",
             "always"
-        ]
+        ],
+        "prettier/prettier": "error"
     }
 }

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -86,7 +86,9 @@ GEM
       eventmachine (>= 0.12.9)
       http_parser.rb (~> 0.6.0)
     eventmachine (1.2.7)
+    eventmachine (1.2.7-x64-mingw32)
     ffi (1.11.1)
+    ffi (1.11.1-x64-mingw32)
     formatador (0.2.5)
     forwardable-extended (2.6.0)
     guard (2.15.0)
@@ -195,10 +197,13 @@ GEM
     thread_safe (0.3.6)
     tzinfo (1.2.5)
       thread_safe (~> 0.1)
+    tzinfo-data (1.2019.1)
+      tzinfo (>= 1.0.0)
     unf (0.1.4)
       unf_ext
     unf_ext (0.0.7.6)
     vcr (5.0.0)
+    wdm (0.1.1)
     webmock (3.6.0)
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
@@ -206,6 +211,7 @@ GEM
 
 PLATFORMS
   ruby
+  x64-mingw32
 
 DEPENDENCIES
   activesupport

--- a/_includes/_footer.html
+++ b/_includes/_footer.html
@@ -4,7 +4,7 @@
 <h5><a href="https://www.crossroads.net/locations/">One Church, Many Locations</a></h5>
 <p><strong>Cincinnati Area</strong><br><a href="https://www.crossroads.net/eastside/">East Side</a><a href="https://www.crossroads.net/florence/"><br>Florence</a> <br><a href="https://www.crossroads.net/mason/">Mason</a> <br><a href="https://www.crossroads.net/oakley/" data-automation-id="footer-oakley-location">Oakley</a><br><a href="https://www.crossroads.net/oxford/">Oxford</a> <br><a href="https://www.crossroads.net/uptown/">Uptown</a><br><a href="https://www.crossroads.net/westside/">West Side</a></p>
 <p><strong>Central Kentucky Area</strong><br><a href="https://www.crossroads.net/lexington/" class="ss-broken ss-broken">Lexington</a><br><a href="https://www.crossroads.net/downtownlex/" class="ss-broken ss-broken">Downtown Lexington</a><br><a href="https://www.crossroads.net/georgetown/" class="ss-broken ss-broken">Georgetown</a><br><a href="https://www.crossroads.net/richmond/" class="ss-broken ss-broken">Richmond</a></p>
-<p><a href="https://www.crossroads.net/live/" class="ss-broken ss-broken ss-broken ss-broken ss-broken ss-broken ss-broken ss-broken ss-broken ss-broken ss-broken ss-broken ss-broken ss-broken ss-broken ss-broken ss-broken ss-broken ss-broken ss-broken ss-broken ss-broken ss-broken ss-broken">Anywhere</a><br><a href="https://www.crossroads.net/cleveland/">Cleveland</a><br><a href="https://www.crossroads.net/columbus/">Columbus</a><br><a href="https://www.crossroads.net/dayton/">Dayton</a></p>
+<p><a href="https://www.crossroads.net/live/" class="ss-broken ss-broken ss-broken ss-broken ss-broken ss-broken ss-broken ss-broken ss-broken ss-broken ss-broken ss-broken ss-broken ss-broken ss-broken ss-broken ss-broken ss-broken ss-broken ss-broken ss-broken ss-broken ss-broken ss-broken">Anywhere</a><br><a href="https://www.crossroads.net/columbus/">Columbus</a><br><a href="https://www.crossroads.net/dayton/">Dayton</a></p>
 </div>
 <div class="col-sm-2 push-bottom">
 <h5><a href="http://imincampaign.net/" target="_blank">I’M IN Campaign</a></h5>
@@ -16,7 +16,9 @@
 </div>
 <div class="col-sm-2 open push-bottom">
 <h5>Resources</h5>
-<p><a href="https://www.crossroads.net/inthenews/">In The News</a><br><a href="https://www.crossroads.net/churchresources/">Church Resources</a></p>
+<p><a href="https://www.crossroads.net/inthenews/">In The News</a><br><a href="https://www.crossroads.net/churchresources/">Church Resources</a><br>
+  <a href="https://www.crossroads.net/app/">Get the Crossroads App</a>
+  </p>
 </div>
 <div class="col-sm-4 social-icons"><a href="https://twitter.com/crdschurch/" target="_blank" class="text-center"><img src="//d1tmclqz61gqwd.cloudfront.net/images/twitter.svg" alt="twitter account" title="twitter account"></a> <a href="https://www.facebook.com/crdschurch/?_rdr=p" target="_blank" class="text-center"> <img src="//d1tmclqz61gqwd.cloudfront.net/images/facebook.svg" alt="facebook account" title="facebook account"></a> <a href="https://www.youtube.com/user/crdschurch" target="_blank" class="text-center"> <img src="//d1tmclqz61gqwd.cloudfront.net/images/youtube.svg" alt="youtube account" title="youtube account"></a> <a href="https://www.instagram.com/crdschurch/" target="_blank" class="text-center"> <img src="//d1tmclqz61gqwd.cloudfront.net/images/instagram.svg" alt="instagram account" title="instagram account"></a></div>
 </div>

--- a/cypress/integration/homepage/home_page_current_series_spec.js
+++ b/cypress/integration/homepage/home_page_current_series_spec.js
@@ -30,14 +30,13 @@ describe('Testing the Current Series on the Homepage:', function () {
     new ImageDisplayValidator('seriesImage').shouldHaveImgixImage(currentSeries.image);
   });
 
-  //Skipping until DE6922 is fixed
-  it.skip('"Watch Latest Service" button should link to the current series', function () {
+  it('"Watch Latest Service" button should link to the current series', function () {
     //Desktop version
     cy.get('[data-automation-id="watch-series-button"]').as('watchServiceButton');
-    cy.get('@watchServiceButton').should('be.visible').and('have.attr', 'href', currentSeries.URL.absolute);
+    cy.get('@watchServiceButton').should('be.visible').and('have.attr', 'href', currentSeries.URL.relative);
 
     //Mobile version
     cy.get('[data-automation-id="mobile-watch-series-button"]').as('mobileWatchServiceButton');
-    cy.get('@mobileWatchServiceButton').should('not.be.visible').and('have.attr', 'href', currentSeries.URL.absolute);
+    cy.get('@mobileWatchServiceButton').should('not.be.visible').and('have.attr', 'href', currentSeries.URL.relative);
   });
 });

--- a/index.html
+++ b/index.html
@@ -314,7 +314,8 @@ paginate:
               <h4 class="component-header" style="line-height:.9em;"><span class="text-gray-lighter">Watch a
                   service</span><br><span class="text-white">online</span></h4>
               <span class="font-size-small">Pants optional. Coffee encouraged.</span><br>
-              <a class="btn btn-secondary btn-lg" href="{{ series.url }}"
+{% assign recent_series = home_series | first %}
+<a class="btn btn-secondary btn-lg" href="{{ recent_series.url }}"
                 data-automation-id="watch-series-button">Watch the latest service</a>
             </div>
 

--- a/index.html
+++ b/index.html
@@ -314,7 +314,7 @@ paginate:
               <h4 class="component-header" style="line-height:.9em;"><span class="text-gray-lighter">Watch a
                   service</span><br><span class="text-white">online</span></h4>
               <span class="font-size-small">Pants optional. Coffee encouraged.</span><br>
-              <a class="btn btn-secondary btn-lg" data-media-snippet="get_current_series_url:attr[href]"
+              <a class="btn btn-secondary btn-lg" href="{{ series.url }}"
                 data-automation-id="watch-series-button">Watch the latest service</a>
             </div>
 
@@ -322,7 +322,7 @@ paginate:
               <h4 class="component-header" style="line-height:.9em;"><span class="text-gray-lighter">Watch a
                   service</span><br><span class="text-white">online</span></h4>
               <span class="font-size-small">Pants optional. Coffee encouraged.</span><br>
-              <a class="btn btn-secondary btn-lg" data-media-snippet="get_current_series_url:attr[href]"
+              <a class="btn btn-secondary btn-lg" href="{{ series.url }}"
                 data-automation-id="mobile-watch-series-button">Watch the latest service</a>
             </div>
 
@@ -504,7 +504,7 @@ paginate:
   };
 
   document.addEventListener("deferred-js-ready", countdownInit);
-  
+
   if (window.deferredJSReady) {
     countdownInit();
   }

--- a/index.html
+++ b/index.html
@@ -2,47 +2,47 @@
 layout: default
 monetate_page_type: index-main
 meta:
-title: Crossroads
-description: No matter what your beliefs, you are welcome here.
-image:
-url: "//crds-cms-uploads.imgix.net/content/images/cr-social-sharing-still-bg.jpg?w=1200&h=630&fit=crop"
+  title: Crossroads
+  description: No matter what your beliefs, you are welcome here.
+  image:
+    url: "//crds-cms-uploads.imgix.net/content/images/cr-social-sharing-still-bg.jpg?w=1200&h=630&fit=crop"
 paginate:
-articles:
-per: 15
-offset: 1
-limit: 1
-sort: published_at desc
-perspectives:
-per: 3
-limit: 1
-sort: published_at desc
-topics:
-per: 5
-limit: 1
-sort: published_at
-series:
-per: 1
-limit: 1
-sort: starts_at desc
-messages:
-per: 1
-limit: 1
-sort: published_at desc
-home_collection:
-collections:
-- articles
-per: 10
-limit: 1
-offset: 2
-sort: published_at desc
-episodes:
-per: 3
-limit: 1
-sort: published_at desc
-podcasts:
-per: 6
-offset: 1
-limit: 1
+  articles:
+    per: 15
+    offset: 1
+    limit: 1
+    sort: published_at desc
+  perspectives:
+    per: 3
+    limit: 1
+    sort: published_at desc
+  topics:
+    per: 5
+    limit: 1
+    sort: published_at
+  series:
+    per: 1
+    limit: 1
+    sort: starts_at desc
+  messages:
+    per: 1
+    limit: 1
+    sort: published_at desc
+  home_collection:
+    collections:
+      - articles
+    per: 10
+    limit: 1
+    offset: 2
+    sort: published_at desc
+  episodes:
+    per: 3
+    limit: 1
+    sort: published_at desc
+  podcasts:
+    per: 6
+    offset: 1
+    limit: 1
 ---
 
 {% include header.html %}

--- a/index.html
+++ b/index.html
@@ -2,47 +2,47 @@
 layout: default
 monetate_page_type: index-main
 meta:
-  title: Crossroads
-  description: No matter what your beliefs, you are welcome here.
-  image:
-    url: "//crds-cms-uploads.imgix.net/content/images/cr-social-sharing-still-bg.jpg?w=1200&h=630&fit=crop"
+title: Crossroads
+description: No matter what your beliefs, you are welcome here.
+image:
+url: "//crds-cms-uploads.imgix.net/content/images/cr-social-sharing-still-bg.jpg?w=1200&h=630&fit=crop"
 paginate:
-  articles:
-    per: 15
-    offset: 1
-    limit: 1
-    sort: published_at desc
-  perspectives:
-    per: 3
-    limit: 1
-    sort: published_at desc
-  topics:
-    per: 5
-    limit: 1
-    sort: published_at
-  series:
-    per: 1
-    limit: 1
-    sort: starts_at desc
-  messages:
-    per: 1
-    limit: 1
-    sort: published_at desc
-  home_collection:
-    collections:
-      - articles
-    per: 10
-    limit: 1
-    offset: 2
-    sort: published_at desc
-  episodes:
-    per: 3
-    limit: 1
-    sort: published_at desc
-  podcasts:
-    per: 6
-    offset: 1
-    limit: 1
+articles:
+per: 15
+offset: 1
+limit: 1
+sort: published_at desc
+perspectives:
+per: 3
+limit: 1
+sort: published_at desc
+topics:
+per: 5
+limit: 1
+sort: published_at
+series:
+per: 1
+limit: 1
+sort: starts_at desc
+messages:
+per: 1
+limit: 1
+sort: published_at desc
+home_collection:
+collections:
+- articles
+per: 10
+limit: 1
+offset: 2
+sort: published_at desc
+episodes:
+per: 3
+limit: 1
+sort: published_at desc
+podcasts:
+per: 6
+offset: 1
+limit: 1
 ---
 
 {% include header.html %}
@@ -153,7 +153,7 @@ paginate:
         {% if managed_features.size > 0 %}
         featured
         {% else %}
-          latest
+        latest
         {% endif %}
       </h2>
 
@@ -263,9 +263,9 @@ paginate:
               sizes="{{ site.image_sizes.cards_4x }}" data-optimize-img />
           </a>
         </div>
-          {% if forloop.last != true %}
-            <hr>
-          {% endif %}
+        {% if forloop.last != true %}
+        <hr>
+        {% endif %}
         {% endfor %}
       </div>
     </div>
@@ -314,8 +314,8 @@ paginate:
               <h4 class="component-header" style="line-height:.9em;"><span class="text-gray-lighter">Watch a
                   service</span><br><span class="text-white">online</span></h4>
               <span class="font-size-small">Pants optional. Coffee encouraged.</span><br>
-{% assign recent_series = home_series | first %}
-<a class="btn btn-secondary btn-lg" href="{{ recent_series.url }}"
+              {% assign recent_series = home_series | first %}
+              <a class="btn btn-secondary btn-lg" href="{{ recent_series.url }}"
                 data-automation-id="watch-series-button">Watch the latest service</a>
             </div>
 
@@ -447,9 +447,9 @@ paginate:
           </a>
         </div>
 
-          {% if forloop.last != true %}
-            <hr>
-          {% endif %}
+        {% if forloop.last != true %}
+        <hr>
+        {% endif %}
         {% endfor %}
 
         {% assign home_podcasts = page.podcasts.docs | slice: 2, 6 %}
@@ -470,9 +470,9 @@ paginate:
           </a>
         </div>
 
-          {% if forloop.last != true %}
-            <hr>
-          {% endif %}
+        {% if forloop.last != true %}
+        <hr>
+        {% endif %}
         {% endfor %}
       </div>
     </div>

--- a/index.html
+++ b/index.html
@@ -310,11 +310,11 @@ limit: 1
           <p>An authentic community of Christ-followers who believe that your life is made for more.</p>
 
           <div class="row push-top soft-top">
+            {% assign recent_series = home_series | first %}
             <div class="col-sm-4 col-sm-offset-2 text-right hidden-xs soft-sides">
               <h4 class="component-header" style="line-height:.9em;"><span class="text-gray-lighter">Watch a
                   service</span><br><span class="text-white">online</span></h4>
               <span class="font-size-small">Pants optional. Coffee encouraged.</span><br>
-              {% assign recent_series = home_series | first %}
               <a class="btn btn-secondary btn-lg" href="{{ recent_series.url }}"
                 data-automation-id="watch-series-button">Watch the latest service</a>
             </div>
@@ -323,7 +323,7 @@ limit: 1
               <h4 class="component-header" style="line-height:.9em;"><span class="text-gray-lighter">Watch a
                   service</span><br><span class="text-white">online</span></h4>
               <span class="font-size-small">Pants optional. Coffee encouraged.</span><br>
-              <a class="btn btn-secondary btn-lg" href="{{ series.url }}"
+              <a class="btn btn-secondary btn-lg" href="{{ recent_series.url }}"
                 data-automation-id="mobile-watch-series-button">Watch the latest service</a>
             </div>
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -5094,6 +5094,23 @@
         }
       }
     },
+    "eslint-config-prettier": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-6.0.0.tgz",
+      "integrity": "sha512-vDrcCFE3+2ixNT5H83g28bO/uYAwibJxerXPj+E7op4qzBCsAV36QfvdAyVOoNxKAH2Os/e01T/2x++V0LPukA==",
+      "dev": true,
+      "requires": {
+        "get-stdin": "^6.0.0"
+      },
+      "dependencies": {
+        "get-stdin": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-6.0.0.tgz",
+          "integrity": "sha512-jp4tHawyV7+fkkSKyvjuLZswblUtz+SQKzSWnBbii16BuZksJlU1wuBYXY75r+duh/llF1ur6oNwi+2ZzjKZ7g==",
+          "dev": true
+        }
+      }
+    },
     "eslint-plugin-cypress": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/eslint-plugin-cypress/-/eslint-plugin-cypress-2.2.0.tgz",
@@ -5101,6 +5118,15 @@
       "dev": true,
       "requires": {
         "globals": "^11.0.1"
+      }
+    },
+    "eslint-plugin-prettier": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-3.1.0.tgz",
+      "integrity": "sha512-XWX2yVuwVNLOUhQijAkXz+rMPPoCr7WFiAl8ig6I7Xn+pPVhDhzg4DxHpmbeb0iqjO9UronEA3Tb09ChnFVHHA==",
+      "dev": true,
+      "requires": {
+        "prettier-linter-helpers": "^1.0.0"
       }
     },
     "eslint-scope": {
@@ -5446,6 +5472,12 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
       "integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk=",
+      "dev": true
+    },
+    "fast-diff": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/fast-diff/-/fast-diff-1.2.0.tgz",
+      "integrity": "sha512-xJuoT5+L99XlZ8twedaRf6Ax2TgQVxvgZOYoPKqZufmJib0tL2tegPBOZb1pVNgIhlqDlA0eO0c3wBvQcmzx4w==",
       "dev": true
     },
     "fast-json-stable-stringify": {
@@ -9962,6 +9994,15 @@
       "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.18.2.tgz",
       "integrity": "sha512-OeHeMc0JhFE9idD4ZdtNibzY0+TPHSpSSb9h8FqtP+YnoZZ1sl8Vc9b1sasjfymH3SonAF4QcA2+mzHPhMvIiw==",
       "dev": true
+    },
+    "prettier-linter-helpers": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/prettier-linter-helpers/-/prettier-linter-helpers-1.0.0.tgz",
+      "integrity": "sha512-GbK2cP9nraSSUF9N2XwUwqfzlAFlMNYYl+ShE/V+H8a9uNl/oUqB1w2EL54Jh0OlyRSd8RfWYJ3coVS4TROP2w==",
+      "dev": true,
+      "requires": {
+        "fast-diff": "^1.1.2"
+      }
     },
     "pretty-hrtime": {
       "version": "1.0.3",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,9 @@
     "cypress": "^3.3.1",
     "del": "^3.0.0",
     "eslint": "^5.11.1",
+    "eslint-config-prettier": "^6.0.0",
     "eslint-plugin-cypress": "^2.2.0",
+    "eslint-plugin-prettier": "^3.1.0",
     "fs-extra": "^8.0.1",
     "gulp": "^4.0.0",
     "gulp-babel": "^8.0.0",
@@ -41,6 +43,7 @@
     "gulp-uglify": "^3.0.1",
     "node-sass-tilde-importer": "^1.0.2",
     "path": "^0.12.7",
+    "prettier": "1.18.2",
     "remove-markdown": "^0.3.0"
   },
   "dependencies": {}


### PR DESCRIPTION
## Problem
- "Watch the latest message" link on the homepage broke when Shared Header 2.0 was deployed

## Solution
- Changed the href source to  not use media snippets
- Updated automated tests