### PR TITLE
US19602 Jumbotron

### DIFF
--- a/_assets/stylesheets/components/_jumbotron.scss
+++ b/_assets/stylesheets/components/_jumbotron.scss
@@ -52,16 +52,14 @@
       width: 100%;
       
       h1 {
+        border-bottom: 6px solid currentColor;
         font-size: 90px;
         line-height: 100px;
-        text-decoration: underline;
+        padding-bottom: 20px;
         
-        @media screen and (min-width: $screen-xs) {
-          border-bottom: 6px solid currentColor;
+        @media screen and (min-width: $screen-sm) {
           font-size: 130px;
           line-height: 110px;
-          padding-bottom: 20px;
-          text-decoration: none;
         }
       }
     }

--- a/_assets/stylesheets/components/_jumbotron.scss
+++ b/_assets/stylesheets/components/_jumbotron.scss
@@ -45,6 +45,28 @@
     }
   }
 
+  &.jumbotron-home {
+    .jumbotron-home-header {
+      margin: 0 auto;
+      max-width: 760px;
+      width: 100%;
+      
+      h1 {
+        font-size: 90px;
+        line-height: 100px;
+        text-decoration: underline;
+        
+        @media screen and (min-width: $screen-xs) {
+          border-bottom: 6px solid currentColor;
+          font-size: 130px;
+          line-height: 110px;
+          padding-bottom: 20px;
+          text-decoration: none;
+        }
+      }
+    }
+
+  }
 }
 
 .jumbotron[style*='background-image'] list-unstyled a, .jumbotron[data-optimize-bg-img] list-unstyled a {

--- a/_includes/home/_jumbotron.html
+++ b/_includes/home/_jumbotron.html
@@ -1,6 +1,8 @@
-<section class="jumbotron jumbotron-xl jumbotron-home grid-overlay" 
-  style="background-image: url('//crds-media.imgix.net/47HugzxZ1gGwfdZg2JSFNC/e047f199c71a18f3d9b2ef8af06cc6c0/crossroads-collage-new2.jpg?auto=format,compress&w=1920?{{ site.imgix_params.placeholder_sixteen_nine }}');"
-  data-optimize-bg-img>
+<section class="jumbotron jumbotron-xl jumbotron-home bg-video" data-aspect-ratio="2.34615">
+  <div class="bg-video-player">
+    <video height="240" width="360" class="bg-jumbotron-video hide" autoplay="autoplay" loop="loop" muted playsinline src="https://s3.amazonaws.com/crds-cms-uploads/media/video/loop-video.mp4">
+    </video>
+  </div>
   <div class="container">
     <div class="row">
       <div class="col-sm-10 col-sm-offset-1">

--- a/_includes/home/_jumbotron.html
+++ b/_includes/home/_jumbotron.html
@@ -11,7 +11,7 @@
           </a>
           <div class="jumbotron-home-header">
             <h2 class="font-family-condensed-extra text-uppercase flush-bottom text-tan">You were</h2>
-            <h1 class="font-family-condensed-extra text-uppercase flush-top text-tan"><span >Born For Adventure</span></h1>
+            <h1 class="font-family-condensed-extra text-uppercase flush-top text-tan">Born For Adventure</h1>
           </div>
           <p class="font-family-serif">
             We believe you were born for adventure and God challenges YOU to CHANGE THE WORLD.  Crossroads is your spiritual outfitter to guide you through that adventure.  Life isn’t a solo sport.  Find your people, have fun, crush life and leave your mark.  

--- a/_includes/home/_jumbotron.html
+++ b/_includes/home/_jumbotron.html
@@ -1,0 +1,32 @@
+<section class="jumbotron jumbotron-xl jumbotron-home grid-overlay" 
+  style="background-image: url('//crds-media.imgix.net/47HugzxZ1gGwfdZg2JSFNC/e047f199c71a18f3d9b2ef8af06cc6c0/crossroads-collage-new2.jpg?auto=format,compress&w=1920?{{ site.imgix_params.placeholder_sixteen_nine }}');"
+  data-optimize-bg-img>
+  <div class="container">
+    <div class="row">
+      <div class="col-sm-10 col-sm-offset-1">
+        <div class="jumbotron-content">
+          <a href="#" class="inline-video-trigger" data-toggle="modal" data-target="#videoModal">
+            <svg class="media-play-btn icon icon-5 text-white" viewBox="0 0 256 256">
+              <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="/assets/svgs/icons.svg#play-thin"></use>
+            </svg>
+          </a>
+          <div class="jumbotron-home-header">
+            <h2 class="font-family-condensed-extra text-uppercase flush-bottom text-tan">You were</h2>
+            <h1 class="font-family-condensed-extra text-uppercase flush-top text-tan">Born For Adventure</h1>
+          </div>
+          <p>
+            We believe you were born for adventure and God challenges YOU to CHANGE THE WORLD.  Crossroads is your spiritual outfitter to guide you through that adventure.  Life isn’t a solo sport.  Find your people, have fun, crush life and leave your mark.  
+            Get outfitted.  Your adventure starts here.
+          </p>
+          <div class="row">
+            <div class="btn btn-orange"><strong>Start your adventure - 30 Day Trial</strong></div>
+          </div>
+          <div class="row">
+            <div class="btn btn-white btn-outline">Watch the latest message</div>
+            <div class="btn btn-white btn-outline">Ask us a question</div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</section>

--- a/_includes/home/_jumbotron.html
+++ b/_includes/home/_jumbotron.html
@@ -1,13 +1,20 @@
-<section class="jumbotron jumbotron-xl jumbotron-home bg-video" data-aspect-ratio="2.34615">
+<section class="jumbotron jumbotron-xl jumbotron-home inline-video bg-video" style="margin-top: -12px;" >
+  <div class="inline-video-player"></div>
   <div class="bg-video-player">
-    <video height="240" width="360" class="bg-jumbotron-video hide" autoplay="autoplay" loop="loop" muted playsinline src="https://s3.amazonaws.com/crds-cms-uploads/media/video/loop-video.mp4">
+    <video width="360" height="240" class="bg-jumbotron-video hide" autoplay="autoplay" loop="loop" muted="" playsinline="" src="https://videos.ctfassets.net/y3a9myzsdjan/4300VvIlLpOlBaS7uhSfgT/23a0dbd566de021dc924cb2912582f01/go-video-2019-loop.mp4">
+      <object width="360" height="240" data="https://content.crossroads.net/framework/thirdparty/tinymce/plugins/media/moxieplayer.swf" type="application/x-shockwave-flash">
+        <param name="src" value="https://content.crossroads.net/framework/thirdparty/tinymce/plugins/media/moxieplayer.swf">
+        <param name="flashvars" value="url=https%3A//s3.amazonaws.com/crds-cms-uploads/media/video/GoSomewhere-loop-crf30.mp4&amp;poster=/">
+        <param name="allowfullscreen" value="true">
+        <param name="allowscriptaccess" value="true">
+      </object>
     </video>
   </div>
   <div class="container">
     <div class="row">
       <div class="col-sm-10 col-sm-offset-1">
         <div class="jumbotron-content">
-          <a href="#" class="inline-video-trigger" data-toggle="modal" data-target="#videoModal">
+          <a href="#" class="inline-video-trigger">
             <svg class="media-play-btn icon icon-5 text-white" viewBox="0 0 256 256">
               <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="/assets/svgs/icons.svg#play-thin"></use>
             </svg>
@@ -16,7 +23,7 @@
             <h2 class="font-family-condensed-extra text-uppercase flush-bottom text-tan">You were</h2>
             <h1 class="font-family-condensed-extra text-uppercase flush-top text-tan">Born For Adventure</h1>
           </div>
-          <p>
+          <p class="font-family-serif">
             We believe you were born for adventure and God challenges YOU to CHANGE THE WORLD.  Crossroads is your spiritual outfitter to guide you through that adventure.  Life isn’t a solo sport.  Find your people, have fun, crush life and leave your mark.  
             Get outfitted.  Your adventure starts here.
           </p>

--- a/_includes/home/_jumbotron.html
+++ b/_includes/home/_jumbotron.html
@@ -1,27 +1,17 @@
-<section class="jumbotron jumbotron-xl jumbotron-home inline-video bg-video" style="margin-top: -12px;" >
+<section class="jumbotron jumbotron-xl jumbotron-home inline-video grid-overlay" style="background-image: url('//crds-media.imgix.net/47HugzxZ1gGwfdZg2JSFNC/e047f199c71a18f3d9b2ef8af06cc6c0/crossroads-collage-new2.jpg?{{ site.imgix_params.placeholder_sixteen_nine }}');" data-optimize-bg-img >
   <div class="inline-video-player"></div>
-  <div class="bg-video-player">
-    <video width="360" height="240" class="bg-jumbotron-video hide" autoplay="autoplay" loop="loop" muted="" playsinline="" src="https://videos.ctfassets.net/y3a9myzsdjan/4300VvIlLpOlBaS7uhSfgT/23a0dbd566de021dc924cb2912582f01/go-video-2019-loop.mp4">
-      <object width="360" height="240" data="https://content.crossroads.net/framework/thirdparty/tinymce/plugins/media/moxieplayer.swf" type="application/x-shockwave-flash">
-        <param name="src" value="https://content.crossroads.net/framework/thirdparty/tinymce/plugins/media/moxieplayer.swf">
-        <param name="flashvars" value="url=https%3A//s3.amazonaws.com/crds-cms-uploads/media/video/GoSomewhere-loop-crf30.mp4&amp;poster=/">
-        <param name="allowfullscreen" value="true">
-        <param name="allowscriptaccess" value="true">
-      </object>
-    </video>
-  </div>
   <div class="container">
     <div class="row">
       <div class="col-sm-10 col-sm-offset-1">
         <div class="jumbotron-content">
-          <a href="#" class="inline-video-trigger">
+          <a href="#" class="inline-video-trigger" data-video-id="LIdCR2rywl4">
             <svg class="media-play-btn icon icon-5 text-white" viewBox="0 0 256 256">
               <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="/assets/svgs/icons.svg#play-thin"></use>
             </svg>
           </a>
           <div class="jumbotron-home-header">
             <h2 class="font-family-condensed-extra text-uppercase flush-bottom text-tan">You were</h2>
-            <h1 class="font-family-condensed-extra text-uppercase flush-top text-tan">Born For Adventure</h1>
+            <h1 class="font-family-condensed-extra text-uppercase flush-top text-tan"><span >Born For Adventure</span></h1>
           </div>
           <p class="font-family-serif">
             We believe you were born for adventure and God challenges YOU to CHANGE THE WORLD.  Crossroads is your spiritual outfitter to guide you through that adventure.  Life isn’t a solo sport.  Find your people, have fun, crush life and leave your mark.  

--- a/index.html
+++ b/index.html
@@ -46,6 +46,9 @@ paginate:
 ---
 
 {% include header.html %}
+
+{% include home/_jumbotron.html %}
+
 {% assign homePageBanner = site.content_blocks | where: 'slug', 'home-page-promo-banner' | first %}
 
 {{ homePageBanner.content_block }}


### PR DESCRIPTION
## Problem
Should have video b-roll as background, play onload Should behave like the Go page (clicking the icon should swap out the background for a video embed)

[Design here](https://projects.invisionapp.com/share/5TWTAP2G7SH#/screens/418123067_Home_-_V8)

## Solution
[Preview](https://deploy-preview-1504--rebrand-crds-net.netlify.app/)

### Notes
1. May need a lower font weight added for the new serif font used in the jumbotron lead
![Screen Shot 2020-05-29 at 11 16 00 AM](https://user-images.githubusercontent.com/32345656/83275886-cc6f3900-a19d-11ea-9936-0e1c0220885b.png)

2. Had trouble underlining the text. When you do `text-decoration: underline` you get a thick underline that does not match design. Also tried wrapping the text in a `<span>` and adding border bottom but then the under line is too far below the text and sometimes goes over text below.
![Screen Shot 2020-05-29 at 11 17 21 AM](https://user-images.githubusercontent.com/32345656/83276012-faed1400-a19d-11ea-8679-b48c968f273e.png)

3. We are also still waiting on the correct video link for the inline video

### Corresponding Branch
[Crds-Styles](https://github.com/crdschurch/crds-styles/pull/435) (merged)

