### PR TITLE
Redirects Health Check

### DIFF
--- a/_plugins/netlify-plugin-health-check/index.js
+++ b/_plugins/netlify-plugin-health-check/index.js
@@ -1,0 +1,16 @@
+module.exports = {
+  async onPostBuild({ utils: { run, build } }) {
+    try {
+      let idxCheck = await run("./bin/health-check.sh", [
+        "_site/index.html",
+        "we are crossroads",
+      ]);
+      let redirCheck = await run("./bin/health-check.sh", [
+        "_site/_redirects",
+        "/*	/404.html	404",
+      ]);
+    } catch (e) {
+      return build.failBuild(e.stdout);
+    }
+  },
+};

--- a/_plugins/netlify-plugin-health-check/index.js
+++ b/_plugins/netlify-plugin-health-check/index.js
@@ -1,11 +1,11 @@
 module.exports = {
   async onPostBuild({ utils: { run, build } }) {
     try {
-      let idxCheck = await run("./bin/health-check.sh", [
+      await run("./bin/health-check.sh", [
         "_site/index.html",
         "we are crossroads",
       ]);
-      let redirCheck = await run("./bin/health-check.sh", [
+      await run("./bin/health-check.sh", [
         "_site/_redirects",
         "/*	/404.html	404",
       ]);

--- a/_plugins/netlify-plugin-health-check/manifest.yml
+++ b/_plugins/netlify-plugin-health-check/manifest.yml
@@ -1,0 +1,1 @@
+name: netlify-plugin-health-check

--- a/bin/build-command.sh
+++ b/bin/build-command.sh
@@ -6,7 +6,6 @@
   bundle exec jekyll contentful --sites www.crossroads.net -f &&
   bundle exec jekyll build -- --update-search-index &&
   ./bin/prerenderio-bust.sh &&
-  ./bin/health-check.sh "we are crossroads" &&
   ./bin/kickOffCypress.sh
 } 2>buildlog.txt
 ./bin/logzio.sh

--- a/bin/health-check.sh
+++ b/bin/health-check.sh
@@ -1,18 +1,25 @@
 #!/bin/bash
 set -e
-PATH_TO_FILE='./_site/index.html'
 
 if [ $# -eq 0 ]
 then
+  echo "Please specify file to search"
+else
+  PATH_TO_FILE=$1
+fi
+
+if [ $# -eq 1 ]
+then
   echo "Please specify argument containing string to search for."
 else
-  NEEDLE=$1
+  NEEDLE=$2
 fi
 
 if grep -Fq "$NEEDLE" $PATH_TO_FILE
 then
+  echo "\"${NEEDLE}\" is present in ${PATH_TO_FILE}"
   exit 0
 else
-  echo "${NEEDLE} not found in ${PATH_TO_FILE}"
+  echo "\"${NEEDLE}\" not found in ${PATH_TO_FILE}"
   exit 1
 fi

--- a/netlify.toml
+++ b/netlify.toml
@@ -18,6 +18,9 @@ package = "@helloample/netlify-plugin-redirects"
     destination = "./_site/_redirects"
     defaultBranch = "development"
 
+[[plugins]]
+package = "./_plugins/netlify-plugin-health-check"
+
 [context.branch-deploy.environment]
   CRDS_PEOPLE_DOMAIN = "people-int.crossroads.net"
   CRDS_MAP_DOMAIN = "connect-int.crossroads.net"

--- a/package-lock.json
+++ b/package-lock.json
@@ -897,9 +897,9 @@
       }
     },
     "@helloample/netlify-plugin-redirects": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@helloample/netlify-plugin-redirects/-/netlify-plugin-redirects-1.2.0.tgz",
-      "integrity": "sha512-XXzoUA0XYBB9lW3g+eBYnsnS6Pnda+37JUSmsBKf+jb0gO03/PyAc9AdZHZzomED2XYKt9ZLrHbptOHJPBdYfQ==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@helloample/netlify-plugin-redirects/-/netlify-plugin-redirects-1.3.0.tgz",
+      "integrity": "sha512-xHU9v2M6NbNgtQLdAy/BCSDac0erD/KA3yW5b/JIcIPF4sAuOixfboihggmN9XwPW5tEfKX4BA59ZmKXkBAocQ==",
       "dev": true,
       "requires": {
         "csvtojson": "^2.0.10",
@@ -1531,7 +1531,8 @@
         },
         "kind-of": {
           "version": "6.0.2",
-          "resolved": "",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+          "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
           "dev": true
         }
       }
@@ -2832,7 +2833,6 @@
           }
         },
         "yargs": {
-
           "version": "15.4.0",
           "resolved": "https://registry.npmjs.org/yargs/-/yargs-15.4.0.tgz",
           "integrity": "sha512-D3fRFnZwLWp8jVAAhPZBsmeIHY8tTsb8ItV9KaAaopmC6wde2u6Yw29JBIZHXw14kgkRnYmDgmQU4FVMDlIsWw==",
@@ -4193,12 +4193,6 @@
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
       "dev": true
     },
-    "emoji-regex": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-      "dev": true
-    },
     "emojic": {
       "version": "1.1.15",
       "resolved": "https://registry.npmjs.org/emojic/-/emojic-1.1.15.tgz",
@@ -4687,7 +4681,8 @@
         },
         "kind-of": {
           "version": "6.0.2",
-          "resolved": "",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+          "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
           "dev": true
         }
       }
@@ -4713,19 +4708,13 @@
             "ms": "2.0.0"
           }
         },
-        "minimist": {
-          "version": "0.0.8",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
-          "dev": true
-        },
         "mkdirp": {
-          "version": "0.5.1",
-          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-          "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+          "version": "0.5.5",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
+          "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
           "dev": true,
           "requires": {
-            "minimist": "0.0.8"
+            "minimist": "^1.2.5"
           }
         },
         "ms": {
@@ -10104,7 +10093,8 @@
         },
         "kind-of": {
           "version": "6.0.2",
-          "resolved": "",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+          "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
           "dev": true
         }
       }

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   "devDependencies": {
     "@babel/core": "^7.2.0",
     "@babel/preset-env": "^7.2.0",
-    "@helloample/netlify-plugin-redirects": "1.2.0",
+    "@helloample/netlify-plugin-redirects": "1.3.0",
     "bootstrap-sass": "^3.4.0",
     "contentful-cli": "^0.28.0",
     "crds-cypress-config": "^1.0.1",


### PR DESCRIPTION
## Problem
Last night we had a deployment succeed with a zero-length `_redirects` file which broke a bunch of stuff in production. While this is the first time we've seen this issue and it hasn't occurred since, we'd like to build greater confidence prior to deployment and ensure this doesn't happen again. 

## Solution
This PR does a few things to address this issue...

1. Refactors the existing health-check script we were using to check the length of `index.html`
2. Updates the plugin responsible for generating `_redirects` so it runs immediately following the primary build command
3. Moves the health-check from the primary build command to a plugin so it runs during the `onPostBuild` event 

You should now see the following output in the build logs, which indicates the presence of critical strings in the `index.html` and `_redirects` file... 

<img width="623" alt="Screen Shot 2020-08-24 at 8 40 08 AM" src="https://user-images.githubusercontent.com/50378/91045885-86cbdc00-e5e5-11ea-81c7-818589f74eb0.png"> 

If either of these values are not found, the build will fail.

### Corresponding Branch
This PR is identical to crdschurch/crds-net#1781 which targets the `master` branch.