### PR TITLE
DE7379 [osg] markdown not rendering for group meetings

### DIFF
--- a/_layouts/onsite-group-detail.html
+++ b/_layouts/onsite-group-detail.html
@@ -49,7 +49,7 @@ layout: container-fluid
           {% endif %}
 
           <p class="text-gray flush-bottom push-quarter-top small">
-            {{ meeting.description }}
+            {{ meeting.description | markdownify }}
           </p>
           {% if meeting.childcare %}
           <p class="text-gray flush-bottom push-quarter-top small">

--- a/_layouts/onsite-group-location.html
+++ b/_layouts/onsite-group-location.html
@@ -44,7 +44,7 @@ snail_trail: connect
           {{ meeting.title }}
         {% endif %}
       </h4>
-      <p class="text-gray flush-bottom small">{{ meeting.description }}</p>
+      <p class="text-gray flush-bottom small">{{ meeting.description | markdownify }}</p>
       <p class="flush-bottom push-quarter-top small">
         {{ meeting.meeting_time }}
       </p>


### PR DESCRIPTION
## Problem
The Onsite Group meetings descriptions Markdown is not being converted to HTML. This happens on both the Group Location page and the Group Details page. 

<img width="453" alt="Adoption___Foster_Family_Resources___Crossroads" src="https://user-images.githubusercontent.com/56852436/70945504-5c238f80-2023-11ea-99e7-fc80ba615aec.png">

## Solution
Added `markdownify` to the `meeting.description`s in both `onsite-group-location.html` and `onsite-group-detail.html` to convert the Markdown to HTML

## Preview
- [Location](https://deploy-preview-1262--int-crds-net.netlify.com/groups/oakley/)
- [Details](https://deploy-preview-1262--int-crds-net.netlify.com/groups/connection/adoptive-and-foster-care-for-moms)
