### PR TITLE
Feature/us18782 onsite location childcare

### DIFF
--- a/_layouts/onsite-group-location.html
+++ b/_layouts/onsite-group-location.html
@@ -51,6 +51,11 @@ snail_trail: connect
       <p class="flush-bottom push-quarter-top small">
         {{ meeting.meeting_time }} {{ meeting.starts_at | date: "%A" }}s
       </p>
+      {% if meeting.childcare %}
+      <p class="text-gray flush-bottom push-quarter-top small">
+        *childcare is available with one week advance registration.
+      </p>
+      {% endif %}
       {% if meeting.registration_link %}
         <a href="{{ meeting.registration_link }}" class="btn btn-cyan push-top" type="button">Register</a>
       {% endif %}


### PR DESCRIPTION
## Problem
For an individual group meeting, there is a childcare toggle that displays whether or not childcare is available at each meeting. This currently displays an asterisk on the meeting details on at the meeting level. They would like this to display on the location pages as well.

## Solution
Add same logic that is on the meeting details page for childcare to the location page
[Preview](https://deploy-preview-1289--int-crds-net.netlify.com/groups/uptown/)