### PR TITLE
feature/Dockerize crds-net build & serve environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@
 6. Make sure you have [Contentful environment variables set](#working-with-content) and then run `bundle exec jekyll contentful` to get the site's content
 7. Now you are ready to start a local dev server: `bundle exec jekyll serve`. If you are using Windows, you may need to refer to the [advanced instructions](#windows)
 
+Alternatively, you can serve crds-net locally with Docker. Setup instructions [here](/docker/development/README.md).
+
 ## Working With Content
 First, you need to export the following environment variables (you can get these values directly from Contentful or from Netlify)...
 ```bash

--- a/bin/local-build-command.sh
+++ b/bin/local-build-command.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+## Set host to first argument (needed for Docker). Defaults to localhost if empty.
+[ "$1" ] && HOST="$1" || HOST=127.0.0.1
+echo "Host $HOST"
+
+## Build crds-net with Contentful assets & serve locally
+echo "Starting local serve" &&
+bundle exec jekyll crds &&
+bundle exec jekyll contentful &&
+bundle exec jekyll serve --force_polling --host $HOST

--- a/docker/development/Dockerfile
+++ b/docker/development/Dockerfile
@@ -1,0 +1,102 @@
+FROM node:10.15.3
+
+# Install Ruby
+# To change versions you should just need to update the 3 ENV variables below
+# SHA is for .tar.xz version. Found here https://www.ruby-lang.org/en/downloads/releases/
+ENV RUBY_MAJOR 2.6
+ENV RUBY_VERSION 2.6.2
+ENV RUBY_DOWNLOAD_SHA256 91fcde77eea8e6206d775a48ac58450afe4883af1a42e5b358320beb33a445fa
+
+# Below copied from the official Ruby docker image https://github.com/docker-library/ruby/blob/a564feaaee4c8647c299ab11d41498468bb9af7b/2.6/buster/Dockerfile
+# some of ruby's build scripts are written in ruby
+#   we purge system ruby later to make sure our final image uses what we just built
+RUN set -eux; \
+	\
+	savedAptMark="$(apt-mark showmanual)"; \
+	apt-get update; \
+	apt-get install -y --no-install-recommends \
+		bison \
+		dpkg-dev \
+		libgdbm-dev \
+		ruby \
+	; \
+	rm -rf /var/lib/apt/lists/*; \
+	\
+	wget -O ruby.tar.xz "https://cache.ruby-lang.org/pub/ruby/${RUBY_MAJOR%-rc}/ruby-$RUBY_VERSION.tar.xz"; \
+	echo "$RUBY_DOWNLOAD_SHA256 *ruby.tar.xz" | sha256sum --check --strict; \
+	\
+	mkdir -p /usr/src/ruby; \
+	tar -xJf ruby.tar.xz -C /usr/src/ruby --strip-components=1; \
+	rm ruby.tar.xz; \
+	\
+	cd /usr/src/ruby; \
+	\
+# hack in "ENABLE_PATH_CHECK" disabling to suppress:
+#   warning: Insecure world writable dir
+	{ \
+		echo '#define ENABLE_PATH_CHECK 0'; \
+		echo; \
+		cat file.c; \
+	} > file.c.new; \
+	mv file.c.new file.c; \
+	\
+	autoconf; \
+	gnuArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)"; \
+	./configure \
+		--build="$gnuArch" \
+		--disable-install-doc \
+		--enable-shared \
+	; \
+	make -j "$(nproc)"; \
+	make install; \
+	\
+	apt-mark auto '.*' > /dev/null; \
+	apt-mark manual $savedAptMark > /dev/null; \
+	find /usr/local -type f -executable -not \( -name '*tkinter*' \) -exec ldd '{}' ';' \
+		| awk '/=>/ { print $(NF-1) }' \
+		| sort -u \
+		| xargs -r dpkg-query --search \
+		| cut -d: -f1 \
+		| sort -u \
+		| xargs -r apt-mark manual \
+	; \
+	apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false; \
+	\
+	cd /; \
+	rm -r /usr/src/ruby; \
+# verify we have no "ruby" packages installed
+	! dpkg -l | grep -i ruby; \
+	[ "$(command -v ruby)" = '/usr/local/bin/ruby' ]; \
+# rough smoke test
+	ruby --version; \
+	gem --version; \
+	bundle --version
+
+# Done installing Ruby (phew). Onto crds-net stuff
+
+WORKDIR /crds-net
+
+RUN gem install bundler jekyll --no-doc 
+
+# Copy just the package files for js and ruby
+COPY package*.json ./
+COPY Gemfile* ./
+
+# Don't install Cypress
+ENV CYPRESS_INSTALL_BINARY 0 
+
+# install packages
+RUN npm ci 
+RUN bundle install
+
+# This script will be executed when container is started. Define an "entrypoint" in the docker-compose file to
+#  override this default and ignore the CMD below.
+ENTRYPOINT [ "./bin/local-build-command.sh" ]
+
+# This value is appended to the default entrypoint command as its first argument.
+#  There's a quirk with Windows 10 where Jekyll sites served on docker are not accessible on localhost
+#  unless the site is served on host 0.0.0.0. To confuse things more, still use "localhost:4000" to 
+#  access the site once it's served.
+# I do not know if this workaround is necessary for Mac/Linux machines. If the site isn't accessible from "localhost:4000"
+#  on those OSs with this default, add "command: [""]" to the docker-compose file to override this command.
+CMD ["0.0.0.0"]

--- a/docker/development/README.md
+++ b/docker/development/README.md
@@ -1,0 +1,36 @@
+# Build and Serve locally with Docker
+
+The Dockerfile in this folder provides a development environment for crds-net that can be set up and used the same way on any OS. With it, a user can build and serve the crds-net site locally without needing to install Node.js and Ruby. 
+
+## Setup and First Run
+Start by getting all your code...
+1. Clone the repo: `git clone https://github.com/crdschurch/crds-net.git` then `cd ./crds-net`
+2. Initialize and update submodules: `git submodule init && git submodule update`. Issues? see [submodules section](../README.md#submodules) in main readme for help.
+
+...And your environment variables...
+1. Make a copy of the [.env-sample file](../.env-sample) and name it `.env`, then assign the environment variable values in it. The main README has more details about environment variables. //TODO
+
+...And finally setup Docker and run the darn thing.
+1. Install and start Docker, their [docs](https://docs.docker.com/get-docker/) have instructions for each OS. You'll also need to register for a Docker Hub account.
+2. Navigate to the /docker/development folder (`cd ./docker/development`)
+3. Build the Docker container with `$docker-compose build`. The first time you run this it'll take a loooong time because it's downloading and installing Node.js, Ruby and all the packages crds-net needs to build and serve. Once it's been built, this command will only need to be re-run if a npm or Ruby package changes, and that build will be much faster because of Docker caching.
+4. Start the Docker container with `$docker-compose up`. By default this runs the [local-build-command.sh](../bin/local-build-command.sh) which fetches Contentful content then builds and serves the site. This step also takes a few minutes, but you'll know it's ready when you see `Server running... press ctrl-c to stop.` in the command line.
+5. Access the site at `localhost:4000`
+
+By default the server will listen for file changes and automatically rebuild and re-serve the site without needing to restart the server. It takes a minute or so to rebuild the site, so be patient!
+
+Once you're done, stop the Docker container to stop the server with `$ctrl + c`
+
+## Second Run and Beyond
+
+- Docker containers persist once you've stopped them, so to re-start the server you'll just need to run `$docker-compose up` again and wait until the command line indicates the server is running. You do not need to run `$docker-compose build` again unless a Node or Ruby package has changed, or the container has been manually removed.
+- Each time the container starts it will run the [local-build-command.sh](../bin/local-build-command.sh) and fetch Contentful content. If you're stopping and starting the server often and don't want to do that step each time, uncomment the "endpoint" line in the [docker-compose.yml file](./docker-compose.yml) which will override the default startup command and start the server without fetching from Contentful.
+
+## Maintaining the Dockerfile
+- The Dockerfile uses node as it's base image, so to update node you'll need to change the `FROM node:10.15.3` line to match the image and version you want. We're using the official node image from Docker Hub found [here](https://hub.docker.com/_/node/) - check out the Tags section for more options. Once changed, the container will need to be re-built.
+- Ruby is installed on top of the node image using the same script as the official Ruby docker image. To update that version, change the `RUBY_MAJOR`, `RUBY_VERSION` and `RUBY_DOWNLOAD_SHA256` ENV variables in the Dockerfile to what you want. Once changed, the container will need to be re-built.
+
+## Details for the Curious
+### What's with --host 0.0.0.0?
+There's a quirk with Windows 10 where Jekyll sites served on docker are not accessible from the host machine unless the site is served on host 0.0.0.0. To confuse things more, the host machine still accesses the site from "localhost:4000".
+I don't know if this workaround is necessary for Mac/Linux machines, but if the container says the server's running and "localhost:4000" isn't showing anything, add `command: [""]` to the `docker-compose.yml` file and re-run `$docker-compose up`.

--- a/docker/development/README.md
+++ b/docker/development/README.md
@@ -5,16 +5,16 @@ The Dockerfile in this folder provides a development environment for crds-net th
 ## Setup and First Run
 Start by getting all your code...
 1. Clone the repo: `git clone https://github.com/crdschurch/crds-net.git` then `cd ./crds-net`
-2. Initialize and update submodules: `git submodule init && git submodule update`. Issues? see [submodules section](../README.md#submodules) in main readme for help.
+2. Initialize and update submodules: `git submodule init && git submodule update`. Issues? see the submodules section in the in [main readme](../README.md) for help.
 
 ...And your environment variables...
-1. Make a copy of the [.env-sample file](../.env-sample) and name it `.env`, then assign the environment variable values in it. The main README has more details about environment variables. //TODO
+1. Make a copy of the `.env-sample` file and name it `.env`, then assign the environment variable values in it. The main README has more details about environment variables.
 
 ...And finally setup Docker and run the darn thing.
 1. Install and start Docker, their [docs](https://docs.docker.com/get-docker/) have instructions for each OS. You'll also need to register for a Docker Hub account.
 2. Navigate to the /docker/development folder (`cd ./docker/development`)
 3. Build the Docker container with `$docker-compose build`. The first time you run this it'll take a loooong time because it's downloading and installing Node.js, Ruby and all the packages crds-net needs to build and serve. Once it's been built, this command will only need to be re-run if a npm or Ruby package changes, and that build will be much faster because of Docker caching.
-4. Start the Docker container with `$docker-compose up`. By default this runs the [local-build-command.sh](../bin/local-build-command.sh) which fetches Contentful content then builds and serves the site. This step also takes a few minutes, but you'll know it's ready when you see `Server running... press ctrl-c to stop.` in the command line.
+4. Start the Docker container with `$docker-compose up`. By default this runs the `/bin/local-build-command.sh` script which fetches Contentful content then builds and serves the site. This step also takes a few minutes, but you'll know it's ready when you see `Server running... press ctrl-c to stop.` in the command line.
 5. Access the site at `localhost:4000`
 
 By default the server will listen for file changes and automatically rebuild and re-serve the site without needing to restart the server. It takes a minute or so to rebuild the site, so be patient!
@@ -24,7 +24,7 @@ Once you're done, stop the Docker container to stop the server with `$ctrl + c`
 ## Second Run and Beyond
 
 - Docker containers persist once you've stopped them, so to re-start the server you'll just need to run `$docker-compose up` again and wait until the command line indicates the server is running. You do not need to run `$docker-compose build` again unless a Node or Ruby package has changed, or the container has been manually removed.
-- Each time the container starts it will run the [local-build-command.sh](../bin/local-build-command.sh) and fetch Contentful content. If you're stopping and starting the server often and don't want to do that step each time, uncomment the "endpoint" line in the [docker-compose.yml file](./docker-compose.yml) which will override the default startup command and start the server without fetching from Contentful.
+- Each time the container starts it will run the `local-build-command.sh` and fetch Contentful content. If you're stopping and starting the server often and don't want to do that step each time, uncomment the "endpoint" line in the [docker-compose.yml file](./docker-compose.yml) which will override the default startup command and start the server without fetching from Contentful.
 
 ## Maintaining the Dockerfile
 - The Dockerfile uses node as it's base image, so to update node you'll need to change the `FROM node:10.15.3` line to match the image and version you want. We're using the official node image from Docker Hub found [here](https://hub.docker.com/_/node/) - check out the Tags section for more options. Once changed, the container will need to be re-built.

--- a/docker/development/docker-compose.yml
+++ b/docker/development/docker-compose.yml
@@ -1,0 +1,22 @@
+version: '3.8'
+services:
+  crds-net:
+    build: 
+      context: ../../
+      dockerfile: ./docker/development/Dockerfile
+    container_name: crds-net-development
+    env_file: ../../.env
+    volumes:
+      - type: volume
+        source: crds-net_node_modules
+        target: /crds-net/node_modules
+      - type: bind
+        source: ../../
+        target: /crds-net
+    ports:
+      - 4000:4000
+    # entrypoint: [ "bundle", "exec", "jekyll", "serve", "--force_polling", "--host", "0.0.0.0"] # Uncomment to serve without updating contentful on "docker-compose up"
+
+
+volumes: 
+  crds-net_node_modules:


### PR DESCRIPTION
## Problem
- Windows cannot correctly build & serve crds-net locally so it's not possible to fully test changes
- Generally environment setup can be a pain, so contributors with minor/infrequent changes may be discouraged from testing changes locally before committing

## Solution
- Use Docker containers to provide an easy to run build & serve environment that'll behave the same across any OS

## Testing
Could someone with a Mac follow the readme to build & run the Docker container and confirm the following:
- Once the server is running in the container you access the site from "localhost:4000"
- While the server is running you can make changes to the site (like html or css, not Contentful content) and the site will automatically rebuild and serve the changes without needing to restart the container

Could someone (also with a Mac/Linux) who has the environment setup to build & serve crds-net locally confirm the following:
- The bin/local-build-command.sh script works as-is to build & serve crds-net locally
- That script include all the steps you'd normally go through to serve crds-net locally
- You can alternate between serving the site locally and serving it through Docker without either build style breaking the other (ie. they're compatible with each other) 
