### PR TITLE
[hotfix] Reverts #1132

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -115,7 +115,7 @@ collections:
   content_blocks:
     output: false
   onsite_groups:
-    output: false
+    output: true
     permalink: /groups/(:category/:slug)/:slug
   onsite_group_categories:
     output: false

--- a/_plugins/generators/onsite_groups_generator.rb
+++ b/_plugins/generators/onsite_groups_generator.rb
@@ -2,9 +2,6 @@ module Jekyll
   class OnsiteGroupsGenerator < Generator
 
     def generate(site)
-      # Temporarily disable new page generation
-      return
-
       # Get all meetings documents from Jekyll collections
       meetings = site.
         collections['onsite_group_meetings'].docs

--- a/onsite-groups.html
+++ b/onsite-groups.html
@@ -2,7 +2,6 @@
 layout: container-fluid
 title: Onsite Groups
 permalink: /groups/onsite
-published: false
 ---
 
 <div


### PR DESCRIPTION
This hot fix PR reverts b03a948e279dc0b6adab793a27627cf684bba7e1 that was introduced into `release` and `master` last week to prevent OSG pages from displaying in the demo or production environments. 

The intention here is to ensure no conflicts are introduced via future deploys to these two environments. 