### PR TITLE
US19711 Location Detail

### DIFF
--- a/_layouts/location.html
+++ b/_layouts/location.html
@@ -29,8 +29,12 @@ layout: default
       {% if location_happenings.size > 0 %}
       <a href="javascript:void(0)" class="btn btn-white btn-outline" data-smooth-scroll-to="happenings">See what's
         happening at {{ page.name | downcase }}</a>
-        {% endif %}
+      {% endif %}
+      
+      {% if page.kids_club_hours or page.student_ministry_hours %}
       <a href="javascript:void(0)" class="btn btn-white btn-outline" data-smooth-scroll-to="kids-and-students">Kids &amp; Students</a>
+      {% endif %}
+
       <a href="javascript:void(0)" class="btn btn-white btn-outline" data-smooth-scroll-to="community-care">Community Care</a>
     </div>
   </div>

--- a/_layouts/location.html
+++ b/_layouts/location.html
@@ -8,7 +8,9 @@ layout: default
 
 <!-- Featured Section -->
 {% if page.featured_section.size > 0 %}
-  {{ page.featured_section }}
+  <div class="overflow-hidden">
+    {{ page.featured_section }}
+  </div>
 {% endif %}
 
 <!-- Jumbotron section -->
@@ -20,10 +22,10 @@ layout: default
     </span>
     <h1 class="font-family-condensed-extra text-uppercase">Crossroads <br />{{ page.name }}</h1>
 
-    <div class="row push-bottom">
+    <div class="push-bottom">
       <a href="javascript:void(0)" class="btn btn-orange" data-smooth-scroll-to="service-times">View service times</a>
     </div>
-    <div class="row">
+    <div>
       {% if location_happenings.size > 0 %}
       <a href="javascript:void(0)" class="btn btn-white btn-outline" data-smooth-scroll-to="happenings">See what's
         happening at {{ page.name | downcase }}</a>
@@ -71,7 +73,7 @@ layout: default
           </div>
         </div>
       </div>
-      <div class="col-sm-offset-1 col-sm-5">
+      <div class="col-sm-5 col-sm-offset-1 mobile-push-half-sides mobile-soft-sides">
         <div class="row border-top soft-ends">
           <p class="text-orange"><strong>Social Media</strong></p>
           <div>
@@ -98,12 +100,16 @@ layout: default
               formInstanceId: 1,
               onFormReady($form, ctx) {
                 $('fieldset[data-reactid=".hbspt-forms-0.1:$0"]').removeClass('form-columns-2');
+                $('fieldset[data-reactid=".hbspt-forms-0.1:$1"]').removeClass('form-columns-2');
                 $('input[data-reactid=".hbspt-forms-0.1:$0.1:$firstname.$firstname.0"]').attr('placeholder', 'First name')
                 $('input[data-reactid=".hbspt-forms-0.1:$0.1:$lastname.$lastname.0"]').attr('placeholder', 'Last name')
                 $('input[data-reactid=".hbspt-forms-0.1:$1.1:$email.$email.0"]').attr('placeholder', 'Email')
+                $('input[data-reactid=".hbspt-forms-0.1:$1.1:$mobilephone.$mobilephone.0"]').attr('placeholder', 'Phone number')
                 $('label[data-reactid=".hbspt-forms-0.1:$0.1:$firstname.0"]').hide()
                 $('label[data-reactid=".hbspt-forms-0.1:$0.1:$lastname.0"]').hide()
                 $('label[data-reactid=".hbspt-forms-0.1:$1.1:$email.0"]').hide()
+                $('div[data-reactid=".hbspt-forms-0.1:$1.1:$email.$email"]').addClass('flush-right')
+                $('span[data-reactid=".hbspt-forms-0.1:$1.1:$mobilephone.0.0"]').hide()
               }
             });
           </script>
@@ -174,22 +180,6 @@ layout: default
 {% endif %}
 
 
-<!-- Community Care -->
-{% if page.care_link %}
-<section class="push-ends soft-ends" id="community-care">
-  <div class="container">
-    <div class="row well text-center soft-ends">
-      <div class="col-sm-10 col-sm-offset-1 col-md-10 col-md-offset-1">
-        <h3 class="section-header push-half-ends">Community Care Requests</h3>
-        <p class="lead">Prayer requests, listening appointments, hospital visits, or questions about weddings or funerals– we're here to help.</p>
-        <a href="{{ page.care_link }}" class="btn btn-primary" target="_blank">Request care here</a><br />
-        <a href="/care" class="btn btn-primary btn-gray-light text-center">View all community care services</a>
-      </div>
-    </div>
-  </div>
-</section>
-{% endif %}
-
 <!-- Uptown College Student section -->
 {% if page.name == 'Uptown' %}
 <div class="container push-bottom">
@@ -256,7 +246,7 @@ layout: default
 
 <!-- Kids club / Student ministry-->
 {% if page.kids_club_hours or page.student_ministry_hours %}
-<section class="bg-gray">
+<section class="bg-tan-light">
   <div class="container" id="kids-and-students">
     <div class="col-md-12">
       <h3 class="section-header text-center">For Kids &amp; Students</h3>
@@ -288,13 +278,13 @@ layout: default
         <img class="width-100" src="https://crds-cms-uploads.imgix.net/content/images/crossroads-church-sites-kc.jpg?w=29&h=19&fit=crop"
           data-optimize-img>
       </div>
-      <div class="col-sm-6 push-top soft-top soft-sides">
+      <div class="col-sm-6 push-top soft-top soft-sides text-gray-dark">
         <h4>Your kids will love Kids' Club</h4>
         <p dir="ltr">A fun learning environment designed especially for kids (birth through fifth grade). It’s free,
           totally secure, and don't worry-we'll let you know if your child needs you at any point during the service.
         </p>
         <div></div>
-        <a class="btn btn-primary" href="https://www.crossroads.net/kids-club/" target="_blank">Learn more about Kids' Club</a>
+        <crds-button color="blue" display="outline" href="https://www.crossroads.net/kids-club/" target="_blank" text="Learn more about Kids' Club"></crds-button>
         <p class="font-size-small push-half-top">
           <em>{{ page.kids_club_hours | markdownify }}</em>
         </p>
@@ -307,7 +297,7 @@ layout: default
         <img class="width-100" src="https://crds-cms-uploads.imgix.net/content/images/crossroads-church-sites-sm.jpg?w=29&h=19&fit=crop"
           data-optimize-img>
       </div>
-      <div class="col-sm-pull-6 col-sm-6 push-top soft-top soft-sides">
+      <div class="col-sm-pull-6 col-sm-6 push-top soft-top soft-sides text-gray-dark">
         <h4>Student Ministry</h4>
         <p>Middle School (grades 6-8) and High School (grades 9-12) students have a place to call their own. Students
           are challenged
@@ -318,10 +308,28 @@ layout: default
         <p>
           {{ page.student_ministry_hours | markdownify }}
         </p>
-        <a href="https://www.crossroads.net/studentministry/" class="btn btn-primary">Get more info on student ministry</a>
+        <crds-button color="blue" display="outline" href="https://www.crossroads.net/studentministry/" text="Get more info on student ministry"></crds-button>
       </div>
     </div>
     {% endif %}
+  </div>
+</section>
+{% endif %}
+
+<!-- Community Care -->
+{% if page.care_link %}
+<section class="container">
+  <div class="jumbotron jumbotron-sm soft-ends push-ends" id="community-care" style="background-image: url('//crds-media.imgix.net/563dNi01CVnrbOf2U6JPW1/95bcb3d80ea0d612e43de5afae4b2c0f/location-communtiy-care.png?{{ site.imgix_params.placeholder_sixteen_nine }}');" data-optimize-bg-img>
+    <div class="row text-center soft-ends">
+      <div class="col-sm-10 col-sm-offset-1 col-md-10 col-md-offset-1 soft-ends">
+        <h2 class="section-header push-half-ends text-orange">Community Care</h2>
+        <p class="lead text-white">Prayer requests, listening appointments, hospital visits, or questions about weddings or funerals– we're here to help.</p>
+        <div>
+          <crds-button class="push-half-right" href="{{ page.care_link }}" color="white" target="_blank" text="Request care"></crds-button>
+          <crds-button href="/care" color="white" display="outline" text="View all services"></crds-button>
+        </div>
+      </div>
+    </div>
   </div>
 </section>
 {% endif %}
@@ -336,8 +344,8 @@ layout: default
           <img alt="Serve" class="card-img-top card-img-constrained" src="https://crds-media.imgix.net/1YQbxGtQscSoWaM5vfyDs/8891b8c3da93e54f9c6392b8f9068686/get-involved-bg4.jpg?auto=format&amp;crop=top&amp;fit=clamp&amp;ixjsv=2.2.3&amp;w=27"
             data-optimize-img>
         </a>
-        <div class="card-block">
-          <h4 class="card-title card-title--overlap text-uppercase">
+        <div class="card-block hard">
+          <h4 class="card-title font-family-condensed-extra text-uppercase">
             <a href="https://www.crossroads.net/get-connected/">Get Connected</a>
           </h4>
           <div class="card-text">
@@ -350,8 +358,8 @@ layout: default
           <img alt="Get in a Group" class="card-img-top card-img-constrained" src="https://crds-media.imgix.net/7emDm2UBzHPdpW5IJOxMNb/e5b336188a14af162434f187d342c83c/Untitled_design__19_.jpg?auto=format&amp;crop=top&amp;fit=clamp&amp;ixjsv=2.2.3&amp;w=27"
             data-optimize-img>
         </a>
-        <div class="card-block">
-          <h4 class="card-title card-title--overlap text-uppercase">
+        <div class="card-block hard">
+          <h4 class="card-title font-family-condensed-extra text-uppercase">
             <a href="https://sgwayfinder.com/">Wayfinder</a>
           </h4>
           <div class="card-text">
@@ -363,8 +371,8 @@ layout: default
         <a href="https://www.crossroads.net/give" class="block">
           <img alt="Give" class="card-img-top card-img-constrained" src="https://crds-cms-uploads.imgix.net/Uploads/crossroads-church-sites-give.jpg?auto=format&amp;crop=top&amp;fit=clamp&amp;ixjsv=2.2.3&amp;w=27" data-optimize-img>
         </a>
-        <div class="card-block">
-          <h4 class="card-title card-title--overlap text-uppercase">
+        <div class="card-block hard">
+          <h4 class="card-title font-family-condensed-extra text-uppercase">
             <a href="https://www.crossroads.net/give">Give</a>
           </h4>
           <div class="card-text">
@@ -376,8 +384,8 @@ layout: default
         <a href="https://itunes.apple.com/us/app/crossroads-anywhere/id1029478803?mt=8" class="block">
           <img alt="Download the App" class="card-img-top card-img-constrained" src="https://crds-cms-uploads.imgix.net/Uploads/crossroads-church-sites-app.jpg?auto=format&amp;crop=top&amp;fit=clamp&amp;ixjsv=2.2.3&amp;w=27" data-optimize-img>
         </a>
-        <div class="card-block">
-          <h4 class="card-title card-title--overlap text-uppercase">
+        <div class="card-block hard">
+          <h4 class="card-title font-family-condensed-extra text-uppercase">
             <a href="https://itunes.apple.com/us/app/crossroads-anywhere/id1029478803?mt=8">Download the App</a>
           </h4>
           <div class="card-text">
@@ -388,6 +396,14 @@ layout: default
     </div>
   </div>
 </section>
+
+<div class="bg-orange soft">
+  <div class="container text-center soft push-ends">
+    <h2 class="text-white text-uppercase font-family-condensed-extra">We'd love to connect with you</h2>
+    <p class="font-family-serif text-blue">Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>
+    <crds-button color="blue" text="Chat with us" data-trigger="chat"></crds-button>
+  </div>
+</div>
 
 <!--Facebook Pixel Script -->
 {% include _fb-pixel.html %}


### PR DESCRIPTION
## Problem
On location detail pages, a few things need to be finished or updated (see design for reference):
1. Update the image to match the design on the Community Care promo
![image](https://user-images.githubusercontent.com/32345656/85062527-a292ac00-b176-11ea-8207-f9c7675c963a.png)

2. Add the "We'd love to connect with you" jumbotron at the bottom of the page. Should initiate the chat widget when clicked (see US19710)
![image](https://user-images.githubusercontent.com/32345656/85062543-aa525080-b176-11ea-8921-5ca522a33c57.png)

3. Move Community Care promo below Kids & Students and above Go Deeper

4. Use blue outline btns on the Kids & Students section  

5. Make all inputs on the subscribe form the same width
![image](https://user-images.githubusercontent.com/32345656/85062563-b0483180-b176-11ea-8845-7fa575ed0dd7.png)

6. Background color on the Kids & Students section is too dark. 

7. Change btn labels on Community Care promo to "Request care" and "View all services"

8. Card style on Go Deeper section needs updated to no longer use the indented card style:
![image](https://user-images.githubusercontent.com/32345656/85062575-b9390300-b176-11ea-928e-5ad744a4fa7d.png)

9. Alignment of social btns on mobile is off (screenshot)
![image](https://user-images.githubusercontent.com/32345656/85062591-be964d80-b176-11ea-840e-d03d90501d78.png)

## Solution
[Preview](https://deploy-preview-1576--int-crds-net.netlify.app/oakley)
