### PR TITLE
DE7883: [rebrand] capitalize city names on location detail pages

### DIFF
--- a/_layouts/location.html
+++ b/_layouts/location.html
@@ -28,7 +28,7 @@ layout: default
     <div>
       {% if location_happenings.size > 0 %}
       <a href="javascript:void(0)" class="btn btn-white btn-outline" data-smooth-scroll-to="happenings">See what's
-        happening at {{ page.name | downcase }}</a>
+        happening at {{ page.name }}</a>
       {% endif %}
       
       {% if page.kids_club_hours or page.student_ministry_hours %}


### PR DESCRIPTION
Removes `upcase` filter to allow the location title to be as entered in Contentful to solve the capitalization issue on all location pages found in the screenshot below.

<img width="921" alt="Crossroads_Church_in_Columbus__Ohio___Crossroads" src="https://user-images.githubusercontent.com/56852436/85872233-76da7c00-b79d-11ea-9f30-bcd863997cf1.png">



[Rally Story](https://rally1.rallydev.com/#/66096747656d/custom/24109743995?qdp=%2Fdetail%2Fdefect%2F400331166752)