### PR TITLE
DE7872: [rebrand] header doesn't reposition if smart app notification is dismissed on mobile

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -2,7 +2,7 @@
 <html lang="en">
 {% include _head.html %}
 
-<body class="crds-styles">
+<body class="crds-styles relative">
   {% include _gtm-body.html %}
   {% include _monetate-body.html %}
   <script>


### PR DESCRIPTION
In Chrome on iOS the Smart App Banner (banner to download the app) does not appear instead there is a blanks space at the top of the page. This PR adjusts the position of the body to be relative which resolves the issue.

- [List of Links](https://dh-test.netlify.app/de7872-links/) (This is all of the links on the preview. Check as many as you'd like.)
- [Rally](https://rally1.rallydev.com/#/66096747656d/custom/24109743995?detail=%2Fdefect%2F400204708412)
- [Preview](https://deploy-preview-1697--int-crds-net.netlify.app/)