### PR TITLE
DE7823 Homepage

### DIFF
--- a/_includes/home/_jumbotron.html
+++ b/_includes/home/_jumbotron.html
@@ -14,7 +14,7 @@
             <h1 class="font-family-condensed-extra text-uppercase flush-top text-tan">Born For Adventure</h1>
           </div>
           <p class="font-family-serif">
-            We believe you were born for adventure and God challenges YOU to CHANGE THE WORLD.  Crossroads is your spiritual outfitter to guide you through that adventure.  Life isn’t a solo sport.  Find your people, have fun, crush life and leave your mark.
+            We believe you were born for adventure and God challenges YOU to CHANGE THE WORLD.  Crossroads is your <a class="text-orange" href="/spiritual-outfitters">spiritual outfitter</a> to guide you through that adventure.  Life isn’t a solo sport.  Find your people, have fun, crush life and leave your mark.
             Get outfitted.  Your adventure starts here.
           </p>
           <div class="row">

--- a/_includes/home/_you-are-needed.html
+++ b/_includes/home/_you-are-needed.html
@@ -14,8 +14,8 @@
           </crds-media-card>
         </div>
         <div class="push-bottom">
-          <crds-media-card heading="Guide Others" image-src="//crds-media.imgix.net/5CiIKfrRV4DTFrFh2yWUEc/e82b92d16b89073dac27c3816df7b9a7/reachout_2x.png?auto=format" truncate-length="null">
-            <p>We are God’s Plan A. There is no Plan B. See how you can impact the world.</p>
+          <crds-media-card heading="Go be the Church" image-src="//crds-media.imgix.net/5CiIKfrRV4DTFrFh2yWUEc/e82b92d16b89073dac27c3816df7b9a7/reachout_2x.png?auto=format" truncate-length="null">
+            <p>We are God's Plan A. There is no Plan B. See how you can make an impact in your neighborhood and around the world.</p>
             <crds-button display="outline" color="blue" href='/reachout' text='Check out ReachOut'><crds-button>
           </crds-media-card>
         </div>
@@ -28,8 +28,8 @@
           </crds-media-card>
         </div>
         <div class="push-bottom">
-          <crds-media-card heading="Explore Giving" image-src="//crds-media.imgix.net/3i4hkXrp88OK6wJml2b2W1/a5c8eb1bcd0fa285870149ccbd146cb1/give_2x.png?auto=format" truncate-length="null">
-            <p>You’ll never have to wonder if your life mattered.</p>
+          <crds-media-card heading="Give today" image-src="//crds-media.imgix.net/3i4hkXrp88OK6wJml2b2W1/a5c8eb1bcd0fa285870149ccbd146cb1/give_2x.png?auto=format" truncate-length="null">
+            <p>You'll never have to wonder if your life matters.</p>
             <crds-button display="outline" color="blue" href='/giving' text='Explore giving'><crds-button>
           </crds-media-card>
         </div>

--- a/index.html
+++ b/index.html
@@ -79,10 +79,7 @@ notification:
       <div class="col-sm-4 soft-ends">
         <div>
           <div class="push-half-bottom">
-            <p class="font-family-base-bold font-size-smaller text-orange text-uppercase">
-              Our Best Content
-            </p>
-            <h3 class="font-family-serif font-size-small text-uppercase text-white flush">Articles, Podcasts, and More</h3>
+            <h3 class="font-family-serif font-size-small text-uppercase text-white flush">Our Best Content</h3>
           </div>
           <div>
             <div>
@@ -184,18 +181,18 @@ notification:
         </div>
         <div class="col-sm-4 push-bottom">
           <crds-portrait-card-default
-          href="/music"
-          lead="Crossroads Music"
-          title="Every Good Adventure Needs a Playlist"
-          image-src="//crds-media.imgix.net/7suAPpGUjibqsKbvuXyvzz/bbe27b99193f6184cef69bdb01daa83d/crossroads-music-zoom.jpg?format=auto"
-          />
-        </div>
-        <div class="col-sm-4 push-bottom">
-          <crds-portrait-card-default
           href="https://www.facebook.com/crdschurch/"
           lead="Facebook Live Worship"
           title="Kick-start Your Morning at 8:30 am"
           image-src="//crds-media.imgix.net/1zuWtKTzfHUfugdYyoi2ZQ/ff03e2dc6215d565dd6fc678194a8bb4/daily-facebook-worship.jpg?format=auto"
+          />
+        </div>
+        <div class="col-sm-4 push-bottom">
+          <crds-portrait-card-default
+          href="/music"
+          lead="Crossroads Music"
+          title="Every Good Adventure Needs a Playlist"
+          image-src="//crds-media.imgix.net/7suAPpGUjibqsKbvuXyvzz/bbe27b99193f6184cef69bdb01daa83d/crossroads-music-zoom.jpg?format=auto"
           />
         </div>
       </div>


### PR DESCRIPTION
## Problem
homepage logged out feedback from Vivienne per her runthru w/ AG

1. Flip these two cards
![image](https://user-images.githubusercontent.com/32345656/85323494-180fbc80-b496-11ea-8eb8-a629d52ba096.png)

2. In the paragraph of text in the jumbotron, link the words "spiritual outfitter" to /spiritual-outfitters
![image](https://user-images.githubusercontent.com/32345656/85323527-2362e800-b496-11ea-9d5d-42f2b6fa82b4.png)

3. Remove the orange subheader here. Change "Articles, Podcasts and more" to read "OUR BEST CONTENT" instead
![image](https://user-images.githubusercontent.com/32345656/85323545-2d84e680-b496-11ea-9574-60dba5e16939.png)

4. Change copy on the "Guide Others" card in the "YOU ARE NEEDED" section as follows:

header: GO BE THE CHURCH
descrip text: We are God's Plan A. There is no Plan B. See how you can make an impact in your neighborhood and around the world.
(link remains the same)

5. Change copy on the "Explore Giving" card in the "YOU ARE NEEDED" section as follows:

header: GIVE TODAY
descrip text: You'll never have to wonder if your life matters.
(link remains the same)

## Solution
[Preview](https://deploy-preview-1603--int-crds-net.netlify.app/)
