### PR TITLE
[CYP] DE?? - Make /locations search less flaky

### DIFF
--- a/cypress/integration/homepage/home_page_happenings_spec.js
+++ b/cypress/integration/homepage/home_page_happenings_spec.js
@@ -13,8 +13,8 @@ function selectFilter(audience) {
   cy.get('@promoFilter').find(`[data-filter-select="${audience}"]`).as('audienceSelector');
   cy.get('@audienceSelector').click();
 }
-
-describe('Tests Happening section without filters', function () {
+//TODO need to update for personalised happenings app
+describe.skip('Tests Happening section without filters', function () {
   before(function () {
     cy.ignorePropertyUndefinedTypeError();
     cy.visit('/');
@@ -31,7 +31,8 @@ describe('Tests Happening section without filters', function () {
   });
 });
 
-describe('Tests Happenings can be filtered by audience', function () {
+//TODO need to update for personalised happenings app
+describe.skip('Tests Happenings can be filtered by audience', function () {
   let pqm;
   before(function () {
     cy.ignorePropertyUndefinedTypeError();

--- a/cypress/integration/homepage/home_page_happenings_spec.js
+++ b/cypress/integration/homepage/home_page_happenings_spec.js
@@ -13,8 +13,8 @@ function selectFilter(audience) {
   cy.get('@promoFilter').find(`[data-filter-select="${audience}"]`).as('audienceSelector');
   cy.get('@audienceSelector').click();
 }
-//TODO need to update for personalised happenings app
-describe.skip('Tests Happening section without filters', function () {
+
+describe('Tests Happening section without filters', function () {
   before(function () {
     cy.ignorePropertyUndefinedTypeError();
     cy.visit('/');
@@ -31,8 +31,7 @@ describe.skip('Tests Happening section without filters', function () {
   });
 });
 
-//TODO need to update for personalised happenings app
-describe.skip('Tests Happenings can be filtered by audience', function () {
+describe('Tests Happenings can be filtered by audience', function () {
   let pqm;
   before(function () {
     cy.ignorePropertyUndefinedTypeError();

--- a/cypress/integration/locations/locations_search_spec.js
+++ b/cypress/integration/locations/locations_search_spec.js
@@ -11,14 +11,42 @@ function searchForLocation(keyword) {
   });
 }
 
+function visitLocationsSafeForSearch(retries){
+  cy.on('uncaught:exception', (err) => {
+    //Sees error, posts assertion to console, fails if not matching
+    const propertyUndefinedRegex = /.*Cannot read property\W+\w+\W+of undefined.*/;
+    if(err.message.match(propertyUndefinedRegex) !== null){
+      console.log(`ERROR found! retries left visiting locations ${retries}`);
+      retries -= 1; //TODO is retries accessible by this?
+      if(retries > 0){
+        visitLocationsSafeForSearch(retries);
+      }
+      else {
+        return true;
+      }
+      return false;
+    }
+    else
+    {
+      return true;
+    }
+  });
+
+  cy.visit('/locations');
+  searchForLocation(' ');
+}
+
 describe('Given I search for a standard location on /locations:', function () {
   before(function () {
-    cy.ignorePropertyUndefinedTypeError();
+    visitLocationsSafeForSearch(2);
+    // cy.ignorePropertyUndefinedTypeError();
 
-    //Workaround for DE6665 - The locations page sometimes loads with missing functionality. Loading a different page before /locations
-    //  seems to prevent this issue, which is easier than trying to recover from the failure during the test.
-    cy.visit('/prayer');
-    cy.visit('/locations');
+    // //Workaround for DE6665 - The locations page sometimes loads with missing functionality. Loading a different page before /locations
+    // //  then waiting seems to prevent this issue, which is easier than trying to recover from the failure during the test.
+    // cy.visit('/prayer');
+    // cy.visit('/locations');
+    // cy.wait(1000); //We really want to do this
+    // //TODO this didn't work. Add method - is locations fully loaded that reloads itself until can be searched
   });
 
   //For a Contentful Location card to display the distance, its address must be valid
@@ -54,10 +82,11 @@ describe('Given I search for a non-standard location on /locations', function ()
   beforeEach(function () {
     cy.ignorePropertyUndefinedTypeError();
 
-    //Workaround for DE6665 - The locations page sometimes loads with missing functionality. Loading the page twice from the start
-    //  prevents this issue, which is easier than trying to recover from the failure during the test.
-    cy.visit('/locations').then(() =>
-      cy.visit('/locations'));
+    //Workaround for DE6665 - The locations page sometimes loads with missing functionality. Loading a different page before /locations
+    //  then waiting seems to prevent this issue, which is easier than trying to recover from the failure during the test.
+    cy.visit('/prayer');
+    cy.visit('/locations');
+    cy.wait(1000); //We really want to do this
   });
 
   it('Searching for an out of range location should display the Anywhere card first', function () {

--- a/cypress/integration/locations/locations_search_spec.js
+++ b/cypress/integration/locations/locations_search_spec.js
@@ -1,7 +1,7 @@
 //Workaround for DE6665 - The locations page sometimes loads with missing functionality.
 function visitLocationsWithRetry(retries){
   cy.on('uncaught:exception', (err) => {
-    //Sees error, posts assertion to console, fails if not matching
+    //Sees error, posts message to console, fails if not matching
     const propertyUndefinedRegex = /.*Cannot read property\W+\w+\W+of undefined.*/;
     const undefinedObjectRegex = /.*Cannot convert undefined or null to object.*/;
     if(err.message.match(propertyUndefinedRegex) !== null ||

--- a/package-lock.json
+++ b/package-lock.json
@@ -4230,9 +4230,9 @@
       }
     },
     "cypress": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-3.4.0.tgz",
-      "integrity": "sha512-vUE+sK3l23fhs5qTN3dKpveyP0fGr37VmK3FSYaTEjbqC/qh4DbA1Ych/3bLStUpHP4rpE5KAx7i1s/tpdD9vQ==",
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-3.4.1.tgz",
+      "integrity": "sha512-1HBS7t9XXzkt6QHbwfirWYty8vzxNMawGj1yI+Fu6C3/VZJ8UtUngMW6layqwYZzLTZV8tiDpdCNBypn78V4Dg==",
       "dev": true,
       "requires": {
         "@cypress/listr-verbose-renderer": "0.4.1",
@@ -4250,12 +4250,11 @@
         "extract-zip": "1.6.7",
         "fs-extra": "5.0.0",
         "getos": "3.1.1",
-        "glob": "7.1.3",
         "is-ci": "1.2.1",
         "is-installed-globally": "0.1.0",
         "lazy-ass": "1.6.0",
         "listr": "0.12.0",
-        "lodash": "4.17.11",
+        "lodash": "4.17.15",
         "log-symbols": "2.2.0",
         "minimist": "1.2.0",
         "moment": "2.24.0",
@@ -4459,12 +4458,6 @@
               "dev": true
             }
           }
-        },
-        "lodash": {
-          "version": "4.17.11",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-          "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
-          "dev": true
         },
         "log-symbols": {
           "version": "2.2.0",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "contentful-cli": "^0.28.0",
     "crds-cypress-contentful": "^1.0.0",
     "crds-styles": "^3.2.3",
-    "cypress": "^3.4.0",
+    "cypress": "^3.4.1",
     "del": "^3.0.0",
     "eslint": "^5.11.1",
     "eslint-config-prettier": "^6.0.0",


### PR DESCRIPTION
## Problem
- The /locations search tests are pretty flaky due to persistent load order issues

## Workaround
- Added a function that'll try to trigger the errors and reload the page if they're caught. Recursion ftw.