### PR TITLE
US19623/Adds latest message per rebrand standards

### DIFF
--- a/_includes/home/_latest-message.html
+++ b/_includes/home/_latest-message.html
@@ -1,6 +1,6 @@
 <div class="latest-message">
-  <section class="col-mid-8 latest-background container soft-half push-bottom">
-	  <p class="latest-message-title font-family-serif text-uppercase">
+  <div class="latest-message-background soft-half push-bottom">
+    <p class="latest-message-title font-family-serif text-uppercase">
 			Latest Weekly Message
 	  </p>
 	    <div class="embed-container">
@@ -17,13 +17,13 @@
 			    us. In this final episode, we look at what promises God has for us, and
 			    what they mean for our lives today.
 		    </p>
-		    <div class="row soft-half-left">
+		  <div class="row soft-half-left">
 			  <a href="https://youtu.be/ltTiQosa5JY" class="btn latest-message-btn btn-orange btn-block-mobile" type="button">
 			    Watch now
 			  </a>
 			  <a href="/media/podcasts/messages" class="second-btn latest-message-btn btn btn-blue btn-outline btn-block-mobile"type="button">
 			    View all messages
 			  </a>
-    	  </div>
-  </section>
+    	</div>
+  </div>
 </div>

--- a/_includes/home/_latest-message.html
+++ b/_includes/home/_latest-message.html
@@ -3,31 +3,41 @@
 		<p class="latest-message-title font-family-serif text-uppercase">
 			Latest Weekly Message
 		</p>
-        	<div class='embed-container'>
-            	<iframe src='https://www.youtube.com/embed/ltTiQosa5JY' frameborder='0' allowfullscreen></iframe>
-        	</div>
-		<h2 class="latest-message-headline font-family-condensed-extra text-uppercase flush-top">
+		<div class="embed-container">
+			<iframe
+				src="https://www.youtube.com/embed/ltTiQosa5JY"
+				frameborder="0"
+				allowfullscreen
+			></iframe>
+		</div>
+		<h2
+			class="latest-message-headline font-family-condensed-extra text-uppercase flush-top"
+		>
 			Does Jesus keep his promises?
 		</h2>
-		<h3 class="latest-message-subtitle font-size-smaller font-family-base-bold text-uppercase">
+		<h3
+			class="latest-message-subtitle font-size-smaller font-family-base-bold text-uppercase"
+		>
 			Series: Real Encounters With God | Week 6
 		</h3>
 		<p class="latest-message-body">
-			The bible has a lot of prophecies that are meant to guide and encourage us.
-			In this final episode, we look at what promises God has for us, and what
-			they mean for our lives today.
+			The bible has a lot of prophecies that are meant to guide and encourage
+			us. In this final episode, we look at what promises God has for us, and
+			what they mean for our lives today.
 		</p>
 		<div class="row soft-half-left">
 			<a
 				href="https://youtu.be/ltTiQosa5JY"
 				class="btn latest-message-btn btn-orange btn-block-mobile"
 				type="button"
-				>Watch now</a>
+				>Watch now</a
+			>
 			<a
 				href="/media/podcasts/messages"
 				class="second-btn latest-message-btn btn btn-blue btn-outline btn-block-mobile"
 				type="button"
-				>View all messages</a>
+				>View all messages</a
+			>
 		</div>
 	</section>
 </div>

--- a/_includes/home/_latest-message.html
+++ b/_includes/home/_latest-message.html
@@ -1,36 +1,29 @@
 <div class="latest-message">
   <section class="col-mid-8 latest-background container soft-half push-bottom">
-	<p class="latest-message-title font-family-serif text-uppercase">
+	  <p class="latest-message-title font-family-serif text-uppercase">
 			Latest Weekly Message
-	</p>
-	  <div class="embed-container">
-		<iframe src="https://www.youtube.com/embed/ltTiQosa5JY"
-				frameborder="0"
-				allowfullscreen>
-		</iframe>
-	  </div>
-		<h2 class="latest-message-headline font-family-condensed-extra text-uppercase flush-top">
-			Does Jesus keep his promises?
-		</h2>
-		<h3 class="latest-message-subtitle font-size-smaller font-family-base-bold text-uppercase">
-			Series: Real Encounters With God | Week 6
-		</h3>
-		<p class="latest-message-body">
-			The bible has a lot of prophecies that are meant to guide and encourage
-			us. In this final episode, we look at what promises God has for us, and
-			what they mean for our lives today.
-		</p>
-		  <div class="row soft-half-left">
-			<a href="https://youtu.be/ltTiQosa5JY"
-			   class="btn latest-message-btn btn-orange btn-block-mobile"
-			   type="button">
-			   Watch now
-			</a>
-			<a href="/media/podcasts/messages"
-			   class="second-btn latest-message-btn btn btn-blue btn-outline btn-block-mobile"
-			   type="button">
-			   View all messages
-			</a>
+	  </p>
+	    <div class="embed-container">
+		    <iframe src="https://www.youtube.com/embed/ltTiQosa5JY" frameborder="0" allowfullscreen></iframe>
+	    </div>
+		    <h2 class="latest-message-headline font-family-condensed-extra text-uppercase flush-top">
+			    Does Jesus keep his promises?
+		    </h2>
+		    <h3 class="latest-message-subtitle font-size-smaller font-family-base-bold text-uppercase">
+			    Series: Real Encounters With God | Week 6
+		    </h3>
+		    <p class="latest-message-body">
+			    The bible has a lot of prophecies that are meant to guide and encourage
+			    us. In this final episode, we look at what promises God has for us, and
+			    what they mean for our lives today.
+		    </p>
+		    <div class="row soft-half-left">
+			  <a href="https://youtu.be/ltTiQosa5JY" class="btn latest-message-btn btn-orange btn-block-mobile" type="button">
+			    Watch now
+			  </a>
+			  <a href="/media/podcasts/messages" class="second-btn latest-message-btn btn btn-blue btn-outline btn-block-mobile"type="button">
+			    View all messages
+			  </a>
     	  </div>
   </section>
 </div>

--- a/_includes/home/_latest-message.html
+++ b/_includes/home/_latest-message.html
@@ -1,0 +1,33 @@
+<div class="latest-message">
+	<section class="col-mid-8 latest-background container soft-half push-bottom">
+		<p class="latest-message-title font-family-serif text-uppercase">
+			Latest Weekly Message
+		</p>
+        	<div class='embed-container'>
+            	<iframe src='https://www.youtube.com/embed/ltTiQosa5JY' frameborder='0' allowfullscreen></iframe>
+        	</div>
+		<h2 class="latest-message-headline font-family-condensed-extra text-uppercase flush-top">
+			Does Jesus keep his promises?
+		</h2>
+		<h3 class="latest-message-subtitle font-size-smaller font-family-base-bold text-uppercase">
+			Series: Real Encounters With God | Week 6
+		</h3>
+		<p class="latest-message-body">
+			The bible has a lot of prophecies that are meant to guide and encourage us.
+			In this final episode, we look at what promises God has for us, and what
+			they mean for our lives today.
+		</p>
+		<div class="row soft-half-left">
+			<a
+				href="https://youtu.be/ltTiQosa5JY"
+				class="btn latest-message-btn btn-orange btn-block-mobile"
+				type="button"
+				>Watch now</a>
+			<a
+				href="/media/podcasts/messages"
+				class="second-btn latest-message-btn btn btn-blue btn-outline btn-block-mobile"
+				type="button"
+				>View all messages</a>
+		</div>
+	</section>
+</div>

--- a/_includes/home/_latest-message.html
+++ b/_includes/home/_latest-message.html
@@ -1,23 +1,18 @@
 <div class="latest-message">
-	<section class="col-mid-8 latest-background container soft-half push-bottom">
-		<p class="latest-message-title font-family-serif text-uppercase">
+  <section class="col-mid-8 latest-background container soft-half push-bottom">
+	<p class="latest-message-title font-family-serif text-uppercase">
 			Latest Weekly Message
-		</p>
-		<div class="embed-container">
-			<iframe
-				src="https://www.youtube.com/embed/ltTiQosa5JY"
+	</p>
+	  <div class="embed-container">
+		<iframe src="https://www.youtube.com/embed/ltTiQosa5JY"
 				frameborder="0"
-				allowfullscreen
-			></iframe>
-		</div>
-		<h2
-			class="latest-message-headline font-family-condensed-extra text-uppercase flush-top"
-		>
+				allowfullscreen>
+		</iframe>
+	  </div>
+		<h2 class="latest-message-headline font-family-condensed-extra text-uppercase flush-top">
 			Does Jesus keep his promises?
 		</h2>
-		<h3
-			class="latest-message-subtitle font-size-smaller font-family-base-bold text-uppercase"
-		>
+		<h3 class="latest-message-subtitle font-size-smaller font-family-base-bold text-uppercase">
 			Series: Real Encounters With God | Week 6
 		</h3>
 		<p class="latest-message-body">
@@ -25,19 +20,17 @@
 			us. In this final episode, we look at what promises God has for us, and
 			what they mean for our lives today.
 		</p>
-		<div class="row soft-half-left">
-			<a
-				href="https://youtu.be/ltTiQosa5JY"
-				class="btn latest-message-btn btn-orange btn-block-mobile"
-				type="button"
-				>Watch now</a
-			>
-			<a
-				href="/media/podcasts/messages"
-				class="second-btn latest-message-btn btn btn-blue btn-outline btn-block-mobile"
-				type="button"
-				>View all messages</a
-			>
-		</div>
-	</section>
+		  <div class="row soft-half-left">
+			<a href="https://youtu.be/ltTiQosa5JY"
+			   class="btn latest-message-btn btn-orange btn-block-mobile"
+			   type="button">
+			   Watch now
+			</a>
+			<a href="/media/podcasts/messages"
+			   class="second-btn latest-message-btn btn btn-blue btn-outline btn-block-mobile"
+			   type="button">
+			   View all messages
+			</a>
+    	  </div>
+  </section>
 </div>

--- a/rebrand-logged-out-home.html
+++ b/rebrand-logged-out-home.html
@@ -42,9 +42,16 @@ paginate:
 
 {% include home/_jumbotron.html %}
 
-<div class="container">
+<div class="container"> 
+  <div class="col-md-8">
+{% include home/_latest-message.html %}
+  </div>
+</div>
 
+<div class="container">
   {% include home/_you-are-needed.html %}
+</div>
+
 
   <div class="col-sm-4">
     {% include home/_current-series.html %}


### PR DESCRIPTION
## Task
Creates the Latest Message section according to rebrand. 

**Notes**
According to style guide, all orange buttons will have blue text (not white text indicated by design). 
Bitmoving player is not initially implemented. Can implement at a later date. 

<img width="793" alt="Screen Shot 2020-06-01 at 1 15 45 PM" src="https://user-images.githubusercontent.com/57996315/83435349-0c3a5880-a40a-11ea-8b52-1a3a1a39e27d.png">