### PR TITLE
DE7300 Link meetings and locations

### DIFF
--- a/_layouts/onsite-group-detail.html
+++ b/_layouts/onsite-group-detail.html
@@ -33,7 +33,7 @@ layout: container-fluid
         {% assign meeting = site.onsite_group_meetings | where: 'contentful_id', obj.id | first %}
         <div class="col-md-5 push-top push-right soft-right">
           <h4 class="flush-ends font-family-condensed-extra text-uppercase">
-            {{ meeting.location.name }}
+            <a href="/groups/{{ meeting.location.slug }}">{{ meeting.location.name }}</a>
           </h4>
           <h4 class="flush-ends font-family-condensed-extra text-uppercase">
             {{ meeting.meeting_time }}

--- a/_layouts/onsite-group-location.html
+++ b/_layouts/onsite-group-location.html
@@ -36,7 +36,9 @@ snail_trail: connect
     {% for meeting in page.meetings %}
     <div class="col-md-3">
       <h4 class="font-family-condensed-extra text-uppercase">
-        {{ meeting.title }}
+        <a href="{{ page.meeting_group_permalinks[meeting.contentful_id] }}">
+          {{ meeting.title }}
+        </a>
       </h4>
       <p class="text-gray flush-bottom small">{{ meeting.description }}</p>
       <p class="flush-bottom push-quarter-top small">

--- a/_layouts/onsite-group-location.html
+++ b/_layouts/onsite-group-location.html
@@ -36,9 +36,13 @@ snail_trail: connect
     {% for meeting in page.meetings %}
     <div class="col-md-3">
       <h4 class="font-family-condensed-extra text-uppercase">
+        {% if page.meeting_group_permalinks[meeting.contentful_id] %}
         <a href="{{ page.meeting_group_permalinks[meeting.contentful_id] }}">
           {{ meeting.title }}
         </a>
+        {% else %}
+          {{ meeting.title }}
+        {% endif %}
       </h4>
       <p class="text-gray flush-bottom small">{{ meeting.description }}</p>
       <p class="flush-bottom push-quarter-top small">

--- a/_plugins/generators/onsite_groups_generator.rb
+++ b/_plugins/generators/onsite_groups_generator.rb
@@ -2,6 +2,17 @@ module Jekyll
   class OnsiteGroupsGenerator < Generator
 
     def generate(site)
+      # Get the meeting group permalinks
+      meeting_group_permalinks = Hash.new
+      site.
+        collections['onsite_groups'].docs.each do |group|
+          if !group.data['meetings'].nil?
+            group.data['meetings'].each do |meeting|
+              meeting_group_permalinks[meeting['id']] = group.url
+            end
+          end
+        end
+
       # Get all meetings documents from Jekyll collections
       meetings = site.
         collections['onsite_group_meetings'].docs
@@ -28,6 +39,7 @@ module Jekyll
         # Add location and meeting info to page's data object
         page.data['location'] = location
         page.data['meetings'] = meetings_by_location[slug]
+        page.data['meeting_group_permalinks'] = meeting_group_permalinks
         # Add the page to Jekyll's pages array
         site.pages << page
       end


### PR DESCRIPTION
## Problem
Onsite group locations and meeting group pages should be linked together.

[Original Task](https://rally1.rallydev.com/#/38108142417d/custom/292180449324?qdp=%2Fdetail%2Fdefect%2F348354355704)

## Solution
- The titles for the meetings on a location page have been linked to the meetings group page.
- The location names on each meeting page have been linked to the corresponding location

## Testing
- Verify that the meeting groups have their related locations linked. [Click here for the list](https://deploy-preview-1216--int-crds-net.netlify.com/groups/onsite) **Top of page**
![group](https://user-images.githubusercontent.com/56852436/68868714-00818180-06c6-11ea-8c79-0f1dc0ee3361.png)
- Verify that the meetings on the locations are linked to the individual page. [Click here for the list]
  - **Note:** There are some meetings that are not related to a group primarily Lipsum/Test types. They will not receive a link unless they are part of a group.
(https://deploy-preview-1216--int-crds-net.netlify.com/groups/onsite) **Bottom of page**
![location](https://user-images.githubusercontent.com/56852436/68868837-31fa4d00-06c6-11ea-97c1-e1414cd84970.png)

