### PR TITLE
US19751: [rebrand] Update all the videos [LAUNCH CRITICAL]

### DIFF
--- a/_assets/stylesheets/components/_jumbotron.scss
+++ b/_assets/stylesheets/components/_jumbotron.scss
@@ -50,6 +50,13 @@
       z-index: 0;
     }
 
+    &.inline-video.playing {
+      .close-video,
+      .jumbotron-background-cover {
+        z-index: 2;
+      }
+    }
+
     &.grid-overlay:before {
       z-index: 1;
     }

--- a/_assets/stylesheets/components/_jumbotron.scss
+++ b/_assets/stylesheets/components/_jumbotron.scss
@@ -46,6 +46,14 @@
   }
 
   &.jumbotron-home {
+    .bg-video-player {
+      z-index: 0;
+    }
+
+    &.grid-overlay:before {
+      z-index: 1;
+    }
+
     .jumbotron-home-header {
       margin: 0 auto;
       max-width: 760px;

--- a/_includes/home/_jumbotron.html
+++ b/_includes/home/_jumbotron.html
@@ -4,7 +4,7 @@
     <video
       width="1800"
       height="1013"
-      class="bg-jumbotron-video"
+      class="bg-jumbotron-video hide"
       autoplay="autoplay"
       loop="loop"
       muted

--- a/_includes/home/_jumbotron.html
+++ b/_includes/home/_jumbotron.html
@@ -1,10 +1,22 @@
-<section class="jumbotron jumbotron-xl jumbotron-home inline-video grid-overlay flush" style="background-image: url('//crds-media.imgix.net/47HugzxZ1gGwfdZg2JSFNC/e047f199c71a18f3d9b2ef8af06cc6c0/crossroads-collage-new2.jpg?{{ site.imgix_params.placeholder_sixteen_nine }}');" data-optimize-bg-img >
+<section class="jumbotron jumbotron-xl inline-video bg-video grid-overlay flush jumbotron-home" style="background-image: url('//crds-media.imgix.net/47HugzxZ1gGwfdZg2JSFNC/e047f199c71a18f3d9b2ef8af06cc6c0/crossroads-collage-new2.jpg?{{ site.imgix_params.placeholder_sixteen_nine }}');" data-optimize-bg-img>
   <div class="inline-video-player"></div>
+  <div class="bg-video-player">
+    <video
+      width="1800"
+      height="1013"
+      class="bg-jumbotron-video"
+      autoplay="autoplay"
+      loop="loop"
+      muted
+      playsinline
+      src="https://videos.ctfassets.net/y3a9myzsdjan/61UX4j16LJ4i6Hul1obi2Z/02c4498b9d0c1ef87fb7767fbfcaed54/spiritual-outfitters-loop.mp4"
+    ></video>
+  </div>
   <div class="container">
     <div class="row">
       <div class="col-sm-10 col-sm-offset-1">
         <div class="jumbotron-content">
-          <a href="#" class="inline-video-trigger" data-video-id="LIdCR2rywl4">
+          <a href="#" class="inline-video-trigger" data-video-id="jTtFrLl17aM">
             <svg class="media-play-btn icon icon-5 text-white" viewBox="0 0 256 256">
               <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="/assets/svgs/icons.svg#play-thin"></use>
             </svg>

--- a/index.html
+++ b/index.html
@@ -56,9 +56,9 @@ notification:
 
 <section class="soft-top bg-blue soft-bottom bg-topo push-bottom">
   <div class="container">
-    <div class="">
+    <div>
       <div class="col-sm-8 soft-ends">
-        <div class="">
+        <div>
           <div class="col-sm-6 push-bottom">
             <crds-portrait-card-default
               href="/about"


### PR DESCRIPTION
1. Update the video that displays when you click the play btn in the jumbotron on the logged out homepage - https://youtu.be/jTtFrLl17aM ✓
1. Update the background video in the homepage jumbotron (https://videos.ctfassets.net/y3a9myzsdjan/61UX4j16LJ4i6Hul1obi2Z/02c4498b9d0c1ef87fb7767fbfcaed54/spiritual-outfitters-loop.mp4) ✓
1. We do not have the asset for this one.
1. Also removes a few left over `class=""` attributes

## Preview

[Preview](https://deploy-preview-1630--int-crds-net.netlify.app/)