### PR TITLE
DE8070 Online Groups

### DIFF
--- a/redirects.csv
+++ b/redirects.csv
@@ -123,6 +123,7 @@ https://discipleship.crossroads.net/*,https://www.crossroads.net/huddle,301!,mas
 /media/songs/*,${env:CRDS_MUSIC_ENDPOINT}/:splat,302!
 /media/*,https://${env:CRDS_MEDIA_ENDPOINT}/:splat,200!
 /onsitegroups,/groups/onsite,301!
+/groups/onsite/:group/anywhere,/groups/onsite/:group/online,301!
 /groups/online,/connect/?refinementList%5BgroupType%5D%5B0%5D=Online,301!
 /groups/home,/connect/?refinementList%5BgroupType%5D%5B0%5D=At%20Home,301!
 /groups/at-home,/connect/?refinementList%5BgroupType%5D%5B0%5D=At%20Home,301!


### PR DESCRIPTION
## Problem
There are some links for online groups in the wild that are directing users to 404s. 

## Solution
Redirect users to correct path. 