### PR TITLE
US19649 media image updates

### DIFF
--- a/_includes/media/_media-card.html
+++ b/_includes/media/_media-card.html
@@ -14,6 +14,10 @@
       error
     {% endif %}
 
+    {% if item.content_type == "article" or "video" %}
+    <div class="beige-overlay"></div>
+    {% endif %} 
+
     {% assign image = item.image.url %}
 
     {% if item.content_type == 'episode' %}

--- a/_includes/media/_overlay-card.html
+++ b/_includes/media/_overlay-card.html
@@ -32,6 +32,9 @@
   {% endif %}
   {% include media/_video-player-card.html %}
   <div class="overlay-card-image">
+    {% if item.content_type == "article" or "video" %}
+    <div class="beige-overlay"></div>
+    {% endif %} 
     <img src="{% if image %}{{ image | imgix: site.imgix }}{% else %}{{ site.default_image | imgix: site.imgix }}{% endif %}?{{ site.imgix_params.placeholder_sixteen_nine }}"
       sizes="{% if include.size == 'xl' %}{{ site.image_sizes.full_width }}{% else %}{{ site.image_sizes.card_2x }}{% endif %}"
       alt="{{ image.title }}" data-optimize-img>

--- a/index.html
+++ b/index.html
@@ -218,6 +218,7 @@ notification:
       <a href="{{ article.url }}" class="overlay-card">
         <div class="bg-overlay"></div>
         <div class="overlay-card-image">
+          <div class="beige-overlay"></div>
           <img src="{{ article.image.url | imgix: site.imgix }}?{{ site.imgix_params.placeholder_sixteen_nine }}"
             sizes="{{ site.image_sizes.three_fourths }}" data-optimize-img />
         </div>
@@ -240,6 +241,7 @@ notification:
           {% assign category = article.category | get_doc %}
           <div class="card carousel-cell card-2x">
             <a class="relative" href="{{ article.url }}">
+              <div class="beige-overlay"></div>
               {% include media/_media-label.html source=article %}
               <img src="{{ article.image.url | imgix: site.imgix }}?{{ site.imgix_params.placeholder_sixteen_nine }}"
                 sizes="{{ site.image_sizes.one_fourth }}" data-optimize-img />


### PR DESCRIPTION
## Task
AG has asked that we apply the beige color overlay to certain images within the media project. Specifically:

- Jumbotrons on article detail pages
- Related article thumbnails at the bottom of article detail pages
- All media cards on /media/articles
- All cards /media/videos
- Media Landing page: all media cards for content types ARTICLE and VIDEO (non-message) only
- Homepage Logged In: all media cards for content types ARTICLE and VIDEO (non-message) only\
- Homepage Logged Out: ll media cards for content types ARTICLE and VIDEO (non-message) only -- note this should only impact the three media cards towards the bottom third of the page. 


### Corresponding PR
[Crds-Media](https://github.com/crdschurch/crds-media/pull/938)
[Crds-Components](https://github.com/crdschurch/crds-components/pull/670)