### PR TITLE
DE7835/Community Pastor section on locations page

### DIFF
--- a/_includes/_location-card.html
+++ b/_includes/_location-card.html
@@ -13,7 +13,7 @@
     </div>
     <div class="card-text">
       {% if location.community_pastor_name %}
-      <div class="location-leader soft-half-sides soft-quarter-ends bg-gray push-bottom">
+      <div class="location-leader soft-half-sides soft-quarter-ends bg-gray-lightest push-bottom">
         <div class="d-flex push-quarter-sides align-items-center" style="flex-wrap: wrap;">
           <div class="push-quarter-ends push-half-right" style="flex: 1 0;">
             <strong style="color: #4d4d4d;">{{location.community_pastor_name}}</strong><br>


### PR DESCRIPTION
## Problem
Community Pastors section was too dark, and text was dark. 
[Rally ](https://rally1.rallydev.com/#/66096747656ud/detail/defect/399691515592?fdp=true)

## Solution
Lightened up gray background and changed `<p>` text to white. 

Before: 
<img width="251" alt="Before" src="https://user-images.githubusercontent.com/57996315/85435871-1dccd700-b556-11ea-8367-11b38a22896c.png">

After: 
<img width="249" alt="After" src="https://user-images.githubusercontent.com/57996315/85435975-46ed6780-b556-11ea-9dd4-bac87c134478.png">



