### PR TITLE
Remove decorating signup

### DIFF
--- a/_layouts/location.html
+++ b/_layouts/location.html
@@ -9,45 +9,45 @@ layout: default
 {% if page.title == "Andover" %}
 {% assign care_link = "https://docs.google.com/forms/d/e/1FAIpQLSc_tN4sn2STiUwDuAj2kkvD586-gE6Ztp5MI7es6D46hx1zyQ/viewform" %}
 {% elsif page.title == "Lexington" %}
-{% assign fi_link = "http://www.crossroads.net/lexington/christmasdecoratingsignup/" %}
+
 {% assign cgd_link = "http://www.crossroads.net/cgd/lexington" %}
 {% assign care_link = "https://docs.google.com/forms/d/e/1FAIpQLSc_tN4sn2STiUwDuAj2kkvD586-gE6Ztp5MI7es6D46hx1zyQ/viewform" %}
 {% elsif page.title == "Columbus" %}
 {% elsif page.title == "Dayton" %}
-{% assign fi_link = "https://www.crossroads.net/dayton/christmasvolunteersignup/" %}
+
 {% assign care_link = "https://docs.google.com/forms/d/e/1FAIpQLScA4hpYfwYROgpwQs1iDelr5nahobys0SuK_Tm8cfOANTR-Dg/viewform" %}
 {% elsif page.name == "Downtown Lexington" %}
-{% assign fi_link = "https://www.crossroads.net/downtown/christmasdecoratingsignup/" %}
+
 {% assign care_link = "https://docs.google.com/forms/d/e/1FAIpQLSeyqUR1KRRQnQJDSdX3cPgzfHgXKNK18ABzk2Cl6g99jtRrsA/viewform" %}
 {% elsif page.title == "Eastside" %}
-{% assign fi_link = "https://www.crossroads.net/eastside/christmasdecoratingsignup/" %}
+
 {% assign care_link = "https://docs.google.com/forms/d/e/1FAIpQLScMpEO29vIDaUMuQkjlu-Jcf6II8jL4JG-wyLFA5yKBBCWWDA/viewform" %}
 {% elsif page.title == "Florence" %}
 {% assign cgd_link = "http://www.crossroads.net/cgd/florence" %}
 {% assign eve_link = "http://crossroadschurch1.volunteerlocal.com/volunteer/?start_over&id=43913" %}
 {% assign care_link = "https://docs.google.com/forms/d/e/1FAIpQLSfo2ywXjTQuxNUx5uIa7T3n2K_rZ9rWc2F_3CJCM4x8dMvN3w/viewform" %}
 {% elsif page.title == "Georgetown" %}
-{% assign fi_link = "http://www.crossroads.net/georgetown/christmasdecoratingsignup/" %}
+
 {% assign care_link = "https://docs.google.com/forms/d/e/1FAIpQLSf1VIGPA3qcmjtXb2JG4tCz-LhwoLNPDjPloHLTJ-72u15HQw/viewform" %}
 {% elsif page.title == "Mason" %}
-{% assign fi_link = "https://www.crossroads.net/mason/christmasdecoratingsignup/" %}
+
 {% assign cgd_link = "https://www.crossroads.net/cgd/mason/" %}
 {% assign care_link = "https://docs.google.com/forms/d/e/1FAIpQLSctEwPK6JmDtzB6iN4J4a2cSUWme4BeefEHr2xzqTYorQBr7Q/viewform" %}
 {% elsif page.title == "Oakley" %}
-{% assign fi_link = "http://www.crossroads.net/oakley/christmasdecoratingsignup/" %}
+
 {% assign eve_link = "http://crossroadsallothervolunteers.volunteerlocal.com/volunteer/?id=43586" %}
 {% assign care_link = "https://docs.google.com/forms/d/e/1FAIpQLSdjDSPZQil5lZAipQnodua9xaj0zhrgI1fl0lt6dC2617AJPw/viewform" %}
 {% elsif page.title == "Oxford" %}
 {% assign care_link = "https://docs.google.com/forms/d/e/1FAIpQLSc_zIJaeQHa7H5ZfkSgrNxzjZb6-2Liycyf5P9hYkuK4BRqrQ/viewform" %}
 {% elsif page.title == "Richmond" %}
-{% assign fi_link = "http://www.crossroads.net/richmond/christmasdecoratingsignup/" %}
+
 {% assign eve_link = "http://crossroadschurch1.volunteerlocal.com/volunteer/?id=43719" %}
 {% assign care_link = "https://docs.google.com/forms/d/e/1FAIpQLSegG0d3hMLUpQL-_m65FHG1tniT2TtRODEPQtegPl76qnAq7A/viewform" %}
 {% elsif page.title == "Uptown" %}
-{% assign fi_link = "http://www.crossroads.net/uptown/christmasdecoratingsignup/" %}
+
 {% assign care_link = "https://docs.google.com/forms/d/e/1FAIpQLScTectxJ6mKo-UvZVv4Av8Q5kWkTZZypAGdqLldnR50hYnWGA/viewform" %}
 {% elsif page.title == "Westside" %}
-{% assign fi_link = "http://www.crossroads.net/westside/christmasdecoratingsignup/" %}
+
 {% assign cgd_link = "http://www.crossroads.net/cgd/westside" %}
 {% assign eve_link = "http://crossroadschurch1.volunteerlocal.com/volunteer/?id=43547" %}
 {% assign care_link = "https://docs.google.com/forms/d/e/1FAIpQLSdbCAA4ZqkefkWXOd5zl_B8t8fewruAhfaEXoKUoW9sgt8QGg/viewform" %}
@@ -89,13 +89,6 @@ layout: default
       </div>
     </div>
     <div class="row push-ends">
-      {% if fi_link %}
-      <div class="col-sm-4 soft-sides">
-        <h2 class="component-header text-white flush-top">Christmas Decorating Party</h2>
-        <p style="color: #eab6b6;">From decorating the atrium to behind-the-scenes support, sign up here to volunteer for the Christmas Decorating Party this season.</p>
-        <a href="{{ fi_link }}" class="btn btn-outline btn-white push-quarter-ends text-white" target="_blank">Sign up for Christmas Decorating Party</a>
-      {% endif %}
-      </div>
       {% if cgd_link %}
       <div class="col-sm-4 soft-sides push-bottom">
         <h2 class="component-header text-white flush-top">Christmas Gift Drive</h2>


### PR DESCRIPTION
## Problem
Decorating sign-up for all locations is over and needs to be removed.

## Solution
Removed content block for a sign-up link for all locations

### Corresponding Branch
hotfix/remove-location-decorating-signup

## Testing
Locally tested