### PR TITLE
DE7844 Homepage Edits

### DIFF
--- a/_includes/home/_current-series.html
+++ b/_includes/home/_current-series.html
@@ -1,7 +1,7 @@
 <div class="push-bottom">
   <hr class="flush-top push-half-bottom" />
   <h2 class="text-uppercase font-family-serif font-size-base font-size-small text-gray-light flush-top">
-    Current Teaching Series
+    Current Series
   </h2>
   {% assign home_series = page.series.docs | slice: 0 %} {% for series in
   home_series %}

--- a/_includes/home/_kids-club-jumbotron.html
+++ b/_includes/home/_kids-club-jumbotron.html
@@ -7,7 +7,7 @@
           <div class="col-sm-10 col-sm-offset-1">
             <div class="d-flex justify-content-center row soft">
               <div class="col-sm-3 push-bottom col-sm-offset-1 d-flex align-items-center">
-                <img class="width-100 img-responsive" alt="Kids' Club Logo" src="//crds-media.imgix.net/32YxhqKvbtqWkt1vRulFBy/3c9a437333670efbec53c187d21160b1/crossroads-kids-club-logo-fin.png?{{ site.imgix_params.placeholder }}" data-optimize-img/>
+                <img class="width-100 img-responsive" alt="Kids' Club Logo" src="//crds-media.imgix.net/5JtiyfAQorYUOwsWpKPCEp/9f5182fa06763eb31a6fab9f16d26666/crossroads-new-kids-club-logo-fin.png?{{ site.imgix_params.placeholder }}" data-optimize-img/>
               </div>
               <div class="col-sm-3 push-bottom col-sm-offset-1 d-flex align-items-center">
                 <img class="width-100 img-responsive" alt="Student Ministry" src="//crds-media.imgix.net/2ut2VEDNcwFZyin8cdxoza/2c058f7ff2eece5e682e27ff94828ef9/student-ministry-logo2.png?{{ site.imgix_params.placeholder }}" data-optimize-img/>

--- a/_includes/home/_latest-message.html
+++ b/_includes/home/_latest-message.html
@@ -7,7 +7,7 @@
 	<hr class="flush-top push-half-bottom" />
   <div class="latest-message-background soft-half-bottom push-bottom">
     <h2 class="text-uppercase font-family-serif font-size-base font-size-small text-gray-light flush-top">
-			Latest Weekly Teaching
+			Latest Crossroads Weekend
 	  </h2>
 	    <div class="embed-container">
 				<a href="{{ item | media_url }}" data-automation-id="message-video">

--- a/index.html
+++ b/index.html
@@ -183,7 +183,7 @@ notification:
         </div>
         <div class="col-sm-4 push-bottom">
           <crds-portrait-card-default
-          href=" https://www.facebook.com/crsrdschurch/"
+          href="https://www.facebook.com/crsrdschurch/"
           lead="Facebook Live Worship"
           title="Kick-start Your Morning at 8:30 am"
           image-src="//crds-media.imgix.net/1zuWtKTzfHUfugdYyoi2ZQ/ff03e2dc6215d565dd6fc678194a8bb4/daily-facebook-worship.jpg?format=auto"

--- a/index.html
+++ b/index.html
@@ -33,7 +33,6 @@ paginate:
     collections:
       - articles
       - videos
-      - messages
       - episodes
     per: 10
     limit: 1
@@ -142,11 +141,11 @@ notification:
 </section>
 
 
-{% comment %}Get Equipped: Watch the Latest Teaching{% endcomment %}
+{% comment %}Get Equipped: Watch the Weekend{% endcomment %}
 <section class="bg-tan-light soft-bottom">
   <div class="container soft-ends hard-sides">
     <div class="text-center push-bottom soft-ends mobile-push-half-sides">
-      <h2 class="component-header-box text-orange">Get Equipped: Watch the Latest Teaching</h2>
+      <h2 class="component-header-box text-orange">Get Equipped: Watch the Weekend</h2>
     </div>
     <div class="col-md-8">
       {% include home/_latest-message.html %}
@@ -179,12 +178,12 @@ notification:
           href="/app"
           lead="Crossroads App"
           title="Connect With God. Pray With Others."
-          image-src="//crds-media.imgix.net/7zATdaIpUvdx43aQalg4YY/72ca61d36b14a5abe6ded357ab83e925/resources-crossroads-app.jpg?auto=format,compress&w=1920&h=1246&fit=crop&ixlib=imgixjs-3.3.2"
+          image-src="//crds-media.imgix.net/3tHfRrQ1ZwyNBLvnoDS37s/f67819758e1efc2faabd7405b2a4680b/crossroads-app-home.jpg?format=auto"
           />
         </div>
         <div class="col-sm-4 push-bottom">
           <crds-portrait-card-default
-          href="https://www.facebook.com/crdschurch/"
+          href=" https://www.facebook.com/crsrdschurch/"
           lead="Facebook Live Worship"
           title="Kick-start Your Morning at 8:30 am"
           image-src="//crds-media.imgix.net/1zuWtKTzfHUfugdYyoi2ZQ/ff03e2dc6215d565dd6fc678194a8bb4/daily-facebook-worship.jpg?format=auto"


### PR DESCRIPTION
## Problem
1. Update the Kids Club logo 

2. Update the image for the Crds app callout to show updated screenshots of app UI

3. Update link for Facebook ("kickstart your morning at 8:30am") to point to https://www.facebook.com/crsrdschurch/ (they changed the URL)

4. In the "articles, podcasts, and more" section, any chance we can omit messages from this since we're already showcasing most recent message so prominently on the page? If it's a heavy lift, just skip. it's a nice to have.

5. Change "Latest Weekly Teaching" subheader to "Latest Crossroads Weekend"

6. Change header on "Get Equipped" to "Get Equipped: Watch the Weekend"

7. Change "Current Teaching Series" header to "Current Series"

[Rally Defect](https://rally1.rallydev.com/#/detail/defect/399895452332?fdp=true)

## Solution
[Preview](https://deploy-preview-1622--int-crds-net.netlify.app/)
