### PR TITLE
DE7850: [Rebrand] Old favicon shows while page is loading

### DIFF
--- a/_includes/_head.html
+++ b/_includes/_head.html
@@ -8,11 +8,11 @@
   <link rel="preload" href="{{site.components_endpoint}}/crds-components/crds-components.esm.js" as="script">
   <link rel="preload" href="{{site.components_endpoint}}/crds-components.js" as="script">
 
-  <link rel="apple-touch-icon" sizes="180x180" href="//d1tmclqz61gqwd.cloudfront.net/favicons/apple-touch-icon.png">
-  <link rel="icon" type="image/png" sizes="32x32" href="//d1tmclqz61gqwd.cloudfront.net/favicons/favicon-32x32.png">
-  <link rel="icon" type="image/png" sizes="16x16" href="//d1tmclqz61gqwd.cloudfront.net/favicons/favicon-16x16.png">
+  <link rel="apple-touch-icon" sizes="180x180" href="//d1tmclqz61gqwd.cloudfront.net/favicons/apple-touch-icon.png?v=2">
+  <link rel="icon" type="image/png" sizes="32x32" href="//d1tmclqz61gqwd.cloudfront.net/favicons/favicon-32x32.png?v=2">
+  <link rel="icon" type="image/png" sizes="16x16" href="//d1tmclqz61gqwd.cloudfront.net/favicons/favicon-16x16.png?v=2">
   <link rel="manifest" href="//d1tmclqz61gqwd.cloudfront.net/favicons/manifest.json">
-  <link rel="mask-icon" href="//d1tmclqz61gqwd.cloudfront.net/favicons/safari-pinned-tab.svg">
+  <link rel="mask-icon" href="//d1tmclqz61gqwd.cloudfront.net/favicons/safari-pinned-tab.svg?v=2">
 
   {% if page.distribution_channels %}
     <link rel="canonical" href="{{ page | get_canonical_host }}">


### PR DESCRIPTION
Adds cache buster `?v=2` to favicon URLs to bust the cache.

**Note:** This may be hard to test on a deploy preview due to it being related (I believe) to having the favicon cached

## Related PR

- [crds-media](https://github.com/crdschurch/crds-media/pull/948)

## Preview

- [Preview](https://deploy-preview-1621--int-crds-net.netlify.app/)