### PR TITLE
defect/US19010 - Fix Travis ci leak for Cypress tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ install:
 # Integration Test stage
 integrationTests: &integrationTest
   if: env(RUN_CYPRESS) = true
-  script: "npx cypress run --record --key $cypressDashboard --parallel --group crds-net-parallel --browser chrome"
+  script: "npx cypress run --record --key $cypressDashboard --parallel --group crds-net-parallel"
 
 jobs:
   include:

--- a/bin/kickOffCypress.sh
+++ b/bin/kickOffCypress.sh
@@ -7,7 +7,7 @@ then
     exit 0
 fi
 
-body="{\"request\": { \"branch\":\"$HEAD\", \"config\": {\"env\": { \"RUN_CYPRESS\": \"$RUN_CYPRESS\", \"CYPRESS_configFile\": \"$CYPRESS_CONFIG_FILE\", \"VAULT_SECRET_ID\": \"$VAULT_SECRET_ID\", \"VAULT_ROLE_ID\": \"$VAULT_ROLE_ID\", \"DEBUG_NetlifyContext\": \"$CONTEXT\"}}}}"
+body="{\"request\": { \"branch\":\"$HEAD\", \"config\": {\"env\": { \"RUN_CYPRESS\": \"$RUN_CYPRESS\", \"CYPRESS_configFile\": \"$CYPRESS_CONFIG_FILE\", \"DEBUG_NetlifyContext\": \"$CONTEXT\"}}}}"
 
 curl -s -X POST \
 -H "Content-Type: application/json" \


### PR DESCRIPTION
- Removed key leak when kicking off build in Travis
- Configured Cypress to run on it's built-in Electron browser instead of Chrome (because of issues running Chrome 80 on an old version of Cypress)