### PR TITLE
DE8070 Online Groups

### DIFF
--- a/_layouts/onsite-group-location.html
+++ b/_layouts/onsite-group-location.html
@@ -37,7 +37,7 @@ snail_trail: connect
       <h4 class="font-family-condensed-extra text-uppercase">
         {% assign group = meeting | group_for_meeting %}
         {% if group %}
-        <a href="/groups/onsite/{{ group.slug }}/{{ meeting.location.slug }}">
+        <a href="/groups/onsite/{{ group.slug }}/{% if meeting.location.slug == 'anywhere' %}online{% else %}{{ meeting.location.slug }}{% endif %}">
           {{ meeting.title }}
         </a>
         {% else %}


### PR DESCRIPTION
## Problem
There are some links for online groups in the wild that are directing users to 404s. 

## Solution
This PR addresses root cause and updates the incorrect paths so we're not relying on the redirects introduced in #1893 