### PR TITLE
DE7777 [rebrand] homepage - current series - update copy

### DIFF
--- a/_includes/home/_current-series.html
+++ b/_includes/home/_current-series.html
@@ -1,7 +1,7 @@
 <div class="push-bottom">
   <hr class="flush-top push-half-bottom" />
   <h2 class="text-uppercase font-family-serif font-size-base font-size-small text-gray-light">
-    Current Series
+    Current Teaching Series
   </h2>
   {% assign home_series = page.series.docs | slice: 0 %} {% for series in
   home_series %}
@@ -13,7 +13,7 @@
       <div class="soft-quarter-ends font-size-smaller flush-bottom" data-automation-id="series-description">
         {{ series.description | markdownify | strip_html | truncatewords: 15 }}
       </div>
-      <crds-button href="{{ series.url }}" color="orange" text="View all messages in this series" />
+      <crds-button href="{{ series.url }}" color="orange" text="Watch the current teaching series" />
     </div>
     <a href="{{ series.url }}" class="push-half-bottom" data-automation-id="series-image">
       {% if series.image.url %}


### PR DESCRIPTION
In the "Current Series" section on the logged-out home page. This PR changes header to "Current Teaching Series" and btn label to "Watch the current teaching series"

- [Preview](https://deploy-preview-1546--int-crds-net.netlify.app/rebrand-logged-out-home)
- [Rally Story](https://rally1.rallydev.com/#/66096747656d/custom/24109743995?qdp=%2Fdetail%2Fdefect%2F397667357108)