### PR TITLE
Feature/us18783 alphabetize groups

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -199,3 +199,7 @@ image_sizes:
 
 typekit_url: https://use.typekit.net/ccb3vpa.css
 typekit_scss: _assets/stylesheets/_fonts.scss
+
+strict_front_matter: true
+liquid:
+  error_mode: strict

--- a/_config.yml
+++ b/_config.yml
@@ -199,7 +199,3 @@ image_sizes:
 
 typekit_url: https://use.typekit.net/ccb3vpa.css
 typekit_scss: _assets/stylesheets/_fonts.scss
-
-strict_front_matter: true
-liquid:
-  error_mode: strict

--- a/_layouts/onsite-group-location.html
+++ b/_layouts/onsite-group-location.html
@@ -33,7 +33,7 @@ snail_trail: connect
   </div>
 
   <div class="row onsite-group-location-row push-bottom onsite-group-negative-margin-bottom">
-    {% assign sorted_meeting = page.meetings | sort_natural:"title" %}
+    {% assign sorted_meeting = page.meetings | sort_natural: "title" %}
     {% for meeting in sorted_meeting %}
     <div class="col-md-3">
       <h4 class="font-family-condensed-extra text-uppercase">

--- a/_layouts/onsite-group-location.html
+++ b/_layouts/onsite-group-location.html
@@ -33,7 +33,8 @@ snail_trail: connect
   </div>
 
   <div class="row onsite-group-location-row push-bottom onsite-group-negative-margin-bottom">
-    {% for meeting in page.meetings %}
+    {% assign sorted_meeting = page.meetings | sort_natural:"title" %}
+    {% for meeting in sorted_meeting %}
     <div class="col-md-3">
       <h4 class="font-family-condensed-extra text-uppercase">
         {% if page.meeting_group_permalinks[meeting.contentful_id] %}

--- a/_layouts/onsite-group-location.html
+++ b/_layouts/onsite-group-location.html
@@ -33,7 +33,7 @@ snail_trail: connect
   </div>
 
   <div class="row onsite-group-location-row push-bottom onsite-group-negative-margin-bottom">
-    {% assign sorted_meeting = page.meetings | sort: "title" %}
+    {% assign sorted_meeting = page.meetings | sort_natural: "title" %}
     {% for meeting in sorted_meeting %}
     <div class="col-md-3">
       <h4 class="font-family-condensed-extra text-uppercase">

--- a/_layouts/onsite-group-location.html
+++ b/_layouts/onsite-group-location.html
@@ -33,7 +33,7 @@ snail_trail: connect
   </div>
 
   <div class="row onsite-group-location-row push-bottom onsite-group-negative-margin-bottom">
-    {% assign sorted_meeting = page.meetings | sort_natural: "title" %}
+    {% assign sorted_meeting = page.meetings | sort: "title" %}
     {% for meeting in sorted_meeting %}
     <div class="col-md-3">
       <h4 class="font-family-condensed-extra text-uppercase">


### PR DESCRIPTION
## Problem
On the location pages within OSG, the client has asked that we display the groups in alphabetical order by group name on this page.

## Solution
Sort through meeting titles on location page by using `sort_natural:"title"` 
[Preview](https://deploy-preview-1292--int-crds-net.netlify.com/groups/columbus/)