### PR TITLE
DE7796 Demo Legacy

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -65,7 +65,7 @@
 [context.release.environment]
   CRDS_PEOPLE_DOMAIN = "people-int.crossroads.net"
   CRDS_MAP_DOMAIN = "connect-int.crossroads.net"
-  CRDS_ANGULAR_ENDPOINT = "release--crds-angular.netlify.app"
+  CRDS_ANGULAR_ENDPOINT = "crds-angular-demo.netlify.app"
   CRDS_OKTA_SIGNIN_ENDPOINT = "release.signin.crossroads.net"
   CRDS_SERVE_ENDPOINT = "release.serve.crossroads.net"
   CRDS_PROFILE_ENDPOINT = "profile-int.crossroads.net"


### PR DESCRIPTION
This PR updates the route for the legacy proxy in the DEMO environment. This update won't do anything until merged into `release`.