### PR TITLE
DE7909 our best content section

### DIFF
--- a/_includes/home/_our-best-content.html
+++ b/_includes/home/_our-best-content.html
@@ -5,13 +5,14 @@
   <div>
     <div>
       {% assign feature_obj = site.featured_media | where: 'page_path', 'our-best-content' | first %}
-      {% assign best_content = feature_obj.entries | get_docs %}
-      {% for item in best_content %}
+      {% assign best_content = feature_obj.entries %}
+      {% for content in best_content %}
+      {% assign item = content | get_doc %}
       {% assign image = item.image.url %}
       {% if item.content_type == 'episode' %}
       {% assign image =item.podcast.image.url %}
       {% endif %}
-      {% if item.duration %} 
+      {% if item.duration %}
       {% assign format = 'short' %}
       {% endif %}
         <div>

--- a/_includes/home/_our-best-content.html
+++ b/_includes/home/_our-best-content.html
@@ -6,7 +6,7 @@
     <div>
       {% assign feature_obj = site.featured_media | where: 'page_path', 'our-best-content' | first %}
       {% assign best_content = feature_obj.entries %}
-      {% for content in best_content %}
+      {% for content in best_content limit: 3 %}
       {% assign item = content | get_doc %}
       {% assign image = item.image.url %}
       {% if item.content_type == 'episode' %}

--- a/_includes/home/_our-best-content.html
+++ b/_includes/home/_our-best-content.html
@@ -18,7 +18,7 @@
         <div>
           <div class="border-top border-dashed push-half-bottom"></div>
           <crds-media-object
-          url="{{ item.slug }}"
+          url="{{ item | media_url }}"
           image-src="{{ image | imgix: site.imgix }}?{{ site.imgix_params.placeholder }}"
           type="{{ item.content_type }}"
           title="{{ item.title }}"


### PR DESCRIPTION
## Problem
1. I was told that we display only 3 featured best content items, but I am seeing as many as it's contentful - 6:
2. I should be able to change the order of the items in contentful, and front end should pick up the changed order, but it does not. See image above.
3. All links in that section taking me to oops pages, because they are not pointing to the right place. For example:
clicking/hovering on/around "handling depression..." article points to https://int.crossroads.net/handling-depression-how-to-keep-getting-up instead of https://int.crossroads.net/media/articles/handling-depression-how-to-keep-getting-up 
## Solution
[Preview](https://deploy-preview-1686--int-crds-net.netlify.app/)