### PR TITLE
DE7341 Onsite Group Url

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -120,7 +120,7 @@ collections:
     output: false
   onsite_groups:
     output: true
-    permalink: /groups/(:category/:slug)/:slug
+    permalink: /groups/onsite/(:category/:slug)/:slug
   onsite_group_categories:
     output: false
   onsite_group_meetings:

--- a/_plugins/generators/onsite_groups_generator.rb
+++ b/_plugins/generators/onsite_groups_generator.rb
@@ -3,7 +3,7 @@ module Jekyll
 
     def generate(site)
       # Get the meeting group permalinks
-      meeting_group_permalinks = Hash.new
+      meeting_group_permalinks = Hash.new("onsite")
       site.
         collections['onsite_groups'].docs.each do |group|
           if !group.data['meetings'].nil?
@@ -35,7 +35,7 @@ module Jekyll
         # Render the `onsite-group-location.html` template
         page = Jekyll::Page.new(site, '_layouts', '', 'onsite-group-location.html')
         # Tell Jekyll what URL we want for out page
-        page.instance_variable_set('@url', "/groups/#{slug}/index.html")
+        page.instance_variable_set('@url', "/groups/onsite/#{slug}/index.html")
         # Add location and meeting info to page's data object
         page.data['location'] = location
         page.data['meetings'] = meetings_by_location[slug]


### PR DESCRIPTION
## Problem
navigate to https://int.crossroads.net/groups/onsite and click/hover on any group you see.
The url for the group (fathers for exmpl) is https://int.crossroads.net/groups/connection/fathers instead of https://int.crossroads.net/groups/onsite/connection/fathers

## Solution
Change permalink for onsite groups
[Preview](https://deploy-preview-1238--int-crds-net.netlify.com/groups/onsite)

## Note 
Once this merged, we need to merge [this PR](https://github.com/crdschurch/crds-search-index-data/pull/49) for Crds-search-index-data
