### PR TITLE
US19168 Ctfassets

### DIFF
--- a/bin/build-command.sh
+++ b/bin/build-command.sh
@@ -8,6 +8,7 @@
   bundle exec jekyll crds &&
   bundle exec jekyll contentful -f &&
   bundle exec jekyll build -- --update-search-index &&
+  find . -type f -name "*html" -print0 | xargs -0 sed -i '' -E 's/\/\/images.ctfassets.net\/y3a9myzsdjan/\/\/crds-media.imgix.net/g' &&
   ./bin/prerenderio-bust.sh &&
   ./bin/health-check.sh "we are crossroads" &&
   ./bin/kickOffCypress.sh


### PR DESCRIPTION
## Solution 
We start out with 4354 references to ctfassets and decided to update the build script with sed to change assets and images after the site is built. After running the sed command we are left with 3686 references to ctfassets, that is 571 downloads and 3110 videos. We are not changing assets because they are mostly PDFs and it changes the content type to an image when being hosted from Imgix so It does not get treated as an PDF(when clicked on, it won’t show print or download option like you would normally see from a PDF). We are also not changing videos because some of these videos are entire sermons so the file size is going to be very big and imgix will not be able to handle that.

## Update
The sed script is only changing images because there are PDFs associated to assets