### PR TITLE
Fixes the jumbotron not opening on easter page

### DIFF
--- a/_assets/javascripts/components/jumbotron-video.js
+++ b/_assets/javascripts/components/jumbotron-video.js
@@ -1,3 +1,5 @@
-(function () {
-  new CRDS.JumbotronVideos();
+(function() {
+  window.$(document).ready(function() {
+    new window.CRDS.JumbotronVideos();
+  });
 })();


### PR DESCRIPTION
For all new visits to the `/online-easter-service/` page in a new tab, the "Watch the trailer button does not work" until you refresh the page.

This PR wraps the Jumbotron in` $(document).ready` so it waits until the DOM is loaded to try to initialize the jumbotron videos