### PR TITLE
Removes unused classes for links and makes links more clicky

### DIFF
--- a/_includes/home/_content-menu.html
+++ b/_includes/home/_content-menu.html
@@ -3,11 +3,11 @@
     <div class="content-menu">
       <p class="content-menu-title soft-left font-family-serif text-uppercase">Explore All of Our Content</p>
         <ul class="list-unstyled hard-left"> 
-          <li class="font-size-large push-half-bottom dashed content-menu-list"><a class="content-menu-link text-orange" href="/media/series/">Series</a></li>
-          <li class="font-size-large push-half-bottom dashed content-menu-list"><a class="content-menu-link text-orange" href="https://www.crdsmusic.com/">Music</a></li>
-          <li class="font-size-large push-half-bottom dashed content-menu-list"><a class="content-menu-link text-orange" href="/media/podcasts/">Podcasts</a></li>
-          <li class="font-size-large push-half-bottom dashed content-menu-list"><a class="content-menu-link text-orange" href="/media/articles/">Articles</a></li>
-          <li class="font-size-large push-half-bottom dashed content-menu-list"><a class="content-menu-link text-orange" href="/media/videos/">Videos</a></li>
+          <li class="font-size-large push-half-bottom dashed content-menu-list"><a class="text-orange" href="/media/series/">Series</a></li>
+          <li class="font-size-large push-half-bottom dashed content-menu-list"><a class="text-orange" href="{{ site.crds_music_endpoint }}">Music</a></li>
+          <li class="font-size-large push-half-bottom dashed content-menu-list"><a class="text-orange" href="/media/podcasts/">Podcasts</a></li>
+          <li class="font-size-large push-half-bottom dashed content-menu-list"><a class="text-orange" href="/media/articles/">Articles</a></li>
+          <li class="font-size-large push-half-bottom dashed content-menu-list"><a class="text-orange" href="/media/videos/">Videos</a></li>
           <li class="push-half-bottom dashed content-menu-list"></li>
         </ul>
     </div>


### PR DESCRIPTION
## Problem
Anchor tags on content menu were only clickable above the link. 

Reliant on [crds-styles pull request](https://github.com/crdschurch/crds-styles/pull/461). 
[Rally ](https://rally1.rallydev.com/#/38108142417d/detail/defect/398132680380/discussion)

## Solution
Styles anchor tags directly and removes unused classes. 
