### PR TITLE
[rebrand] US19623/latest message

### DIFF
--- a/_includes/_latest-message.html
+++ b/_includes/_latest-message.html
@@ -1,0 +1,11 @@
+<section class="container soft-half push-bottom">
+<p class="text-gray font-family-serif text-uppercase push-bottom">latest weekly message</p>
+<iframe width="782" height="438" src="https://www.youtube.com/embed/ltTiQosa5JY" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+<h1 class="text-gray font-family-condensed-extra text-uppercase flush-top">Does Jesus keep his promises? </h1>
+<h3 class="text-gray font-size-smaller font-family-base-bold text-uppercase"> series: real encounters with god | week 6</h3>
+<p class="text-gray font-size-large"> The bible has a lot of prophecies that are meant to guide and encourage us. In this final<br>episode, we look at what promises God has for us, and what they mean for our lives today.</p>
+<div class="row soft-half-left"> 
+<a href="https://youtu.be/ltTiQosa5JY" class="btn btn-orange btn-block-mobile" type="button">Watch now</a>
+<a href="/media/podcasts/messages" class="btn btn-blue btn-outline btn-block-mobile" type="button">View all messages</a>
+</div> 
+</section>


### PR DESCRIPTION
## Task
Creates the Latest Message section according to rebrand. 

**Notes**
According to style guide, all orange buttons will have blue text (not white text indicated by design). 
Bitmoving player is not initially implemented. Can implement at a later date. 

<img width="793" alt="Screen Shot 2020-06-01 at 1 15 45 PM" src="https://user-images.githubusercontent.com/57996315/83435349-0c3a5880-a40a-11ea-8b52-1a3a1a39e27d.png">

