### PR TITLE
USXXXXX Remove FB Watch with us btn

### DIFF
--- a/_layouts/location.html
+++ b/_layouts/location.html
@@ -71,7 +71,6 @@ layout: default
               <br />
               {{ page.service_times | markdownify | remove: '<p>'| remove: '</p>' }}
             </p>
-            <crds-button color="orange" text="Watch with us" href="https://www.facebook.com/crsrds{{ page.slug }}" icon="facebook" icon-color="blue-dark" icon-align="left" icon-size="16"></crds-button>
           </div>
           <div class="col-sm-6">
             <p>


### PR DESCRIPTION
## Problem
Removes the facebook watch with us button on location pages

## Solution
[Preview](https://deploy-preview-1815--int-crds-net.netlify.app/oakley)
