### PR TITLE
Enterprise CDN Support

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -55,8 +55,8 @@
 [context.master.environment]
   CRDS_PEOPLE_DOMAIN = "people.crossroads.net"
   CRDS_MAP_DOMAIN = "connect.crossroads.net"
-  CRDS_ANGULAR_ENDPOINT = "crds-angular.netlify.com"
-  CRDS_SIGNIN_ENDPOINT = "crds-signin.netlify.com"
+  CRDS_ANGULAR_ENDPOINT = "crds-angular.crossroads.net"
+  CRDS_SIGNIN_ENDPOINT = "signin.crossroads.net"
   CRDS_SERVE_ENDPOINT = "serve.crossroads.net"
   CRDS_PROFILE_ENDPOINT = "profile.crossroads.net"
   CRDS_EVENT_CHECKIN_ENDPOINT = "event-checkin.crossroads.net"


### PR DESCRIPTION
Ensure production proxies to crds-angular are served via the enterprise CDN