### PR TITLE
US19915 Skeleton Blocks

### DIFF
--- a/_assets/stylesheets/components/_skeletons.scss
+++ b/_assets/stylesheets/components/_skeletons.scss
@@ -24,3 +24,59 @@
     min-height: 600px;
   }
 }
+
+.portrait-card-skeleton {
+  background-image: url("//crds-media.imgix.net/NtEw63mc0zMg1KgHR54mU/26d1fdb3b231adea5c05fdab6f50e6a5/crds-default-portrait_2x.png");
+  background-size: cover;
+  height: 475px;
+  width: 100%;
+}
+
+.portrait-card-skeleton-expanded {
+  background-image: url("//crds-media.imgix.net//1kVyOSybVmWHahTVBVGC8C/ec04181023ba67c69b19a8e5147dd575/crds-default-portrait-expanded_2x.png");
+  background-size: cover;
+  height: 525px;
+  width: 100%;
+}
+
+.portrait-card-skeleton-condensed {
+  background-image: url("//crds-media.imgix.net/3rI53Z36hF1Ij5vEMYqYEP/55d4f5ec9833746bbdc49e7bf42890df/crds-default-portrait-condensed_2x.png");
+  background-size: cover;
+  height: 345px;
+  width: 100%;
+}
+
+.jumbotron-skeleton-sm {
+  background-image: url("http://crds-media.imgix.net/6qe48AYpAzG5pzLngf1adG/194c229a6464fed299cb62dcc8a6956f/crds-jumbotron_2x.png");
+  background-size: cover;
+  height: 300px;
+  width: 100%;
+}
+
+.jumbotron-skeleton-md {
+  background-image: url("http://crds-media.imgix.net/6qe48AYpAzG5pzLngf1adG/194c229a6464fed299cb62dcc8a6956f/crds-jumbotron_2x.png");
+  background-size: cover;
+  height: 400px;
+  width: 100%;
+}
+
+.jumbotron-skeleton-lg {
+  background-image: url("http://crds-media.imgix.net/6qe48AYpAzG5pzLngf1adG/194c229a6464fed299cb62dcc8a6956f/crds-jumbotron_2x.png");
+  background-size: cover;
+  height: 500px;
+  width: 100%;
+}
+
+.jumbotron-skeleton-xl {
+  background-image: url("http://crds-media.imgix.net/6qe48AYpAzG5pzLngf1adG/194c229a6464fed299cb62dcc8a6956f/crds-jumbotron_2x.png");
+  background-size: cover;
+  height: 600px;
+  width: 100%;
+}
+
+.media-object-skeleton {
+  background-image: url("//crds-media.imgix.net/6XakpZ9C0Yrt3660Lgfj3O/81cf020e8800de68026be898d4109984/crds-media-object_2x.png");
+  background-size: cover;
+  height: 100px;
+  width: 100%;
+}

--- a/_assets/stylesheets/components/_skeletons.scss
+++ b/_assets/stylesheets/components/_skeletons.scss
@@ -80,3 +80,10 @@
   height: 100px;
   width: 100%;
 }
+
+.media-card-skeleton {
+  background-image: url("//crds-media.imgix.net/5uZardmgimcesyv7xdkAMw/cbccdd4b456cb407c07c4cf08a40c2c9/crds-media-card-grid-small_2x.png");
+  background-size: cover;
+  height: 350px;
+  width: 100%;
+}

--- a/test.html
+++ b/test.html
@@ -1,0 +1,88 @@
+---
+layout: container-fluid
+---
+<section class="jumbotron-skeleton-xl">
+  <crds-jumbotron inline-video-src="https://www.youtube.com/embed/jTtFrLl17aM" video-src="https://videos.ctfassets.net/y3a9myzsdjan/61UX4j16LJ4i6Hul1obi2Z/02c4498b9d0c1ef87fb7767fbfcaed54/spiritual-outfitters-loop.mp4" size="xl" >
+    <div class="container">
+      <div class="row">
+        <div class="col-sm-10 col-sm-offset-1">
+          <div class="jumbotron-content">
+            <div class="jumbotron-home-header">
+              <h2 class="font-family-condensed-extra text-uppercase flush-bottom text-tan">You were</h2>
+              <h1 class="font-family-condensed-extra text-uppercase flush-top text-tan">Born For Adventure</h1>
+            </div>
+            <p class="font-family-serif soft-half-top">
+              You were born to make a difference. Designed to partner with God to change the world for good. If that sounds like your type of adventure, Crossroads is your <a class="text-orange" href="/spiritual-outfitters">spiritual outfitter.</a>
+            </p>
+            <div class="row">
+              <a href="/30-day-trial" class="btn btn-orange"><strong>Start your adventure - 30 Day Trial</strong></a>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </crds-jumbotron>
+</section>
+<div class="container">
+  <div class="row push-ends">
+    <div class="col-sm-4">
+     <div class="portrait-card-skeleton" data-optimize-bg-img>
+      <crds-portrait-card theme="default" href="#" lead="Derp" title="Derpity Derp" bg-overlay="true" image-src="//crds-media.imgix.net/3JkzXblF0KxdBpXp4CbPRl/227dc944ff29c3881480fe84187b6515/crossroads-brian.jpg?h=250"></crds-portrait-card>
+     </div>
+    </div>
+    <div class="col-sm-4">
+      <div class="portrait-card-skeleton-expanded" data-optimize-bg-img>
+        <crds-portrait-card theme="expanded" href="#" lead="Derp" title="Derpity Derp" bg-overlay="true" image-src="//crds-media.imgix.net/3JkzXblF0KxdBpXp4CbPRl/227dc944ff29c3881480fe84187b6515/crossroads-brian.jpg?h=250">
+          <p>
+            Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
+            eiusmod tempor incididunt ut labore et dolore magna aliqua.
+            Ut enim ad minim veniam, quis nostrud exercitation ullamco
+          </p>
+          <crds-button type="primary" color="blue" href='#' text='Click me!'></crds-button>
+        </crds-portrait-card>
+       </div>
+    </div>
+    <div class="col-sm-4">
+      <div class="portrait-card-skeleton-condensed" data-optimize-bg-img>
+        <crds-portrait-card theme="condensed" href="#" lead="Derp" title="Derpity Derp" bg-overlay="true" image-src="//crds-media.imgix.net/3JkzXblF0KxdBpXp4CbPRl/227dc944ff29c3881480fe84187b6515/crossroads-brian.jpg?h=250"></crds-portrait-card>
+      </div>
+    </div>
+  </div>
+
+  <div class="row push-ends">
+    <div class="col-sm-4">
+      <div class="media-object-skeleton">
+        <crds-media-object
+        url="/media/podcasts/the-aggressive-life-with-brian-tome/mark-burnett-producer-of-survivor-and-shark-tank"
+        image-src="https://crds-media.imgix.net/23MkUegs3aTxmKBzzUzDfF/c84f63a4c022c2963c803801a53e4d92/AggressiveLife_podcast_artwork.jpg?auto=format,compress&w=80&h=80&fit=crop&ixlib=imgixjs-3.3.2"
+        type="episode"
+        title="Mark Burnett - Producer of Survivor & Shark Tank"
+        duration="28 min">
+    </crds-media-object>
+      </div>
+    </div>
+    <div class="col-sm-4">
+      <div class="media-object-skeleton">
+        <crds-media-object
+        url="/media/podcasts/the-aggressive-life-with-brian-tome/mark-burnett-producer-of-survivor-and-shark-tank"
+        image-src="https://crds-media.imgix.net/23MkUegs3aTxmKBzzUzDfF/c84f63a4c022c2963c803801a53e4d92/AggressiveLife_podcast_artwork.jpg?auto=format,compress&w=80&h=80&fit=crop&ixlib=imgixjs-3.3.2"
+        type="episode"
+        title="Mark Burnett - Producer of Survivor & Shark Tank"
+        duration="28 min">
+    </crds-media-object>
+      </div>
+    </div>
+    <div class="col-sm-4">
+      <div class="media-object-skeleton">
+        <crds-media-object
+        url="/media/podcasts/the-aggressive-life-with-brian-tome/mark-burnett-producer-of-survivor-and-shark-tank"
+        image-src="https://crds-media.imgix.net/23MkUegs3aTxmKBzzUzDfF/c84f63a4c022c2963c803801a53e4d92/AggressiveLife_podcast_artwork.jpg?auto=format,compress&w=80&h=80&fit=crop&ixlib=imgixjs-3.3.2"
+        type="episode"
+        title="Mark Burnett - Producer of Survivor & Shark Tank"
+        duration="28 min">
+    </crds-media-object>
+      </div>
+    </div>
+   
+  </div>
+</div>

--- a/test.html
+++ b/test.html
@@ -23,6 +23,7 @@ layout: container-fluid
     </div>
   </crds-jumbotron>
 </section>
+
 <div class="container">
   <div class="row push-ends">
     <div class="col-sm-4">
@@ -49,40 +50,69 @@ layout: container-fluid
     </div>
   </div>
 
+  <div class="row push-ends soft-ends">
+    <div class="col-sm-4">
+      <div class="media-object-skeleton">
+        <crds-media-object
+        url="/media/podcasts/the-aggressive-life-with-brian-tome/mark-burnett-producer-of-survivor-and-shark-tank"
+        image-src="https://crds-media.imgix.net/23MkUegs3aTxmKBzzUzDfF/c84f63a4c022c2963c803801a53e4d92/AggressiveLife_podcast_artwork.jpg?auto=format,compress&w=80&h=80&fit=crop&ixlib=imgixjs-3.3.2"
+        type="episode"
+        title="Mark Burnett - Producer of Survivor & Shark Tank"
+        duration="28 min">
+    </crds-media-object>
+      </div>
+    </div>
+    <div class="col-sm-4">
+      <div class="media-object-skeleton">
+        <crds-media-object
+        url="/media/podcasts/the-aggressive-life-with-brian-tome/mark-burnett-producer-of-survivor-and-shark-tank"
+        image-src="https://crds-media.imgix.net/23MkUegs3aTxmKBzzUzDfF/c84f63a4c022c2963c803801a53e4d92/AggressiveLife_podcast_artwork.jpg?auto=format,compress&w=80&h=80&fit=crop&ixlib=imgixjs-3.3.2"
+        type="episode"
+        title="Mark Burnett - Producer of Survivor & Shark Tank"
+        duration="28 min">
+    </crds-media-object>
+      </div>
+    </div>
+    <div class="col-sm-4">
+      <div class="media-object-skeleton">
+        <crds-media-object
+        url="/media/podcasts/the-aggressive-life-with-brian-tome/mark-burnett-producer-of-survivor-and-shark-tank"
+        image-src="https://crds-media.imgix.net/23MkUegs3aTxmKBzzUzDfF/c84f63a4c022c2963c803801a53e4d92/AggressiveLife_podcast_artwork.jpg?auto=format,compress&w=80&h=80&fit=crop&ixlib=imgixjs-3.3.2"
+        type="episode"
+        title="Mark Burnett - Producer of Survivor & Shark Tank"
+        duration="28 min">
+    </crds-media-object>
+      </div>
+    </div>
+
   <div class="row push-ends">
     <div class="col-sm-4">
-      <div class="media-object-skeleton">
-        <crds-media-object
-        url="/media/podcasts/the-aggressive-life-with-brian-tome/mark-burnett-producer-of-survivor-and-shark-tank"
-        image-src="https://crds-media.imgix.net/23MkUegs3aTxmKBzzUzDfF/c84f63a4c022c2963c803801a53e4d92/AggressiveLife_podcast_artwork.jpg?auto=format,compress&w=80&h=80&fit=crop&ixlib=imgixjs-3.3.2"
-        type="episode"
-        title="Mark Burnett - Producer of Survivor & Shark Tank"
-        duration="28 min">
-    </crds-media-object>
+      <div class="media-card-skeleton">
+        <crds-media-card heading="Game of thrones" icon-label="5 min" meta="10/19/19 - 10/25/19" category="Example" thumbnail-src="https://crossroads-media.imgix.net/images/crds-music/jumbotron/music-laying-it-all-down-bg.jpg?format=auto,compress" image-src="https://crds-media.imgix.net/4CWCvxN6iSb0QXDqvaT9Gt/a80cfd9a0b8154874777cbd71da59175/shutterstock_403980601.jpg?auto=format,compress" url="#" content-type="article">
+          <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco Lorem ipsum...</p>
+          <crds-button type="primary" color="blue" href="#" text="Click me!" ></crds-button>
+          </crds-media-card>
       </div>
     </div>
+
     <div class="col-sm-4">
-      <div class="media-object-skeleton">
-        <crds-media-object
-        url="/media/podcasts/the-aggressive-life-with-brian-tome/mark-burnett-producer-of-survivor-and-shark-tank"
-        image-src="https://crds-media.imgix.net/23MkUegs3aTxmKBzzUzDfF/c84f63a4c022c2963c803801a53e4d92/AggressiveLife_podcast_artwork.jpg?auto=format,compress&w=80&h=80&fit=crop&ixlib=imgixjs-3.3.2"
-        type="episode"
-        title="Mark Burnett - Producer of Survivor & Shark Tank"
-        duration="28 min">
-    </crds-media-object>
+      <div class="media-card-skeleton">
+        <crds-media-card heading="Game of thrones" icon-label="5 min" meta="10/19/19 - 10/25/19" category="Example" thumbnail-src="https://crossroads-media.imgix.net/images/crds-music/jumbotron/music-laying-it-all-down-bg.jpg?format=auto,compress" image-src="https://crds-media.imgix.net/4CWCvxN6iSb0QXDqvaT9Gt/a80cfd9a0b8154874777cbd71da59175/shutterstock_403980601.jpg?auto=format,compress" url="#" content-type="article">
+          <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco Lorem ipsum...</p>
+          <crds-button type="primary" color="blue" href="#" text="Click me!" ></crds-button>
+          </crds-media-card>
       </div>
     </div>
+
     <div class="col-sm-4">
-      <div class="media-object-skeleton">
-        <crds-media-object
-        url="/media/podcasts/the-aggressive-life-with-brian-tome/mark-burnett-producer-of-survivor-and-shark-tank"
-        image-src="https://crds-media.imgix.net/23MkUegs3aTxmKBzzUzDfF/c84f63a4c022c2963c803801a53e4d92/AggressiveLife_podcast_artwork.jpg?auto=format,compress&w=80&h=80&fit=crop&ixlib=imgixjs-3.3.2"
-        type="episode"
-        title="Mark Burnett - Producer of Survivor & Shark Tank"
-        duration="28 min">
-    </crds-media-object>
+      <div class="media-card-skeleton">
+        <crds-media-card heading="Game of thrones" icon-label="5 min" category="Example" thumbnail-src="https://crossroads-media.imgix.net/images/crds-music/jumbotron/music-laying-it-all-down-bg.jpg?format=auto,compress" image-src="https://crds-media.imgix.net/4CWCvxN6iSb0QXDqvaT9Gt/a80cfd9a0b8154874777cbd71da59175/shutterstock_403980601.jpg?auto=format,compress" url="#" content-type="article"></crds-media-card>
+      </div>
+      <div class="media-card-skeleton">
+        <crds-media-card heading="Game of thrones" icon-label="5 min" category="Example" thumbnail-src="https://crossroads-media.imgix.net/images/crds-music/jumbotron/music-laying-it-all-down-bg.jpg?format=auto,compress" image-src="https://crds-media.imgix.net/4CWCvxN6iSb0QXDqvaT9Gt/a80cfd9a0b8154874777cbd71da59175/shutterstock_403980601.jpg?auto=format,compress" url="#" content-type="article"></crds-media-card>
       </div>
     </div>
-   
+
+   </div>
   </div>
 </div>


### PR DESCRIPTION
## Spike
Look into ways to load skeleton blocks onto pages to create efficiencies in updating templates once skeleton blocks are created
 ## Solution
First I went down the path of using [animated SVGs](https://github.com/crdschurch/crds-net/pull/1729). I then wanted it to be easier for developers to implement a skeleton block. Before you would have to wrap the component in a div, add a skeleton class and then add the svg which were becoming large. I decided to make the skeleton blocks PNGs to simplify the implementation and have less room for error. 
[Preview](https://deploy-preview-1736--int-crds-net.netlify.app/test/)