### PR TITLE
Feature/us18721 osg add start date

### DIFF
--- a/_layouts/onsite-group-location.html
+++ b/_layouts/onsite-group-location.html
@@ -46,6 +46,9 @@ snail_trail: connect
       </h4>
       <p class="text-gray flush-bottom small">{{ meeting.description }}</p>
       <p class="flush-bottom push-quarter-top small">
+        Starts {{ meeting.starts_at | date: "%B %-d" }}
+      </p>
+      <p class="flush-bottom push-quarter-top small">
         {{ meeting.meeting_time }} {{ meeting.starts_at | date: "%A" }}s
       </p>
       {% if meeting.registration_link %}


### PR DESCRIPTION
## Problem
Client has requested that the start date for each meeting instance be displayed on the Locations view only. 

## Solution
[Preview](https://deploy-preview-1272--int-crds-net.netlify.com/groups/columbus/)
