### PR TITLE
hotfix/hotJarTrigger fixup

### DIFF
--- a/index.html
+++ b/index.html
@@ -313,7 +313,7 @@ paginate:
 <script>
   var triggerTimer = setInterval(hotJarTrigger, 1000);
   function hotJarTrigger() {
-    if (window.hj.scriptLoaded == true) {
+    if (window.hj && window.hj.scriptLoaded == true) {
       hj("trigger", "track_unauthenticated_homepage_users");
       triggerFired();
     }

--- a/logged-in-homepage.html
+++ b/logged-in-homepage.html
@@ -304,7 +304,7 @@ paginate:
 <script>
   var triggerTimer = setInterval(hotJarTrigger, 1000);
   function hotJarTrigger() {
-    if (window.hj.scriptLoaded == true) {
+    if (window.hj && window.hj.scriptLoaded == true) {
       hj("trigger", "track_authenticated_homepage_users");
       triggerFired();
     }


### PR DESCRIPTION
## Problem
If window.hj is not defined when hotJarTrigger() is called an error will be thrown. Probably doesn't matter to end users, but this type of thing breaks Cypress integration tests and is difficult to track to a source.

## Solution
Checks for window.hj to exist before checking properties

