### PR TITLE
US19688 about

### DIFF
--- a/_assets/stylesheets/_utilities.scss
+++ b/_assets/stylesheets/_utilities.scss
@@ -96,6 +96,11 @@
   }
 }
 
+.flex-wrap {
+  display: flex;
+  flex-wrap: wrap;
+}
+
 .visually-hidden {
   visibility: hidden;
 }

--- a/_assets/stylesheets/components/_jumbotron.scss
+++ b/_assets/stylesheets/components/_jumbotron.scss
@@ -53,6 +53,7 @@
 
       h1 {
         border-bottom: 6px solid currentColor;
+        display: inline-block;
         font-size: 90px;
         line-height: 100px;
         padding-bottom: 20px;

--- a/_includes/about/_faqs.html
+++ b/_includes/about/_faqs.html
@@ -1,0 +1,76 @@
+<section>
+  <div class="container">
+    <div class="row text-center push-ends">
+      <h1 class="component-header-box text-blue">Crossroads FAQs</h1>
+    </div>
+    <div class="row border-bottom">
+      <ul class="list-unstyled font-size-base">
+        <li class="soft-quarter-bottom">
+          <a href="javascript:void(0)" data-smooth-scroll-to="denomination">What denomination is this?</a>
+        </li>
+        <li class="soft-quarter-bottom">
+          <a href="javascript:void(0)" data-smooth-scroll-to="cult">Is this place a cult?</a>
+        </li>
+        <li class="soft-quarter-bottom">
+          <a href="javascript:void(0)" data-smooth-scroll-to="welcomed">I absolutely do not believe in God. Am I still welcome?</a>
+        </li>
+        <li class="soft-quarter-bottom">
+          <a href="javascript:void(0)" data-smooth-scroll-to="kids">What do I do with my kids?</a>
+        </li>
+        <li class="soft-quarter-bottom">
+          <a href="javascript:void(0)" data-smooth-scroll-to="funds">Who funds this place?</a>
+        </li>
+        <li class="soft-quarter-bottom">
+          <a href="javascript:void(0)" data-smooth-scroll-to="staff">Are all the people working on the weekend, on staff?</a>
+        </li>
+        <li class="soft-quarter-bottom">
+          <a href="javascript:void(0)" data-smooth-scroll-to="church">This doesn’t look like a church.</a>
+        </li>
+      </ul>
+    </div>
+    <div class="font-size-base row">
+      <div class="soft-top" id="denomination">
+        <p class="soft-top">
+          <strong>What denomination is this?</strong><br />
+          Crossroads is interdenominational. Our beliefs are shared by many different Christian denominations, and we welcome everyone. It’s like one big pool party, with Methodists and Catholics and Presbyterians all doing cannonballs together.
+        </p>
+      </div>
+      <div class="soft-top" id="cult">
+        <p class="soft-top">
+          <strong>Is this place a cult?</strong><br />
+          Great question. After all, it’s full of people singing songs and drinking the same beloved liquid (in this case, great coffee). Plus, numerous guitars and people dressed comfortably. But seriously. No. Cults tell you what to believe, take away your freedoms and forbid you to leave. Here, you’re welcome no matter what you believe, and we want you to experience freedom (including the freedom to leave whenever you want). If that still isn’t enough for you, then the answer is “Fine, we’re a cult.” But we’re rubber and you’re glue.
+        </p>
+      </div>
+      <div class="soft-top" id="welcomed">
+        <p class="soft-top">
+          <strong>I absolutely do not believe in God. Am I still welcome?</strong><br />
+          Yes, you absolutely are welcome. We do expect that you’ll be open to exploring your questions about God and wrestling with what you find. And we do expect you to believe we’re funny. Or at least fake it.
+        </p>
+      </div>
+      <div class="soft-top" id="kids">
+        <p class="soft-top">
+          <strong>What do I do with my kids?</strong><br />
+          Beats us. No, seriously, we have a perfect answer: BRING THEM. There’s a place at Crossroads called Kids’ Club—available at most weekend services—where your kids can be surrounded by adults who are committed to a safe, fun environment. It’s where kids can figure out what God and the Bible are all about. (And for teens, it’s called Middle School and High School.)
+        </p>
+      </div>
+      <div class="soft-top" id="funds">
+        <p class="soft-top">
+          <strong>Who funds this place?</strong><br />
+          Let’s be clear on who is NOT funding this place: there are no corporate sponsors or franchise affiliations, and there’s no phantom fat cat paying for the building. It’s the generosity of everyday people in our community that fuels the life change we experience around here. Our support comes from the normal tithes (10 percent of earnings) and offerings of average folks who love contributing to the kinds of things they see God doing in our midst.
+        </p>
+      </div>
+      <div class="soft-top" id="staff">
+        <p class="soft-top">
+          <strong>Are all the people working on the weekend, on staff?</strong><br />
+          Nope. Believe it or not, from the coffee you drink to the mail you get, 94.6% of the Crossroads stuff you encounter results from volunteers. Volunteers care for our kids, take out the trash and sing on main stage. Crossroads does have a paid staff of about 300 people. They dwell in a cube farm on the other side of the business entrance. They’re hairy, work in the dark, and love to eat free food.
+        </p>
+      </div>
+      <div class="soft-top" id="church">
+        <p class="soft-top">
+          <strong>This doesn’t look like a church.</strong><br />
+          First of all, that’s not even a question. How about this: “What’s a church supposed to look like?” We think a church is about the people inside—not about the building—so it shouldn’t matter if we look like a former warehouse or a city school. And while you might not find steeples or stained glass around here, there’s no shortage of really authentic people—and free coffee.
+        </p>
+      </div>
+    </div>
+  </div>
+</section>

--- a/_includes/about/_faqs.html
+++ b/_includes/about/_faqs.html
@@ -3,73 +3,77 @@
     <div class="row text-center push-ends">
       <h1 class="component-header-box text-blue">Crossroads FAQs</h1>
     </div>
-    <div class="row border-bottom">
-      <ul class="list-unstyled font-size-base">
-        <li class="soft-quarter-bottom">
-          <a href="javascript:void(0)" data-smooth-scroll-to="denomination">What denomination is this?</a>
-        </li>
-        <li class="soft-quarter-bottom">
-          <a href="javascript:void(0)" data-smooth-scroll-to="cult">Is this place a cult?</a>
-        </li>
-        <li class="soft-quarter-bottom">
-          <a href="javascript:void(0)" data-smooth-scroll-to="welcomed">I absolutely do not believe in God. Am I still welcome?</a>
-        </li>
-        <li class="soft-quarter-bottom">
-          <a href="javascript:void(0)" data-smooth-scroll-to="kids">What do I do with my kids?</a>
-        </li>
-        <li class="soft-quarter-bottom">
-          <a href="javascript:void(0)" data-smooth-scroll-to="funds">Who funds this place?</a>
-        </li>
-        <li class="soft-quarter-bottom">
-          <a href="javascript:void(0)" data-smooth-scroll-to="staff">Are all the people working on the weekend, on staff?</a>
-        </li>
-        <li class="soft-quarter-bottom">
-          <a href="javascript:void(0)" data-smooth-scroll-to="church">This doesn’t look like a church.</a>
-        </li>
-      </ul>
+    <div class="row">
+      <div class="col-md-offset-2 col-md-8 border-bottom">
+        <ul class="list-unstyled font-size-base">
+          <li class="soft-quarter-bottom">
+            <a href="javascript:void(0)" data-smooth-scroll-to="denomination">What denomination is this?</a>
+          </li>
+          <li class="soft-quarter-bottom">
+            <a href="javascript:void(0)" data-smooth-scroll-to="cult">Is this place a cult?</a>
+          </li>
+          <li class="soft-quarter-bottom">
+            <a href="javascript:void(0)" data-smooth-scroll-to="welcomed">I absolutely do not believe in God. Am I still welcome?</a>
+          </li>
+          <li class="soft-quarter-bottom">
+            <a href="javascript:void(0)" data-smooth-scroll-to="kids">What do I do with my kids?</a>
+          </li>
+          <li class="soft-quarter-bottom">
+            <a href="javascript:void(0)" data-smooth-scroll-to="funds">Who funds this place?</a>
+          </li>
+          <li class="soft-quarter-bottom">
+            <a href="javascript:void(0)" data-smooth-scroll-to="staff">Are all the people working on the weekend, on staff?</a>
+          </li>
+          <li class="soft-quarter-bottom">
+            <a href="javascript:void(0)" data-smooth-scroll-to="church">This doesn’t look like a church.</a>
+          </li>
+        </ul>
+      </div>
     </div>
     <div class="font-size-base row">
-      <div class="soft-top" id="denomination">
-        <p class="soft-top">
-          <strong>What denomination is this?</strong><br />
-          Crossroads is interdenominational. Our beliefs are shared by many different Christian denominations, and we welcome everyone. It’s like one big pool party, with Methodists and Catholics and Presbyterians all doing cannonballs together.
-        </p>
-      </div>
-      <div class="soft-top" id="cult">
-        <p class="soft-top">
-          <strong>Is this place a cult?</strong><br />
-          Great question. After all, it’s full of people singing songs and drinking the same beloved liquid (in this case, great coffee). Plus, numerous guitars and people dressed comfortably. But seriously. No. Cults tell you what to believe, take away your freedoms and forbid you to leave. Here, you’re welcome no matter what you believe, and we want you to experience freedom (including the freedom to leave whenever you want). If that still isn’t enough for you, then the answer is “Fine, we’re a cult.” But we’re rubber and you’re glue.
-        </p>
-      </div>
-      <div class="soft-top" id="welcomed">
-        <p class="soft-top">
-          <strong>I absolutely do not believe in God. Am I still welcome?</strong><br />
-          Yes, you absolutely are welcome. We do expect that you’ll be open to exploring your questions about God and wrestling with what you find. And we do expect you to believe we’re funny. Or at least fake it.
-        </p>
-      </div>
-      <div class="soft-top" id="kids">
-        <p class="soft-top">
-          <strong>What do I do with my kids?</strong><br />
-          Beats us. No, seriously, we have a perfect answer: BRING THEM. There’s a place at Crossroads called Kids’ Club—available at most weekend services—where your kids can be surrounded by adults who are committed to a safe, fun environment. It’s where kids can figure out what God and the Bible are all about. (And for teens, it’s called Middle School and High School.)
-        </p>
-      </div>
-      <div class="soft-top" id="funds">
-        <p class="soft-top">
-          <strong>Who funds this place?</strong><br />
-          Let’s be clear on who is NOT funding this place: there are no corporate sponsors or franchise affiliations, and there’s no phantom fat cat paying for the building. It’s the generosity of everyday people in our community that fuels the life change we experience around here. Our support comes from the normal tithes (10 percent of earnings) and offerings of average folks who love contributing to the kinds of things they see God doing in our midst.
-        </p>
-      </div>
-      <div class="soft-top" id="staff">
-        <p class="soft-top">
-          <strong>Are all the people working on the weekend, on staff?</strong><br />
-          Nope. Believe it or not, from the coffee you drink to the mail you get, 94.6% of the Crossroads stuff you encounter results from volunteers. Volunteers care for our kids, take out the trash and sing on main stage. Crossroads does have a paid staff of about 300 people. They dwell in a cube farm on the other side of the business entrance. They’re hairy, work in the dark, and love to eat free food.
-        </p>
-      </div>
-      <div class="soft-ends" id="church">
-        <p class="soft-ends">
-          <strong>This doesn’t look like a church.</strong><br />
-          First of all, that’s not even a question. How about this: “What’s a church supposed to look like?” We think a church is about the people inside—not about the building—so it shouldn’t matter if we look like a former warehouse or a city school. And while you might not find steeples or stained glass around here, there’s no shortage of really authentic people—and free coffee.
-        </p>
+      <div class="col-md-offset-2 col-md-8">
+        <div class="soft-top" id="denomination">
+          <p class="soft-top">
+            <strong>What denomination is this?</strong><br />
+            Crossroads is interdenominational. Our beliefs are shared by many different Christian denominations, and we welcome everyone. It’s like one big pool party, with Methodists and Catholics and Presbyterians all doing cannonballs together.
+          </p>
+        </div>
+        <div class="soft-top" id="cult">
+          <p class="soft-top">
+            <strong>Is this place a cult?</strong><br />
+            Great question. After all, it’s full of people singing songs and drinking the same beloved liquid (in this case, great coffee). Plus, numerous guitars and people dressed comfortably. But seriously. No. Cults tell you what to believe, take away your freedoms and forbid you to leave. Here, you’re welcome no matter what you believe, and we want you to experience freedom (including the freedom to leave whenever you want). If that still isn’t enough for you, then the answer is “Fine, we’re a cult.” But we’re rubber and you’re glue.
+          </p>
+        </div>
+        <div class="soft-top" id="welcomed">
+          <p class="soft-top">
+            <strong>I absolutely do not believe in God. Am I still welcome?</strong><br />
+            Yes, you absolutely are welcome. We do expect that you’ll be open to exploring your questions about God and wrestling with what you find. And we do expect you to believe we’re funny. Or at least fake it.
+          </p>
+        </div>
+        <div class="soft-top" id="kids">
+          <p class="soft-top">
+            <strong>What do I do with my kids?</strong><br />
+            Beats us. No, seriously, we have a perfect answer: BRING THEM. There’s a place at Crossroads called Kids’ Club—available at most weekend services—where your kids can be surrounded by adults who are committed to a safe, fun environment. It’s where kids can figure out what God and the Bible are all about. (And for teens, it’s called Middle School and High School.)
+          </p>
+        </div>
+        <div class="soft-top" id="funds">
+          <p class="soft-top">
+            <strong>Who funds this place?</strong><br />
+            Let’s be clear on who is NOT funding this place: there are no corporate sponsors or franchise affiliations, and there’s no phantom fat cat paying for the building. It’s the generosity of everyday people in our community that fuels the life change we experience around here. Our support comes from the normal tithes (10 percent of earnings) and offerings of average folks who love contributing to the kinds of things they see God doing in our midst.
+          </p>
+        </div>
+        <div class="soft-top" id="staff">
+          <p class="soft-top">
+            <strong>Are all the people working on the weekend, on staff?</strong><br />
+            Nope. Believe it or not, from the coffee you drink to the mail you get, 94.6% of the Crossroads stuff you encounter results from volunteers. Volunteers care for our kids, take out the trash and sing on main stage. Crossroads does have a paid staff of about 300 people. They dwell in a cube farm on the other side of the business entrance. They’re hairy, work in the dark, and love to eat free food.
+          </p>
+        </div>
+        <div class="soft-ends" id="church">
+          <p class="soft-ends">
+            <strong>This doesn’t look like a church.</strong><br />
+            First of all, that’s not even a question. How about this: “What’s a church supposed to look like?” We think a church is about the people inside—not about the building—so it shouldn’t matter if we look like a former warehouse or a city school. And while you might not find steeples or stained glass around here, there’s no shortage of really authentic people—and free coffee.
+          </p>
+        </div>
       </div>
     </div>
   </div>

--- a/_includes/about/_faqs.html
+++ b/_includes/about/_faqs.html
@@ -65,8 +65,8 @@
           Nope. Believe it or not, from the coffee you drink to the mail you get, 94.6% of the Crossroads stuff you encounter results from volunteers. Volunteers care for our kids, take out the trash and sing on main stage. Crossroads does have a paid staff of about 300 people. They dwell in a cube farm on the other side of the business entrance. They’re hairy, work in the dark, and love to eat free food.
         </p>
       </div>
-      <div class="soft-top" id="church">
-        <p class="soft-top">
+      <div class="soft-ends" id="church">
+        <p class="soft-ends">
           <strong>This doesn’t look like a church.</strong><br />
           First of all, that’s not even a question. How about this: “What’s a church supposed to look like?” We think a church is about the people inside—not about the building—so it shouldn’t matter if we look like a former warehouse or a city school. And while you might not find steeples or stained glass around here, there’s no shortage of really authentic people—and free coffee.
         </p>

--- a/_includes/about/_leadership.html
+++ b/_includes/about/_leadership.html
@@ -1,0 +1,105 @@
+<section class="bg-blue">
+  <div class="container soft-ends">
+    <div class="row text-center soft-bottom">
+      <h1 class="component-header-box text-white">Leadership</h1>
+    </div>
+    <div class="row flex-wrap">
+      <div class="col-md-4 push-bottom">
+        <crds-portrait-card theme="expanded" text-color="white" href="#" lead="Senior Pastor" title="Brian Tome" image-src="//crds-media.imgix.net/1ofFTnFyNR4qmQnr9zNvtz/1992460ebb4566715436868dcc4523bb/leadership-brian-tome.png?h=250">
+          <p>Brian is the founding and senior pastor of Crossroads Church. He calls it like he sees it and will challenge you to do the same. Don’t be passive. Don’t skirt around challenges. With God you can meet them head on.</p>
+          <crds-button href="/media/authors/brian-tome" color="orange" text="About Brian" ></crds-button> 
+          <crds-button href="https://www.instagram.com/Briantome/" color="white" display="outline" text="Follow on Instagram" icon="instagram" icon-color="white" icon-size="14" icon-align="left" ></crds-button>
+          <crds-button href="https://www.facebook.com/briantomebooks/" color="white" display="outline" text="Follow on Facebook" icon="facebook" icon-color="white" icon-size="14" icon-align="left" ></crds-button>
+        </crds-portrait-card>
+      </div>
+      
+      <div class="col-md-4 push-bottom">
+        <crds-portrait-card theme="expanded" text-color="white" href="#" lead="Studio Director/Co-Founder" title="Vivenne Bechtold" image-src="//crds-media.imgix.net/4c5j5i5IreNCa56er3Dhpk/40d5487b30cb3202c6ed9e36506d2092/leadership-vivienne-bechtold.png?h=250">
+          <p>Vivienne heads up Leadership Development and the Studio which is our internal agency bringing together marketing, analytics, research, design, and digital products to help Crossroads reach new people, connect them with God, and get involved in our community. She's been around from the start, responsible for hiring Brian Tome, and brings a ton of experience from P&G.</p>
+        </crds-portrait-card>
+      </div>
+      
+      <div class="col-md-4 push-bottom">
+        <crds-portrait-card theme="expanded" text-color="white" href="#" lead="Director of Finance & Operations" title="Season Huff" image-src="//crds-media.imgix.net/jbx76OrxPyS7hYmqf2caB/7f610276bfc1c16f987597ff0ccdcfb5/leadership-season-huff.png?h=250">
+          <p>Season is the Director of Finance & Operations. Her team keeps the day-to-day needs of the church moving like a well-oiled machine. Don’t let her accounting degree fool you, she loves live music, skydiving is on her bucket list, and she drives to help people reach the full potential of God's calling on their life. </p>
+        </crds-portrait-card>
+      </div>
+      
+      <div class="col-md-4 push-bottom">
+        <crds-portrait-card theme="expanded" text-color="white" href="#" lead="Teaching Pastor/Oakley Pastor" title="Chuck Mingo" image-src="//crds-media.imgix.net/H9RKt9YMVyiA2DehDUNys/441b1e5b5d0996a1bbc7f4c1d2db48ee/leadership-chuck-mingo.png?h=250">
+          <p>Chuck is the Oakley Community Pastor. Chuck is passionate about his relationship with Jesus, his family, racial solidarity, and getting people to a new place on their journey with God.</p>
+          <crds-button href="/media/authors/chuck-mingo" color="orange" text="About Chuck" ></crds-button> 
+          <crds-button href="https://www.instagram.com/chuckmingo/" color="white" display="outline" text="Follow on Instagram" icon="instagram" icon-color="white" icon-size="14" icon-align="left" ></crds-button>
+          <crds-button href="https://www.facebook.com/chuckdmingo/" color="white" display="outline" text="Follow on Facebook" icon="facebook" icon-color="white" icon-size="14" icon-align="left" ></crds-button>
+        </crds-portrait-card>
+      </div>
+      
+      <div class="col-md-4 push-bottom">
+        <crds-portrait-card theme="expanded" text-color="white" href="#" lead="Teaching Pastor" title="Alli Patterson" image-src="//crds-media.imgix.net/5SLEmZq6spJ6GUkSAm3Ohe/7e3669f96b994b327df4a77097dc8e62/leadership-alli-patterson.png?h=250">
+          <p>Passionate learner and teacher, wife and mother of 4. Alli is the co-host of our podcast "IKR." She brings truth, vulnerability, courage, and hope to every single endeavor.</p>
+          <crds-button href="/media/authors/alli-patterson" color="orange" text="About Alli" ></crds-button> 
+          <crds-button href="https://www.instagram.com/theallipatterson/" color="white" display="outline" text="Follow on Instagram" icon="instagram" icon-color="white" icon-size="14" icon-align="left" ></crds-button>
+          <crds-button href="https://www.facebook.com/theallipatterson/" color="white" display="outline" text="Follow on Facebook" icon="facebook" icon-color="white" icon-size="14" icon-align="left" ></crds-button>
+        </crds-portrait-card>
+      </div>
+      
+      <div class="col-md-4 push-bottom">
+        <crds-portrait-card theme="expanded" text-color="white" href="#" lead="HR Director" title="Latasha Patrick" image-src="//crds-media.imgix.net/6aaFzqU4ZvXQOsH6U0MJWf/9547f0aadbf93e36aeae4eeb9bc94dec/leadership-latasha-patrick.png?h=250">
+          <p>LaTasha is the Director of Human Resources at Crossroads, and co-host of our podcast “IKR”. Daughter of God and proud mamma to a college student (and a pitbull). LaTasha loves to prowl Home Depot, buy power tools, and let YouTube influencers convince her she can install a shed in her backyard.</p>
+          <crds-button href="/media/authors/latasha-patrick" color="orange" text="About Latasha" ></crds-button> 
+        </crds-portrait-card>
+      </div>
+      
+      <div class="col-md-4 push-bottom">
+        <crds-portrait-card theme="expanded" text-color="white" href="#" lead="Multi-Site Director" title="Terry Phillips" image-src="//crds-media.imgix.net/47m3GOcEvswi7Eb190sONz/50b17437c8c48133a130d859de7b86f3/leadership-terry-philips.png?h=250">
+          <p>Terry is the Multi-Site Director of Crossroads. He's passionate about people connecting with Jesus in a way they can feel and understand. He also enjoys playing ice hockey, smoking a perfect pork shoulder, and adventure motorcycle riding.</p>
+        </crds-portrait-card>
+      </div>
+
+      <div class="col-md-4 push-bottom">
+        <crds-portrait-card theme="expanded" text-color="white" href="/media/authors/kyle-ranson" lead="Teaching Pastor/Director of ET" title="Kyle Ranson" image-src="//crds-media.imgix.net/2LgGIDcVfk1mFMnz4X2ts2/d44d87888e6e82d6b9dc3b12f12b7f7c/leadership-kyle-ranson.png?h=250">
+          <p>Kyle is the Director of the Experience Team at Crossroads, they create stuff like videos, music, articles, and weekend services. He joyfully fulfills stereotypes about Milennials with his love of craft beer, tight jeans, and woodworking, and is passionate about people finding God.</p>
+          <crds-button href="/media/authors/kyle-ranson" color="orange" text="About Kyle" ></crds-button> 
+          <crds-button href="https://www.instagram.com/kranson28/" color="white" display="outline" text="Follow on Instagram" icon="instagram" icon-color="white" icon-size="14" icon-align="left" ></crds-button>
+          <crds-button href="https://www.facebook.com/kyleransoncrds" color="white" display="outline" text="Follow on Facebook" icon="facebook" icon-color="white" icon-size="14" icon-align="left" ></crds-button>
+        </crds-portrait-card>
+      </div>
+
+      <div class="col-md-4 push-bottom">
+        <crds-portrait-card theme="expanded" text-color="white" href="#" lead="Director of Central Kentucky" title="Glen Schneiders" image-src="//crds-media.imgix.net/59sHFKKJHobPAdHBEdAwqK/46b9bb7afa814a70b7471749d7b77cc7/leadership-glen-schneiders.png?h=250">
+          <p>Glen is the Director of Central Kentucky sites where he's invested his last 30+ years. Glen enjoys his four grandkids, all sports - OSU and UK, working with young leaders, and seeing the church impact its communities.</p>
+          <crds-button href="https://www.facebook.com/gschneiders" color="white" display="outline" text="Follow on Facebook" icon="facebook" icon-color="white" icon-size="14" icon-align="left" ></crds-button>
+        </crds-portrait-card>
+      </div>
+
+      <div class="col-md-4 push-bottom">
+        <crds-portrait-card theme="expanded" text-color="white" href="#" lead="Online “Anywhere” Church Pastor" title="Lena Schuler" image-src="//crds-media.imgix.net/3Bwa8gDJKiYDDHgrTgHtIv/5416cc0fbb6c121684c80850606c7c5a/leadership-lena-schuler.png?h=250">
+          <p>Lena is the Community Pastor of Crossroads’ online “Anywhere” community. Lena is a proud UC alum. She and her family live on the East Side of Cincinnati. She'd love to challenge you to a tennis match (if you lose, Rhinegeist Bubbles is her preferred celebratory beverage)</p>
+          <crds-button href="https://www.instagram.com/lena_schuler/" color="white" display="outline" text="Follow on Instagram" icon="instagram" icon-color="white" icon-size="14" icon-align="left" ></crds-button>
+          <crds-button href="https://www.facebook.com/ltome" color="white" display="outline" text="Follow on Facebook" icon="facebookhref="" " icon-color="white" icon-size="14" icon-align="left" ></crds-button>
+        </crds-portrait-card>
+      </div>
+      
+      <div class="col-md-4 push-bottom">
+        <crds-portrait-card theme="expanded" text-color="white" href="#" lead="Spiritual Growth Director" title="Illya Thomas" image-src="//crds-media.imgix.net/61Y3mBHczzS1PiuixfYyem/853131cdc31a80cae623878cfbf26939/leadership-illya-thomas.png?h=250">
+          <p>Illya is the Director for Spiritual Growth and leads the Site Support team for Crossroads. He’s a semi-cool dad of 2 teenage daughters and an alum of Purdue Engineering, P&G, Cincinnati Christian University and the Baptist church. He serves on the Wyoming (OH) City Schools Board of Education and the Board of Citylink because he doesn't have enough to do.</p>
+          <crds-button href="/media/authors/illya-thomas" color="orange" text="About Illya" ></crds-button> 
+        </crds-portrait-card>
+      </div>
+      
+      <div class="col-md-4 push-bottom">
+        <crds-portrait-card theme="expanded" text-color="white" href="#" lead="Director of Digital Strategy" title="Matt Welty" image-src="//crds-media.imgix.net/2iXVRcID9tMI0aa04bQqK0/e5b730eeeb671632210a1891c2140354/leadership-matt-welty.png?h=250">
+          <p>Matt is the Director of Digital Strategy at Crossroads, leading the web, app, and digital product teams. He's passionate about how technology is creating new ways for people to be part of the church and change the world. </p>
+          <crds-button href="https://twitter.com/mattwelty" color="white" display="outline" text="Follow on Twitter" icon="twitter" icon-color="white" icon-size="14" icon-align="left" ></crds-button>
+        </crds-portrait-card>
+      </div>
+      
+      <div class="col-md-4 push-bottom">
+        <crds-portrait-card theme="expanded" text-color="white" href="#" lead="Executive Pastor" title="Darin Yates">
+          <p>Executive Pastor of Crossroads Church. He is responsible for managing all Crossroads staff and keeping Brian Tome in check (if that’s possible). He is a passionate student of leadership, enjoys unwinding on the golf course, and playing with bunnies.</p>
+          <crds-button href="/media/authors/darin-yates" color="orange" text="About Darin" ></crds-button> 
+        </crds-portrait-card>
+      </div>
+    </div>
+  </div>
+</section>

--- a/_includes/about/_leadership.html
+++ b/_includes/about/_leadership.html
@@ -5,7 +5,7 @@
     </div>
     <div class="row flex-wrap">
       <div class="col-md-4 push-bottom">
-        <crds-portrait-card theme="expanded" text-color="white" href="#" lead="Senior Pastor" title="Brian Tome" image-src="//crds-media.imgix.net/1ofFTnFyNR4qmQnr9zNvtz/1992460ebb4566715436868dcc4523bb/leadership-brian-tome.png?h=250">
+        <crds-portrait-card theme="expanded" text-color="white" href="#" lead="Senior Pastor" title="Brian Tome" bg-overlay="true" image-src="//crds-media.imgix.net/1ofFTnFyNR4qmQnr9zNvtz/1992460ebb4566715436868dcc4523bb/leadership-brian-tome.png?h=250">
           <p>Brian is the founding and senior pastor of Crossroads Church. He calls it like he sees it and will challenge you to do the same. Don’t be passive. Don’t skirt around challenges. With God you can meet them head on.</p>
           <crds-button href="/media/authors/brian-tome" color="orange" text="About Brian" ></crds-button> 
           <crds-button href="https://www.instagram.com/Briantome/" color="white" display="outline" text="Follow on Instagram" icon="instagram" icon-color="white" icon-size="14" icon-align="left" ></crds-button>
@@ -14,19 +14,19 @@
       </div>
       
       <div class="col-md-4 push-bottom">
-        <crds-portrait-card theme="expanded" text-color="white" href="#" lead="Studio Director/Co-Founder" title="Vivenne Bechtold" image-src="//crds-media.imgix.net/4c5j5i5IreNCa56er3Dhpk/40d5487b30cb3202c6ed9e36506d2092/leadership-vivienne-bechtold.png?h=250">
+        <crds-portrait-card theme="expanded" text-color="white" href="#" lead="Studio Director/Co-Founder" title="Vivenne Bechtold" bg-overlay="true" image-src="//crds-media.imgix.net/4c5j5i5IreNCa56er3Dhpk/40d5487b30cb3202c6ed9e36506d2092/leadership-vivienne-bechtold.png?h=250">
           <p>Vivienne heads up Leadership Development and the Studio which is our internal agency bringing together marketing, analytics, research, design, and digital products to help Crossroads reach new people, connect them with God, and get involved in our community. She's been around from the start, responsible for hiring Brian Tome, and brings a ton of experience from P&G.</p>
         </crds-portrait-card>
       </div>
       
       <div class="col-md-4 push-bottom">
-        <crds-portrait-card theme="expanded" text-color="white" href="#" lead="Director of Finance & Operations" title="Season Huff" image-src="//crds-media.imgix.net/jbx76OrxPyS7hYmqf2caB/7f610276bfc1c16f987597ff0ccdcfb5/leadership-season-huff.png?h=250">
+        <crds-portrait-card theme="expanded" text-color="white" href="#" lead="Director of Finance & Operations" title="Season Huff" bg-overlay="true" image-src="//crds-media.imgix.net/jbx76OrxPyS7hYmqf2caB/7f610276bfc1c16f987597ff0ccdcfb5/leadership-season-huff.png?h=250">
           <p>Season is the Director of Finance & Operations. Her team keeps the day-to-day needs of the church moving like a well-oiled machine. Don’t let her accounting degree fool you, she loves live music, skydiving is on her bucket list, and she drives to help people reach the full potential of God's calling on their life. </p>
         </crds-portrait-card>
       </div>
       
       <div class="col-md-4 push-bottom">
-        <crds-portrait-card theme="expanded" text-color="white" href="#" lead="Teaching Pastor/Oakley Pastor" title="Chuck Mingo" image-src="//crds-media.imgix.net/H9RKt9YMVyiA2DehDUNys/441b1e5b5d0996a1bbc7f4c1d2db48ee/leadership-chuck-mingo.png?h=250">
+        <crds-portrait-card theme="expanded" text-color="white" href="#" lead="Teaching Pastor/Oakley Pastor" title="Chuck Mingo" bg-overlay="true" image-src="//crds-media.imgix.net/H9RKt9YMVyiA2DehDUNys/441b1e5b5d0996a1bbc7f4c1d2db48ee/leadership-chuck-mingo.png?h=250">
           <p>Chuck is the Oakley Community Pastor. Chuck is passionate about his relationship with Jesus, his family, racial solidarity, and getting people to a new place on their journey with God.</p>
           <crds-button href="/media/authors/chuck-mingo" color="orange" text="About Chuck" ></crds-button> 
           <crds-button href="https://www.instagram.com/chuckmingo/" color="white" display="outline" text="Follow on Instagram" icon="instagram" icon-color="white" icon-size="14" icon-align="left" ></crds-button>
@@ -35,7 +35,7 @@
       </div>
       
       <div class="col-md-4 push-bottom">
-        <crds-portrait-card theme="expanded" text-color="white" href="#" lead="Teaching Pastor" title="Alli Patterson" image-src="//crds-media.imgix.net/5SLEmZq6spJ6GUkSAm3Ohe/7e3669f96b994b327df4a77097dc8e62/leadership-alli-patterson.png?h=250">
+        <crds-portrait-card theme="expanded" text-color="white" href="#" lead="Teaching Pastor" title="Alli Patterson" bg-overlay="true" image-src="//crds-media.imgix.net/5SLEmZq6spJ6GUkSAm3Ohe/7e3669f96b994b327df4a77097dc8e62/leadership-alli-patterson.png?h=250">
           <p>Passionate learner and teacher, wife and mother of 4. Alli is the co-host of our podcast "IKR." She brings truth, vulnerability, courage, and hope to every single endeavor.</p>
           <crds-button href="/media/authors/alli-patterson" color="orange" text="About Alli" ></crds-button> 
           <crds-button href="https://www.instagram.com/theallipatterson/" color="white" display="outline" text="Follow on Instagram" icon="instagram" icon-color="white" icon-size="14" icon-align="left" ></crds-button>
@@ -44,20 +44,20 @@
       </div>
       
       <div class="col-md-4 push-bottom">
-        <crds-portrait-card theme="expanded" text-color="white" href="#" lead="HR Director" title="Latasha Patrick" image-src="//crds-media.imgix.net/6aaFzqU4ZvXQOsH6U0MJWf/9547f0aadbf93e36aeae4eeb9bc94dec/leadership-latasha-patrick.png?h=250">
+        <crds-portrait-card theme="expanded" text-color="white" href="#" lead="HR Director" title="Latasha Patrick" bg-overlay="true" image-src="//crds-media.imgix.net/6aaFzqU4ZvXQOsH6U0MJWf/9547f0aadbf93e36aeae4eeb9bc94dec/leadership-latasha-patrick.png?h=250">
           <p>LaTasha is the Director of Human Resources at Crossroads, and co-host of our podcast “IKR”. Daughter of God and proud mamma to a college student (and a pitbull). LaTasha loves to prowl Home Depot, buy power tools, and let YouTube influencers convince her she can install a shed in her backyard.</p>
           <crds-button href="/media/authors/latasha-patrick" color="orange" text="About Latasha" ></crds-button> 
         </crds-portrait-card>
       </div>
       
       <div class="col-md-4 push-bottom">
-        <crds-portrait-card theme="expanded" text-color="white" href="#" lead="Multi-Site Director" title="Terry Phillips" image-src="//crds-media.imgix.net/47m3GOcEvswi7Eb190sONz/50b17437c8c48133a130d859de7b86f3/leadership-terry-philips.png?h=250">
+        <crds-portrait-card theme="expanded" text-color="white" href="#" lead="Multi-Site Director" title="Terry Phillips" bg-overlay="true" image-src="//crds-media.imgix.net/47m3GOcEvswi7Eb190sONz/50b17437c8c48133a130d859de7b86f3/leadership-terry-philips.png?h=250">
           <p>Terry is the Multi-Site Director of Crossroads. He's passionate about people connecting with Jesus in a way they can feel and understand. He also enjoys playing ice hockey, smoking a perfect pork shoulder, and adventure motorcycle riding.</p>
         </crds-portrait-card>
       </div>
 
       <div class="col-md-4 push-bottom">
-        <crds-portrait-card theme="expanded" text-color="white" href="/media/authors/kyle-ranson" lead="Teaching Pastor/Director of ET" title="Kyle Ranson" image-src="//crds-media.imgix.net/2LgGIDcVfk1mFMnz4X2ts2/d44d87888e6e82d6b9dc3b12f12b7f7c/leadership-kyle-ranson.png?h=250">
+        <crds-portrait-card theme="expanded" text-color="white" href="/media/authors/kyle-ranson" lead="Teaching Pastor/Director of ET" title="Kyle Ranson" bg-overlay="true" image-src="//crds-media.imgix.net/2LgGIDcVfk1mFMnz4X2ts2/d44d87888e6e82d6b9dc3b12f12b7f7c/leadership-kyle-ranson.png?h=250">
           <p>Kyle is the Director of the Experience Team at Crossroads, they create stuff like videos, music, articles, and weekend services. He joyfully fulfills stereotypes about Milennials with his love of craft beer, tight jeans, and woodworking, and is passionate about people finding God.</p>
           <crds-button href="/media/authors/kyle-ranson" color="orange" text="About Kyle" ></crds-button> 
           <crds-button href="https://www.instagram.com/kranson28/" color="white" display="outline" text="Follow on Instagram" icon="instagram" icon-color="white" icon-size="14" icon-align="left" ></crds-button>
@@ -66,36 +66,36 @@
       </div>
 
       <div class="col-md-4 push-bottom">
-        <crds-portrait-card theme="expanded" text-color="white" href="#" lead="Director of Central Kentucky" title="Glen Schneiders" image-src="//crds-media.imgix.net/59sHFKKJHobPAdHBEdAwqK/46b9bb7afa814a70b7471749d7b77cc7/leadership-glen-schneiders.png?h=250">
+        <crds-portrait-card theme="expanded" text-color="white" href="#" lead="Director of Central Kentucky" title="Glen Schneiders" bg-overlay="true" image-src="//crds-media.imgix.net/59sHFKKJHobPAdHBEdAwqK/46b9bb7afa814a70b7471749d7b77cc7/leadership-glen-schneiders.png?h=250">
           <p>Glen is the Director of Central Kentucky sites where he's invested his last 30+ years. Glen enjoys his four grandkids, all sports - OSU and UK, working with young leaders, and seeing the church impact its communities.</p>
           <crds-button href="https://www.facebook.com/gschneiders" color="white" display="outline" text="Follow on Facebook" icon="facebook" icon-color="white" icon-size="14" icon-align="left" ></crds-button>
         </crds-portrait-card>
       </div>
 
       <div class="col-md-4 push-bottom">
-        <crds-portrait-card theme="expanded" text-color="white" href="#" lead="Online “Anywhere” Church Pastor" title="Lena Schuler" image-src="//crds-media.imgix.net/3Bwa8gDJKiYDDHgrTgHtIv/5416cc0fbb6c121684c80850606c7c5a/leadership-lena-schuler.png?h=250">
+        <crds-portrait-card theme="expanded" text-color="white" href="#" lead="Online “Anywhere” Church Pastor" title="Lena Schuler" bg-overlay="true" image-src="//crds-media.imgix.net/3Bwa8gDJKiYDDHgrTgHtIv/5416cc0fbb6c121684c80850606c7c5a/leadership-lena-schuler.png?h=250">
           <p>Lena is the Community Pastor of Crossroads’ online “Anywhere” community. Lena is a proud UC alum. She and her family live on the East Side of Cincinnati. She'd love to challenge you to a tennis match (if you lose, Rhinegeist Bubbles is her preferred celebratory beverage)</p>
           <crds-button href="https://www.instagram.com/lena_schuler/" color="white" display="outline" text="Follow on Instagram" icon="instagram" icon-color="white" icon-size="14" icon-align="left" ></crds-button>
-          <crds-button href="https://www.facebook.com/ltome" color="white" display="outline" text="Follow on Facebook" icon="facebookhref="" " icon-color="white" icon-size="14" icon-align="left" ></crds-button>
+          <crds-button href="https://www.facebook.com/ltome" color="white" display="outline" text="Follow on Facebook" icon="facebook" icon-color="white" icon-size="14" icon-align="left" ></crds-button>
         </crds-portrait-card>
       </div>
       
       <div class="col-md-4 push-bottom">
-        <crds-portrait-card theme="expanded" text-color="white" href="#" lead="Spiritual Growth Director" title="Illya Thomas" image-src="//crds-media.imgix.net/61Y3mBHczzS1PiuixfYyem/853131cdc31a80cae623878cfbf26939/leadership-illya-thomas.png?h=250">
+        <crds-portrait-card theme="expanded" text-color="white" href="#" lead="Spiritual Growth Director" title="Illya Thomas" bg-overlay="true" image-src="//crds-media.imgix.net/61Y3mBHczzS1PiuixfYyem/853131cdc31a80cae623878cfbf26939/leadership-illya-thomas.png?h=250">
           <p>Illya is the Director for Spiritual Growth and leads the Site Support team for Crossroads. He’s a semi-cool dad of 2 teenage daughters and an alum of Purdue Engineering, P&G, Cincinnati Christian University and the Baptist church. He serves on the Wyoming (OH) City Schools Board of Education and the Board of Citylink because he doesn't have enough to do.</p>
           <crds-button href="/media/authors/illya-thomas" color="orange" text="About Illya" ></crds-button> 
         </crds-portrait-card>
       </div>
       
       <div class="col-md-4 push-bottom">
-        <crds-portrait-card theme="expanded" text-color="white" href="#" lead="Director of Digital Strategy" title="Matt Welty" image-src="//crds-media.imgix.net/2iXVRcID9tMI0aa04bQqK0/e5b730eeeb671632210a1891c2140354/leadership-matt-welty.png?h=250">
+        <crds-portrait-card theme="expanded" text-color="white" href="#" lead="Director of Digital Strategy" title="Matt Welty" bg-overlay="true" image-src="//crds-media.imgix.net/2iXVRcID9tMI0aa04bQqK0/e5b730eeeb671632210a1891c2140354/leadership-matt-welty.png?h=250">
           <p>Matt is the Director of Digital Strategy at Crossroads, leading the web, app, and digital product teams. He's passionate about how technology is creating new ways for people to be part of the church and change the world. </p>
           <crds-button href="https://twitter.com/mattwelty" color="white" display="outline" text="Follow on Twitter" icon="twitter" icon-color="white" icon-size="14" icon-align="left" ></crds-button>
         </crds-portrait-card>
       </div>
       
       <div class="col-md-4 push-bottom">
-        <crds-portrait-card theme="expanded" text-color="white" href="#" lead="Executive Pastor" title="Darin Yates">
+        <crds-portrait-card theme="expanded" text-color="white" href="#" lead="Executive Pastor" title="Darin Yates" bg-overlay="true">
           <p>Executive Pastor of Crossroads Church. He is responsible for managing all Crossroads staff and keeping Brian Tome in check (if that’s possible). He is a passionate student of leadership, enjoys unwinding on the golf course, and playing with bunnies.</p>
           <crds-button href="/media/authors/darin-yates" color="orange" text="About Darin" ></crds-button> 
         </crds-portrait-card>

--- a/_includes/about/_leadership.html
+++ b/_includes/about/_leadership.html
@@ -1,7 +1,7 @@
 <section class="bg-blue">
   <div class="container soft-ends">
     <div class="row text-center soft-bottom">
-      <h1 class="component-header-box text-white">Leadership</h1>
+      <h1 class="component-header-box text-tan">Leadership</h1>
     </div>
     <div class="row flex-wrap">
       <div class="col-md-4 push-bottom">

--- a/about.html
+++ b/about.html
@@ -2,6 +2,7 @@
 layout: container-fluid
 title: About Us
 permalink: /about
+snail_trail: disabled
 ---
 
 <section class="jumbotron jumbotron-xl jumbotron-home flush" style="background-image: url('//crds-media.imgix.net/47HugzxZ1gGwfdZg2JSFNC/e047f199c71a18f3d9b2ef8af06cc6c0/crossroads-collage-new2.jpg?{{ site.imgix_params.placeholder_sixteen_nine }}');" data-optimize-bg-img >

--- a/about.html
+++ b/about.html
@@ -5,7 +5,6 @@ permalink: /about
 ---
 
 <section class="jumbotron jumbotron-xl jumbotron-home flush" style="background-image: url('//crds-media.imgix.net/47HugzxZ1gGwfdZg2JSFNC/e047f199c71a18f3d9b2ef8af06cc6c0/crossroads-collage-new2.jpg?{{ site.imgix_params.placeholder_sixteen_nine }}');" data-optimize-bg-img >
-  <div class="bg-overlay"></div>
   <div class="container">
     <div class="row">
       <div class="col-sm-10 col-sm-offset-1">
@@ -15,7 +14,7 @@ permalink: /about
             <h1 class="font-family-condensed-extra text-uppercase flush-top text-tan">Crossroads</h1>
           </div>
           <p class="font-family-serif">
-            Back in ‘95, eleven people got together to start a church in Cincinnati for their friends who didn’t like church. Today, Crossroads is a movement of people meeting in person and digitally all over the country. No memberships or awkward hand-holding, just unfiltered talk and biblical truth that will wake your soul.  
+            Back in ‘95, eleven people got together to start a church in Cincinnati for their friends who didn’t like church. Today, Crossroads is a movement of people meeting in person and digitally all over the country. No memberships or awkward hand-holding, just unfiltered talk and biblical truth that will wake your soul.
           </p>
           <crds-button href="/30daytrial" color="orange" text="Start your 30 day trial"></crds-button>
         </div>

--- a/about.html
+++ b/about.html
@@ -1,0 +1,72 @@
+---
+layout: container-fluid
+title: About Us
+permalink: /about
+---
+
+<section class="jumbotron jumbotron-xl jumbotron-home flush" style="background-image: url('//crds-media.imgix.net/47HugzxZ1gGwfdZg2JSFNC/e047f199c71a18f3d9b2ef8af06cc6c0/crossroads-collage-new2.jpg?{{ site.imgix_params.placeholder_sixteen_nine }}');" data-optimize-bg-img >
+  <div class="bg-overlay"></div>
+  <div class="container">
+    <div class="row">
+      <div class="col-sm-10 col-sm-offset-1">
+        <div class="jumbotron-content">
+          <div class="jumbotron-home-header">
+            <h2 class="font-family-condensed-extra text-uppercase flush-bottom text-tan">About</h2>
+            <h1 class="font-family-condensed-extra text-uppercase flush-top text-tan">Crossroads</h1>
+          </div>
+          <p class="font-family-serif">
+            Back in ‘95, eleven people got together to start a church in Cincinnati for their friends who didn’t like church. Today, Crossroads is a movement of people meeting in person and digitally all over the country. No memberships or awkward hand-holding, just unfiltered talk and biblical truth that will wake your soul.  
+          </p>
+          <crds-button href="/30daytrial" color="orange" text="Start your 30 day trial"></crds-button>
+        </div>
+      </div>
+    </div>
+  </div>
+</section>
+
+<section class="bg-orange">
+  <div class="bg-topo">
+    <div class="container">
+      <div class="row text-center push-ends">
+        <h1 class="component-header-box text-blue">The Basics</h1>
+      </div>
+      <div class="row push-bottom soft-bottom">
+        <div class="col-md-3 col-sm-6 col-xs-12 push-bottom">
+          <crds-portrait-card  href="#" title="Crossroads History" image-src="//crds-media.imgix.net//5OZiKpKybDXDdJMK1TCHfG/8c4d64a042198add2dad902ec05165d5/our-history-portrait.png?h=250"></crds-portrait-card>
+        </div>
+        <div class="col-md-3 col-sm-6 col-xs-12 push-bottom">
+          <crds-portrait-card  href="#" title="Seven Hills &nbsp; We Die On" image-src="//crds-media.imgix.net//2scMNc3w8u0VaVGZfZKn3h/c8a7589253d896eb50171070deeecacc/seven-hills-portrait.png?h=250"></crds-portrait-card>
+        </div>
+        <div class="col-md-3 col-sm-6 col-xs-12 push-bottom">
+          <crds-portrait-card  href="#" title="What We Believe" image-src="//crds-media.imgix.net//7IA56fjbbW5PeXzcP1Qxg9/c401ed40c06ffdc6062db33ff86427fd/annual-report-portrait.png?h=250"></crds-portrait-card>
+        </div>
+        <div class="col-md-3 col-sm-6 col-xs-12 push-bottom">
+          <crds-portrait-card  href="#" title="Annual &nbsp; Report" image-src="//crds-media.imgix.net/4TESG278E9KQuQ4e4DhoEq/b3ece955d9eb02762039f45aee094a2f/what-we-believe-portrait.png?h=250"></crds-portrait-card>
+        </div>
+      </div>
+    </div>
+  </div>
+</section>
+
+{% include about/_leadership.html %}
+
+{% include about/_faqs.html %}
+
+<section class="bg-orange">
+  <div class="container soft-ends text-center">
+    <div class="push-top soft-top row">
+      <crds-arrow arrow-color="blue" text-color="orange">It's go time</crds-arrow>
+    </div>
+    <div class="row">
+      <div class="col-md-8 col-md-push-2">
+        <h1 class="component-header-box component-header-box-border-lg font-size-h1 text-white">Ready to start your adventure?</h1>
+      </div>
+    </div>
+    <div class="row">
+      <p class="font-family-serif text-blue push font-size-base">Take the 30 day challenge</p>
+    </div>
+    <div class="push-bottom soft-bottom row">
+      <crds-button href="/30daytrial/sign-up" color="blue" size="lg" text="Sign up now"></crds-button>
+    </div>
+  </div>
+</section>


### PR DESCRIPTION
## Task
Compose About page based off [design](https://invis.io/5TWTAP2G7SH#/421584693_About_Us_-_Final_-2-)
- Uses the new portrait card expanded component
- FAQs at bottom should all act as anchor links
- You will also need to get all the links to their social handles
- 30 Day Trial CTA btns link to /30daytrial/sign-up (page does not exist on INT, only on prod)
[Rally Story](https://rally1.rallydev.com/#/detail/userstory/397742052760?fdp=true)

## Solution 
[Preview](https://deploy-preview-1564--int-crds-net.netlify.app/about)

## Notes
On the jumbotron, the background gradient overlay color is being fixed in US19707

## Corresponding Branch
This PR adds bg-overlay on the portrait card images and adds a gray background for staff without an image (i.e. Darin Yates)
[Crds-Components](https://github.com/crdschurch/crds-components/pull/661)