### PR TITLE
Onsite Groups

### DIFF
--- a/_layouts/onsite-group-location.html
+++ b/_layouts/onsite-group-location.html
@@ -35,7 +35,7 @@ snail_trail: connect
   <div class="row onsite-group-location-row push-bottom onsite-group-negative-margin-bottom">
     {% assign sorted_meeting = page.meetings | sort_natural: "title" %}
     {% for meeting in sorted_meeting %}
-    <div class="col-md-3">
+    <div class="col-md-3" data-id="{{ meeting.contentful_id }}">
       <h4 class="font-family-condensed-extra text-uppercase">
         {% assign group = meeting | group_for_meeting %}
         {% if group %}

--- a/lib/crds/onsite_groups.rb
+++ b/lib/crds/onsite_groups.rb
@@ -6,7 +6,7 @@ module CRDS
       @site = site
       @collections = site.collections.select{|k,v| k.include?('onsite_group') }
       @collections['locations'] = site.collections['locations']
-      @collections['onsite_group_meetings'].reject{|m| !known_meeting_ids.include?(m['id']) }
+      @collections['onsite_group_meetings'].docs.reject!{|m| !known_meeting_ids.include?(m['id']) }
     end
 
     def by_location

--- a/lib/crds/onsite_groups.rb
+++ b/lib/crds/onsite_groups.rb
@@ -1,11 +1,12 @@
 module CRDS
   class OnSiteGroups
-    attr_accessor :collections, :site
+    attr_accessor :collections, :site, :known_meeting_ids
 
     def initialize(site)
       @site = site
       @collections = site.collections.select{|k,v| k.include?('onsite_group') }
       @collections['locations'] = site.collections['locations']
+      @collections['onsite_group_meetings'].reject{|m| !known_meeting_ids.include?(m['id']) }
     end
 
     def by_location
@@ -59,6 +60,14 @@ module CRDS
         (group.data.dig('meetings') || []).collect{|m| m.dig('id') }.include?(meeting_id)
       end
     end
+
+    private
+
+      def known_meeting_ids
+        @known_meeting_ids ||= begin
+          @collections['onsite_groups'].docs.flat_map{|g| g.data.dig('meetings').collect{|m| m['id'] } }.flatten.compact
+        end
+      end
 
   end
 end

--- a/spec/fixtures/collections/_onsite_groups/adoption-and-foster-family-resources.md
+++ b/spec/fixtures/collections/_onsite_groups/adoption-and-foster-family-resources.md
@@ -28,18 +28,6 @@ meetings:
   childcare: true
   id: 2fis1qVWaqR4Pow8UWMilD
   content_type: onsite_group_meeting
-- title: Adoptive, Foster, Kinship Parent Group | East Side
-  registration_link: "/adoptionfoster-parent-group-east-side/"
-  description: |-
-    We are adoptive, foster and kinship parents who are committed to caring for the fatherless. We join together to grow through training, education and most importantly building community with other adoptive and foster families. We are encouraged as we share stories and learn from others who are on a similar journey. We believe that the church can be a part of equipping and empowering families as we together “take up the cause of the fatherless” Isaiah 1:17.
-
-    We meet the second Thursday of every month January - May.
-  starts_at: '2020-01-09'
-  meeting_time: 2nd Thursday of Month (Jan - May) 6:30-8:30PM
-  room: Meeting Room C
-  childcare: true
-  id: 5157xqQ7zWsu5MYbDdqW2x
-  content_type: onsite_group_meeting
 - title: Adoptive, Foster, Kinship Parent Group | Oakley
   registration_link: "/sign-up/adoptive-foster-kinship-parent-group-oakley/"
   description: "Adoptive, Foster, Kinship Parent Group in Oakley will meet on the

--- a/spec/unit/onsite_groups_spec.rb
+++ b/spec/unit/onsite_groups_spec.rb
@@ -51,4 +51,9 @@ describe CRDS::OnSiteGroups do
     expect(group.data['id']).to eq('7deAOj56E3OHEmL0yQtCG7')
   end
 
+  it 'should not return meetings that have no group association' do
+    total = @site.collections['onsite_group_meetings'].count
+    expect(@groups.send(:known_meeting_ids).count).to be(total - 1)
+  end
+
 end

--- a/spec/unit/onsite_groups_spec.rb
+++ b/spec/unit/onsite_groups_spec.rb
@@ -53,7 +53,7 @@ describe CRDS::OnSiteGroups do
 
   it 'should not return meetings that have no group association' do
     total = @site.collections['onsite_group_meetings'].count
-    expect(@groups.send(:known_meeting_ids).count).to be(total - 1)
+    expect(@groups.send(:known_meeting_ids).count).to be(total)
   end
 
 end


### PR DESCRIPTION
This PR ensures that meetings which have no association to a group do not display on the front-end. 