### PR TITLE
[CYP] Fixed Live jumbotron tests

### DIFF
--- a/cypress/integration/live/live_jumbotron_spec.js
+++ b/cypress/integration/live/live_jumbotron_spec.js
@@ -9,7 +9,7 @@ function visitLiveWithSchedule(fakeSchedule) {
   cy.visit('/live');
 }
 
-describe('Tests the /live jumbotron content with different stream times', function () {
+describe('Tests the /live jumbotron content with different stream times:', function () {
   let scheduleGenerator;
   let currentMessage;
   before(function () {
@@ -22,17 +22,17 @@ describe('Tests the /live jumbotron content with different stream times', functi
     });
   });
 
-  describe('Tests button navigation', function () {
+  describe('Tests button navigation:', function () {
     it('Live Stream State: Checks clicking "Watch Now" navs to the live stream', function () {
       const fakeCurrentSchedule = scheduleGenerator.getStreamStartingAfterHours(0);
       visitLiveWithSchedule(fakeCurrentSchedule);
 
-      //Spoof shcedule route again
+      //Spoof shcedule route again before navigating
       cy.server();
       cy.route(`${Cypress.env('schedule_env')}/streamSchedule`, fakeCurrentSchedule);
 
       cy.get('[data-automation-id="jumbotron-watch-now-button"]').click();
-      RouteValidator.pageFoundAndURLMatches(`${Cypress.config().baseUrl}/live/stream`);
+      RouteValidator.pageFoundAndURLMatches(`${Cypress.config().baseUrl}/live/stream/?autoplay=true&sound=11`);
     });
 
     it('Offstream State: Checks clicking "Watch This Weeks Service" navs to the latest message', function () {
@@ -42,69 +42,61 @@ describe('Tests the /live jumbotron content with different stream times', functi
     });
   });
 
+  describe('Tests state when stream is running', function () {
+    before(function () {
+      visitLiveWithSchedule(scheduleGenerator.getStreamStartingAfterHours(0));
+    });
 
-  [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17].forEach(hoursBefore => {
-    if (hoursBefore == 0) {
+    it('Checks live content is displayed', function () {
+      cy.get('[class^="content-live"]').should('be.visible');
+      cy.get('[class^="content-upcoming"]').should('not.be.visible');
+      cy.get('[class^="content-offstream"]').should('not.be.visible');
+    });
 
-      describe('Tests state when stream is running', function () {
-        before(function () {
-          visitLiveWithSchedule(scheduleGenerator.getStreamStartingAfterHours(hoursBefore));
-        });
+    it('Checks "Watch Now" is displayed and has correct link', function () {
+      cy.get('[data-automation-id="jumbotron-watch-now-button"]')
+        .should('be.visible')
+        .and('have.attr', 'href', '/live/stream?autoplay=true&sound=11');
+    });
+  });
 
-        it('Checks live content is displayed', function () {
-          cy.get('[class^="content-live"]').should('be.visible');
-          cy.get('[class^="content-upcoming"]').should('not.be.visible');
-          cy.get('[class^="content-offstream"]').should('not.be.visible');
-        });
+  //Upcoming state is between 0.1 and 16 hours
+  //Note that future streaming time can't be accurately spoofed when running on Travis, so don't check exact time
+  describe('Tests display when the stream is upcoming', function () {
+    before(function () {
+      visitLiveWithSchedule(scheduleGenerator.getStreamStartingAfterHours(10));
+    });
 
-        it('Checks "Watch Now" is displayed and has correct link', function () {
-          cy.get('[data-automation-id="jumbotron-watch-now-button"]')
-            .should('be.visible')
-            .and('have.attr', 'href', '/live/stream');
-        });
-      });
+    it('Checks upcoming content is displayed', function () {
+      cy.get('[class^="content-live"]').should('not.be.visible');
+      cy.get('[class^="content-upcoming"]').should('be.visible');
+      cy.get('[class^="content-offstream"]').should('not.be.visible');
+    });
 
-    }
-    else if (hoursBefore < 16) {
+    it('Checks the countdown is displayed with correct days and hours left', function () {
+      cy.get('[data-automation-id="jumbotron-countdown"]').as('countdown').should('be.visible');
+      cy.get('@countdown').find('[class^="countdown-days"]').text().should('eq', '00');
+      cy.get('@countdown').find('[class^="countdown-hours"]').text().should('not.eq', '00');
+    });
+  });
 
-      describe.skip(`Tests state when the stream will start in ${hoursBefore} hours`, function () {
-        before(function () {
-          visitLiveWithSchedule(scheduleGenerator.getStreamStartingAfterHours(hoursBefore));
-        });
+  //Offstream state is over 16 hours
+  //Note that future streaming time can't be accurately spoofed when running on Travis, so don't check exact time
+  describe('Tests display when the stream is in the "offstream" state', function () {
+    before(function () {
+      visitLiveWithSchedule(scheduleGenerator.getStreamStartingAfterHours(36));
+    });
 
-        it('Checks upcoming content is displayed', function () {
-          cy.get('[class^="content-live"]').should('not.be.visible');
-          cy.get('[class^="content-upcoming"]').should('be.visible');
-          cy.get('[class^="content-offstream"]').should('not.be.visible');
-        });
+    it('Checks offstream content is displayed', function () {
+      cy.get('[class^="content-live"]').should('not.be.visible');
+      cy.get('[class^="content-upcoming"]').should('not.be.visible');
+      cy.get('[class^="content-offstream"]').should('be.visible');
+    });
 
-        it('Checks the countdown is displayed with correct days and hours left', function () {
-          cy.get('[data-automation-id="jumbotron-countdown"]').as('countdown').should('be.visible');
-          cy.get('@countdown').find('[class^="countdown-days"]').text().should('eq', '00');
-          cy.get('@countdown').find('[class^="countdown-hours"]').text().should('match', new RegExp(`0?${hoursBefore - 1}`));
-        });
-      });
-
-    }
-    else {
-
-      describe(`Tests state when the stream will start in ${hoursBefore} hours`, function () {
-        before(function () {
-          visitLiveWithSchedule(scheduleGenerator.getStreamStartingAfterHours(hoursBefore));
-        });
-
-        it('Checks offstream content is displayed', function () {
-          cy.get('[class^="content-live"]').should('not.be.visible');
-          cy.get('[class^="content-upcoming"]').should('not.be.visible');
-          cy.get('[class^="content-offstream"]').should('be.visible');
-        });
-
-        it('Check "Watch This Weeks Service" is displayed and has correct link', function () {
-          cy.get('[data-automation-id="watch-service-button"]')
-            .should('be.visible')
-            .and('have.attr', 'href', currentMessage.autoplayURL.relative);
-        });
-      });
-    }
+    it('Check "Watch This Weeks Service" is displayed and has correct link', function () {
+      cy.get('[data-automation-id="watch-service-button"]')
+        .should('be.visible')
+        .and('have.attr', 'href', currentMessage.autoplayURL.relative);
+    });
   });
 });

--- a/cypress/support/RouteValidator.js
+++ b/cypress/support/RouteValidator.js
@@ -8,10 +8,10 @@ export class RouteValidator{
     RouteValidator.pageShouldNotBe404();
   }
 
-  static pageShouldMatchUrl(url){;
+  static pageShouldMatchUrl(url){
     cy.url().then(pageUrl => {
       const noTrailinSlashRegex = /\/$/g;
       expect(pageUrl.replace(noTrailinSlashRegex, '')).to.eq(url.replace(noTrailinSlashRegex, ''));
-    })
+    });
   }
 }


### PR DESCRIPTION
## Problem
- Exact start times for live stream cannot be spoofed accurately when running on Travis

## Solution
- Test around streaming states - "offstream", "upcoming" and "live" instead of exact times.