### PR TITLE
US19575/ Rebrand meeting details button

### DIFF
--- a/_includes/groups/_meeting-details.html
+++ b/_includes/groups/_meeting-details.html
@@ -14,5 +14,5 @@
   {% endif %}
 </p>
 {% if meeting.registration_link %}
-  <p class="push-top"><a href="{{ meeting.registration_link }}" class="btn btn-cyan" type="button">Register</a></p>
+  <p class="push-top"><a href="{{ meeting.registration_link }}" class="btn btn-orange" type="button">Register</a></p>
 {% endif %}


### PR DESCRIPTION
## Task
Change button color for onsite group details page to match rebrand criteria (orange button/ blue text) 

[Rally](https://rally1.rallydev.com/#/66096747656ud/detail/userstory/393973364824?fdp=true)
[CRDS-Styles](https://github.com/crdschurch/crds-styles/pull/432)

## Solution
Created orange button with blue text and implemented style to on-site groups details page. 

## Testing
Run crds-net locally, and navigate to any on-site groups details page. 
Example url - /groups/onsite/COME-AS-YOU-ARE-FLORENCE-2019/columbus/
<img width="386" alt="Screen Shot 2020-05-22 at 11 00 43 AM" src="https://user-images.githubusercontent.com/57996315/82681959-7f7ae800-9c1c-11ea-9bc8-6de3284f15e2.png">

