### PR TITLE
HOTFIX: Removing other ways to watch link

### DIFF
--- a/_includes/_location-card.html
+++ b/_includes/_location-card.html
@@ -27,8 +27,7 @@
       <div data-automation-id="location-service-times" class="push-half-bottom">
         <strong>Service Times:</strong>
         <br />
-        {{ location.service_times | markdownify | remove: '<p>'| remove: '</p>' }}<br>
-        <a href="https://www.crossroads.net/watch/#ways-to-watch">Other ways to watch</a>
+        {{ location.service_times | markdownify | remove: '<p>'| remove: '</p>' }}
       </div>
       <p class="push-half-bottom soft-quarter-bottom">
         {% if location.facebook_page_url %}


### PR DESCRIPTION
## Problem
"Other Ways to Watch" link is being managed in Contentful and we have a static link in the location card template. This is causing duplication.

## Solution
Remove static link for "Other Ways to Watch" in the location card template.

## Testing
Local