### PR TITLE
DE7872: [rebrand] header doesn't reposition if smart app notification is dismissed on mobile

### DIFF
--- a/_includes/home/_jumbotron.html
+++ b/_includes/home/_jumbotron.html
@@ -1,23 +1,25 @@
-<section class="jumbotron jumbotron-xl inline-video bg-video grid-overlay flush jumbotron-home" style="background-image: url('//crds-media.imgix.net/47HugzxZ1gGwfdZg2JSFNC/e047f199c71a18f3d9b2ef8af06cc6c0/crossroads-collage-new2.jpg?{{ site.imgix_params.placeholder_sixteen_nine }}');" data-optimize-bg-img>
-  <div class="inline-video-player"></div>
-  <div class="bg-video-player">
-    <video
-      width="1800"
-      height="1013"
-      class="bg-jumbotron-video hide"
-      autoplay="autoplay"
-      loop="loop"
-      muted
-      playsinline
-      src="https://videos.ctfassets.net/y3a9myzsdjan/61UX4j16LJ4i6Hul1obi2Z/02c4498b9d0c1ef87fb7767fbfcaed54/spiritual-outfitters-loop.mp4"
-    ></video>
-  </div>
-  <div class="container">
-    <div class="row">
-      <div class="col-sm-10 col-sm-offset-1">
-        {% assign jumbotron_content = site.content_blocks | where: 'slug', 'home-jumbotron-content' | first %}
-        {{ jumbotron_content.content_block }}
+<section>
+  <div class="jumbotron jumbotron-xl inline-video bg-video grid-overlay flush jumbotron-home" style="background-image: url('//crds-media.imgix.net/47HugzxZ1gGwfdZg2JSFNC/e047f199c71a18f3d9b2ef8af06cc6c0/crossroads-collage-new2.jpg?{{ site.imgix_params.placeholder_sixteen_nine }}');" data-optimize-bg-img>
+    <div class="inline-video-player"></div>
+    <div class="bg-video-player">
+      <video
+        width="1800"
+        height="1013"
+        class="bg-jumbotron-video hide"
+        autoplay="autoplay"
+        loop="loop"
+        muted
+        playsinline
+        src="https://videos.ctfassets.net/y3a9myzsdjan/61UX4j16LJ4i6Hul1obi2Z/02c4498b9d0c1ef87fb7767fbfcaed54/spiritual-outfitters-loop.mp4"
+      ></video>
+    </div>
+    <div class="container">
+      <div class="row">
+        <div class="col-sm-10 col-sm-offset-1">
+          {% assign jumbotron_content = site.content_blocks | where: 'slug', 'home-jumbotron-content' | first %}
+          {{ jumbotron_content.content_block }}
+        </div>
       </div>
     </div>
-  </div>
+  </divclass="jumbotron jumbotron-xl inline-video bg-video grid-overlay flush jumbotron-home" style="background-image: url('//crds-media.imgix.net/47HugzxZ1gGwfdZg2JSFNC/e047f199c71a18f3d9b2ef8af06cc6c0/crossroads-collage-new2.jpg?{{ site.imgix_params.placeholder_sixteen_nine }}');" data-optimize-bg-img>
 </section>


### PR DESCRIPTION
In Chrome on iOS the [App Banner](https://developer.apple.com/library/archive/documentation/AppleApplications/Reference/SafariWebContent/PromotingAppswithAppBanners/PromotingAppswithAppBanners.html) for the Crossroads app does not load on the home page.

This was related to the `data-optimize-bg-img` on the video Jumbotron. The Imgix Optimizer uses the parent elements position at the end which set the `<body />` to `position: static` breaking the app banner in Chrome. Moving the jumbotron one element deeper resolves the issue.

**Important:** This must be tested on a real device simulators will not work.

[Preview](https://deploy-preview-1682--int-crds-net.netlify.app/)
[Rally](https://rally1.rallydev.com/#/66096747656d/custom/24109743995?qdp=%2Fdetail%2Fdefect%2F400204708412)