### PR TITLE
DE7849/removes hard-coded space in title

### DIFF
--- a/_includes/_the-basics.html
+++ b/_includes/_the-basics.html
@@ -6,16 +6,16 @@
         </div>
         <div class="row push-bottom soft-bottom">
           <div class="col-md-3 col-sm-6 col-xs-12 push-bottom">
-            <crds-portrait-card theme="condensed" href="/ourhistory" title="Crossroads History" image-src="//crds-media.imgix.net//5OZiKpKybDXDdJMK1TCHfG/8c4d64a042198add2dad902ec05165d5/our-history-portrait.png?h=250"></crds-portrait-card>
+            <crds-portrait-card theme="condensed" href="/ourhistory" title="Crossroads<br>History" image-src="//crds-media.imgix.net//5OZiKpKybDXDdJMK1TCHfG/8c4d64a042198add2dad902ec05165d5/our-history-portrait.png?h=250"></crds-portrait-card>
           </div>
           <div class="col-md-3 col-sm-6 col-xs-12 push-bottom">
-            <crds-portrait-card theme="condensed" href="/sevenhills" title="Seven Hills We Die On" image-src="//crds-media.imgix.net//2scMNc3w8u0VaVGZfZKn3h/c8a7589253d896eb50171070deeecacc/seven-hills-portrait.png?h=250"></crds-portrait-card>
+            <crds-portrait-card theme="condensed" href="/sevenhills" title="Seven Hills<br>We Die On" image-src="//crds-media.imgix.net//2scMNc3w8u0VaVGZfZKn3h/c8a7589253d896eb50171070deeecacc/seven-hills-portrait.png?h=250"></crds-portrait-card>
           </div>
           <div class="col-md-3 col-sm-6 col-xs-12 push-bottom">
-            <crds-portrait-card theme="condensed" href="/whatwebelieve" title="What We Believe" image-src="//crds-media.imgix.net/4TESG278E9KQuQ4e4DhoEq/b3ece955d9eb02762039f45aee094a2f/what-we-believe-portrait.png?h=250"></crds-portrait-card>
+            <crds-portrait-card theme="condensed" href="/whatwebelieve" title="What We<br>Believe" image-src="//crds-media.imgix.net/4TESG278E9KQuQ4e4DhoEq/b3ece955d9eb02762039f45aee094a2f/what-we-believe-portrait.png?h=250"></crds-portrait-card>
           </div>
           <div class="col-md-3 col-sm-6 col-xs-12 push-bottom">
-            <crds-portrait-card theme="condensed" image-src="//crds-media.imgix.net//7IA56fjbbW5PeXzcP1Qxg9/c401ed40c06ffdc6062db33ff86427fd/annual-report-portrait.png?h=250" href="/annualreport" title="Annual Report" ></crds-portrait-card>
+            <crds-portrait-card theme="condensed" image-src="//crds-media.imgix.net//7IA56fjbbW5PeXzcP1Qxg9/c401ed40c06ffdc6062db33ff86427fd/annual-report-portrait.png?h=250" href="/annualreport" title="Annual<br>Report" ></crds-portrait-card>
           </div>
         </div>
       </div>

--- a/_includes/_the-basics.html
+++ b/_includes/_the-basics.html
@@ -9,13 +9,13 @@
             <crds-portrait-card theme="condensed" href="/ourhistory" title="Crossroads History" image-src="//crds-media.imgix.net//5OZiKpKybDXDdJMK1TCHfG/8c4d64a042198add2dad902ec05165d5/our-history-portrait.png?h=250"></crds-portrait-card>
           </div>
           <div class="col-md-3 col-sm-6 col-xs-12 push-bottom">
-            <crds-portrait-card theme="condensed" href="/sevenhills" title="Seven Hills &nbsp; We Die On" image-src="//crds-media.imgix.net//2scMNc3w8u0VaVGZfZKn3h/c8a7589253d896eb50171070deeecacc/seven-hills-portrait.png?h=250"></crds-portrait-card>
+            <crds-portrait-card theme="condensed" href="/sevenhills" title="Seven Hills We Die On" image-src="//crds-media.imgix.net//2scMNc3w8u0VaVGZfZKn3h/c8a7589253d896eb50171070deeecacc/seven-hills-portrait.png?h=250"></crds-portrait-card>
           </div>
           <div class="col-md-3 col-sm-6 col-xs-12 push-bottom">
             <crds-portrait-card theme="condensed" href="/whatwebelieve" title="What We Believe" image-src="//crds-media.imgix.net/4TESG278E9KQuQ4e4DhoEq/b3ece955d9eb02762039f45aee094a2f/what-we-believe-portrait.png?h=250"></crds-portrait-card>
           </div>
           <div class="col-md-3 col-sm-6 col-xs-12 push-bottom">
-            <crds-portrait-card theme="condensed" image-src="//crds-media.imgix.net//7IA56fjbbW5PeXzcP1Qxg9/c401ed40c06ffdc6062db33ff86427fd/annual-report-portrait.png?h=250" href="/annualreport" title="Annual &nbsp; Report" ></crds-portrait-card>
+            <crds-portrait-card theme="condensed" image-src="//crds-media.imgix.net//7IA56fjbbW5PeXzcP1Qxg9/c401ed40c06ffdc6062db33ff86427fd/annual-report-portrait.png?h=250" href="/annualreport" title="Annual Report" ></crds-portrait-card>
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Problem
Portrait cards are inaccurately spaced on mobile. 
[Rally](https://rally1.rallydev.com/#/66096747656ud/detail/defect/399926726576?fdp=true)

## Solution
Removes hard-coded `&nbsp;` and adds a max-width to `portrait-card-title` in contentful on affected pages. 


