### PR TITLE
US19036 [OSG] Landing: Refactor to 3 Column Layout

### DIFF
--- a/_plugins/filters/onsite_groups_filters.rb
+++ b/_plugins/filters/onsite_groups_filters.rb
@@ -1,11 +1,11 @@
 module Jekyll
   module OnsiteGroupsFilters
 
-    def onsite_groups_for_category(category)
+    def onsite_groups_for_category(category, perSlice = 2)
       groups = site.collections['onsite_groups'].docs.
         select{|g| g.data.keys.include?('category') }.
         select{|g| g['category']['slug'] == category['slug'] }
-      groups.each_slice(2).to_a
+      groups.each_slice(perSlice).to_a
     end
 
     def locations_with_onsite_groups(collection)

--- a/onsite-groups.html
+++ b/onsite-groups.html
@@ -20,15 +20,11 @@ snail_trail: connect
 
 <section class="container">
   {% for category in site['onsite_group_categories'] %}
-  {% assign groups = category | onsite_groups_for_category %}
+  {% assign groups = category | onsite_groups_for_category: 3 %}
   {% if groups.size > 0 %}
   <a class="anchor" id="{{ category.title | slugify }}"></a>
-  <div class="row soft-ends push-bottom push-quarter-top">
-    <div class="col-sm-3">
-      <img src="{{ category.image.url | imgix: site.imgix }}?{{ site.imgix_params.placeholder_sixteen_nine }}"
-        sizes="{{ site.image_sizes.one_fourth }}" class="width-100" data-optimize-img />
-    </div>
-    <div class="col-sm-9 push-bottom">
+  <div class="soft-ends push-bottom push-quarter-top">
+    <div class="push-bottom">
       <div class="row">
         <div class="col-md-12">
           <h2 class="font-family-condensed-extra flush-top mobile-soft-top text-uppercase">
@@ -41,7 +37,7 @@ snail_trail: connect
       {% for row in groups %}
       <div class="row onsite-group-negative-margin-bottom">
         {% for col in row %}
-        <div class="col-md-6">
+        <div class="col-md-4">
           <h3 class="font-family-condensed-extra text-uppercase">
             <a href="{{ col.url }}">{{ col.title }}</a>
           </h3>

--- a/onsite-groups.html
+++ b/onsite-groups.html
@@ -45,7 +45,7 @@ snail_trail: connect
           <h3 class="font-family-condensed-extra text-uppercase">
             <a href="{{ col.url }}">{{ col.title }}</a>
           </h3>
-          <div class="text-gray small">{{ col.description | markdownify }}</div>
+          <div class="text-gray small">{{ col.description | markdownify | strip_html | truncate: 275 }}</div>
         </div>
         {% endfor %}
       </div>


### PR DESCRIPTION
## Task
- Converts the Onsite Groups landing page to 3 columns
- Truncate group description to  275 characters ~5 lines
- [Story](https://rally1.rallydev.com/#/66096747656d/custom/24109743995?qdp=%2Fdetail%2Fuserstory%2F370828226740)
- [Design](https://projects.invisionapp.com/share/TVSEW6P3MDK#/screens)

## Preview
[Preview](https://deploy-preview-1360--int-crds-net.netlify.com/groups/onsite)
