### PR TITLE
Resolves double scroll and repositions parralax images

### DIFF
--- a/_assets/stylesheets/pages/_kids-club.scss
+++ b/_assets/stylesheets/pages/_kids-club.scss
@@ -74,7 +74,7 @@
   height: auto;
   position: absolute;
   left: 69%;
-  top: 108%;
+  top: 118%;
   width: 30%;
   z-index: 1;
   transform: translateZ(0.25px) scale(0.75) translateX(8%) translateY(-184%) rotate(0deg);
@@ -90,7 +90,7 @@
   height: auto;
   position: absolute;
   left: -3%;
-  top: 97%;
+  top: 104%;
   width: 40%;
   z-index: 1;
   transform: translateZ(0.25px) scale(0.75) translateX(-4%) translateY(-237%) rotate(0deg);
@@ -106,7 +106,7 @@
   height: auto;
   position: absolute;
   left: 69%;
-  top: 50%;
+  top: 45%;
   width: 30%;
   z-index: 1;
   transform: translateZ(0.25px) scale(0.75) translateX(5.7%) translateY(-97.1%) rotate(0deg);
@@ -122,7 +122,7 @@
   height: auto;
   position: absolute;
   left: -3%;
-  top: 50%;
+  top: 62%;
   width: 40%;
   z-index: 1;
   transform: translateZ(0.25px) scale(0.75) translateX(-4%) translateY(-270%) rotate(0deg);

--- a/_assets/stylesheets/pages/_kids-club.scss
+++ b/_assets/stylesheets/pages/_kids-club.scss
@@ -3,9 +3,9 @@
   padding:0;
   perspective: 1px;
   transform-style: preserve-3d;
-  height: 100vh;
-  overflow-y: scroll;
-  overflow-x: hidden;
+  height: auto;
+  overflow-y: auto;
+  overflow-x: auto;
     @media screen and (max-width: $screen-sm-min) {
     perspective: none;
     transform-style: flat;
@@ -74,7 +74,7 @@
   height: auto;
   position: absolute;
   left: 69%;
-  top: 70%;;
+  top: 108%;
   width: 30%;
   z-index: 1;
   transform: translateZ(0.25px) scale(0.75) translateX(8%) translateY(-184%) rotate(0deg);
@@ -90,7 +90,7 @@
   height: auto;
   position: absolute;
   left: -3%;
-  top: 80%;
+  top: 97%;
   width: 40%;
   z-index: 1;
   transform: translateZ(0.25px) scale(0.75) translateX(-4%) translateY(-237%) rotate(0deg);
@@ -106,7 +106,7 @@
   height: auto;
   position: absolute;
   left: 69%;
-  top: 52%;
+  top: 50%;
   width: 30%;
   z-index: 1;
   transform: translateZ(0.25px) scale(0.75) translateX(5.7%) translateY(-97.1%) rotate(0deg);
@@ -122,7 +122,7 @@
   height: auto;
   position: absolute;
   left: -3%;
-  top: 95%;
+  top: 50%;
   width: 40%;
   z-index: 1;
   transform: translateZ(0.25px) scale(0.75) translateX(-4%) translateY(-270%) rotate(0deg);

--- a/_assets/stylesheets/pages/_kids-club.scss
+++ b/_assets/stylesheets/pages/_kids-club.scss
@@ -90,7 +90,7 @@
   height: auto;
   position: absolute;
   left: -3%;
-  top: 104%;
+  top: 98%;
   width: 40%;
   z-index: 1;
   transform: translateZ(0.25px) scale(0.75) translateX(-4%) translateY(-237%) rotate(0deg);
@@ -122,7 +122,7 @@
   height: auto;
   position: absolute;
   left: -3%;
-  top: 62%;
+  top: 58%;
   width: 40%;
   z-index: 1;
   transform: translateZ(0.25px) scale(0.75) translateX(-4%) translateY(-270%) rotate(0deg);


### PR DESCRIPTION
## Problem
An `overflow-y: scroll` on `kc-body` was causing a double scrollbar on Chrome using Windows 10. 
[Rally](https://rally1.rallydev.com/#/66096747656ud/custom/24109743995?detail=%2Fdefect%2F403385612096&fdp=true)

<img width="986" alt="Screen Shot 2020-07-16 at 11 21 08 AM" src="https://user-images.githubusercontent.com/57996315/87689643-77d84b00-c756-11ea-9251-e51e0c858847.png">

## Solution
Changed `overflow-x:` and `overflow-y:` to `auto` and repositioned images. 

## Testing
Cannot duplicate on Mac, can only duplicate using BrowserStack. 
