### PR TITLE
De7119 future was now

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,15 @@ This behavior is odd. After hitting `Enter` after the first line, nothing happen
 
 If you try to push again, you should be prompted for a new username and password and those will be stored in your keychain for future use.
 
+## Future Dated content
+The file name is what keeps future dated content from showing on non layout pages. There are examples of this in the config.yml.
+
+```yaml
+collections:
+  articles:
+    filename: "{{ published_at | date: '%Y-%m-%d' }}-{{ slug }}"
+```
+
 ## Build Logs
 
 Build logs are dependant on two environment variables

--- a/_config.yml
+++ b/_config.yml
@@ -35,12 +35,18 @@ exclude:
 contentful:
   article:
     query: "fields.exclude_from_crossroads[ne]=true"
+    map:
+      date: published_at
   series:
     limit: 10
     order: "published_at desc"
+    map:
+      date: published_at
   message:
     limit: 4
     order: "published_at desc"
+    map:
+      date: published_at
   featured_media:
     query: fields.site=net
     map:
@@ -55,8 +61,12 @@ contentful:
     query: "fields.exclude_from_crossroads[ne]=true"
   episode:
     query: "content_type=episode&fields.podcast.sys.contentType.sys.id=podcast&fields.podcast.fields.exclude_from_crossroads[ne]=true"
+    map:
+      date: published_at
   video:
     query: "fields.exclude_from_crossroads[ne]=true"
+    map:
+      date: published_at
   exclude:
     - album
     - migration
@@ -86,6 +96,7 @@ collections:
     filename: "{{ published_at | date: '%Y-%m-%d-%H-%M-%S' }}-{{ title | slugify }}-{{ slug }}"
     output: false
   articles:
+    filename: "{{ published_at | date: '%Y-%m-%d' }}-{{ slug }}"
     output: false
   topics:
     output: false
@@ -94,6 +105,7 @@ collections:
   podcasts:
     output: false
   episodes:
+    filename: "{{ published_at | date: '%Y-%m-%d' }}-{{ slug }}"
     output: false
     permalink: /podcasts/(:podcast/:slug)/:title
   tags:
@@ -111,6 +123,7 @@ collections:
   songs:
     output: false
   videos:
+    filename: "{{ published_at | date: '%Y-%m-%d' }}-{{ slug }}"
     output: false
   system_pages:
     output: false


### PR DESCRIPTION
## Problem
Content with a future published_at date is being shown on the homepage

## Solution
properly configure collections to append the file with the date so that it becomes excluded
