### PR TITLE
de7141 onsite groups zero state

### DIFF
--- a/onsite-groups.html
+++ b/onsite-groups.html
@@ -19,6 +19,8 @@ permalink: /groups/onsite
 
 <section class="container">
   {% for category in site['onsite_group_categories'] %}
+  {% assign groups = category | onsite_groups_for_category %}
+  {% if groups.size > 0 %}
   <div class="row soft-ends push-bottom push-quarter-top">
     <div class="col-sm-3">
       <img src="{{ category.image.url | imgix: site.imgix }}?{{ site.imgix_params.placeholder_sixteen_nine }}"
@@ -34,7 +36,6 @@ permalink: /groups/onsite
         </div>
       </div>
       <hr />
-      {% assign groups = category | onsite_groups_for_category %}
       {% for row in groups %}
       <div class="row onsite-group-negative-margin-bottom">
         {% for col in row %}
@@ -49,6 +50,7 @@ permalink: /groups/onsite
       {% endfor %}
     </div>
   </div>
+  {% endif %}
   {% endfor %}
 
   <div class="row">


### PR DESCRIPTION
## Problem
Onsite group categories were showing up even if there were no groups

## Solution
Add a zero state for onsite group categories

## Testing
The Recovery category is no longer on the page.
https://deploy-preview-1135--int-crds-net.netlify.com/groups/onsite

Previous screenshot: The Recovery category is showing and has no groups
![image](https://user-images.githubusercontent.com/1730906/64378560-f9b9fc80-cffa-11e9-95d5-8cfe6b385b19.png)

