### PR TITLE
fixing stream events

### DIFF
--- a/_assets/javascripts/components/bitmovin.js
+++ b/_assets/javascripts/components/bitmovin.js
@@ -86,11 +86,9 @@ class BitmovinManager {
         this.bitmovinPlayer.on('paused', (eventProps) => {
             if (eventProps.issuer !== "ui") return;
             this.onPlayerEnd('Paused')
-            this.cancelStreams();
+            if (this.isStream) this.cancelStreams();
         });
-        if (this.isStream) {
 
-        }
         this.bitmovinPlayer.on('subtitleenable', () => { this.onSubtitlesEnabled() });
         this.bitmovinPlayer.on('sourceloaded', () => { this.addExternalSubtitles() });
         this.bitmovinPlayer.on('ready', () => { this.onPlayerReady(new Date()) });

--- a/_assets/javascripts/components/bitmovin.js
+++ b/_assets/javascripts/components/bitmovin.js
@@ -46,7 +46,7 @@ class BitmovinManager {
         }
 
         if (this.isStream) {
-            if(this.countdown.events) this.streamInit(this.countdown.events, bitmovinConfig);
+            if (this.countdown.events) this.streamInit(this.countdown.events, bitmovinConfig);
             this.countdown.streamStatusPromise.then(events => {
                 this.streamInit(events, bitmovinConfig);
             });
@@ -83,9 +83,13 @@ class BitmovinManager {
         );
         this.bitmovinPlayer.on('play', () => { this.onPlayerStart() });
         this.bitmovinPlayer.on('playbackfinished', () => { this.onPlayerEnd('Ended') });
-        this.bitmovinPlayer.on('paused', () => { this.onPlayerEnd('Paused') });
+        this.bitmovinPlayer.on('paused', (eventProps) => {
+            if (eventProps.issuer !== "ui") return;
+            this.onPlayerEnd('Paused')
+            this.cancelStreams();
+        });
         if (this.isStream) {
-            this.bitmovinPlayer.on('paused', () => { this.cancelStreams() });
+
         }
         this.bitmovinPlayer.on('subtitleenable', () => { this.onSubtitlesEnabled() });
         this.bitmovinPlayer.on('sourceloaded', () => { this.addExternalSubtitles() });
@@ -219,13 +223,12 @@ class BitmovinManager {
     }
 
     showStandbyMessaging() {
-        this.bitmovinPlayer.pause();
+        this.pauseVideo();
         this.standbyElm.style.opacity = 1;
         this.standbyElm.style.zIndex = 10;
     }
 
     hideStandbyMessaging() {
-        this.bitmovinPlayer.play();
         this.standbyElm.style.opacity = 0;
         this.standbyElm.style.zIndex = 0;
     }
@@ -275,7 +278,7 @@ class BitmovinManager {
         min = min || 0;
         sec = sec || 0;
         this.bitmovinPlayer.seek(min * 60 + sec, true);
-        this.bitmovinPlayer.play();
+        this.playVideo();
         history.pushState({}, document.title, '?min=' + min + '&sec=' + sec);
     }
 
@@ -300,7 +303,7 @@ class BitmovinManager {
         });
     }
 
-    streamInit(events, bitmovinConfig){ 
+    streamInit(events, bitmovinConfig) {
         this.createSource(bitmovinConfig);
         this.createPlayer();
         this.bitmovinPlayer.on('sourceloaded', () => {


### PR DESCRIPTION
## Problem
Events were not working for live streaming. Due to adding the "if a player pauses disable all future events."

## Solution
Only cancel events if a pause is caused by the UI. If the player loads and the browser blocks playback this should not count as a "pause" event. If the playback finished, this should also not count as a "paused" event. 

## Testing
See rally story for testing scenarios.
