### PR TITLE
Kill travis

### DIFF
--- a/.github/workflows/run.cypress.yml
+++ b/.github/workflows/run.cypress.yml
@@ -22,4 +22,3 @@ jobs:
           CYPRESS_RECORD_KEY: ${{ secrets.CYPRESS_RECORD_KEY }}
           VAULT_ROLE_ID: ${{ secrets.VAULT_ROLE_ID }}
           VAULT_SECRET_ID: ${{ secrets.VAULT_SECRET_ID }}
-          IN_RUNNER: true

--- a/.github/workflows/run.cypress.yml
+++ b/.github/workflows/run.cypress.yml
@@ -6,6 +6,8 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
+      matrix:
+        containers: [1,2,3,4,5]
     steps:
       - name: Checkout
         uses: actions/checkout@v1

--- a/.github/workflows/run.cypress.yml
+++ b/.github/workflows/run.cypress.yml
@@ -20,3 +20,5 @@ jobs:
           config-file: cypress/config/int_crossroads.json
         env:
           CYPRESS_RECORD_KEY: ${{ secrets.CYPRESS_RECORD_KEY }}
+          VAULT_ROLE_ID: ${{ secrets.VAULT_ROLE_ID }}
+          VAULT_SECRET_ID: ${{ secrets.VAULT_SECRET_ID }}

--- a/.github/workflows/run.cypress.yml
+++ b/.github/workflows/run.cypress.yml
@@ -22,3 +22,4 @@ jobs:
           CYPRESS_RECORD_KEY: ${{ secrets.CYPRESS_RECORD_KEY }}
           VAULT_ROLE_ID: ${{ secrets.VAULT_ROLE_ID }}
           VAULT_SECRET_ID: ${{ secrets.VAULT_SECRET_ID }}
+          IN_RUNNER: true

--- a/.github/workflows/run.cypress.yml
+++ b/.github/workflows/run.cypress.yml
@@ -1,5 +1,5 @@
 name: Cypress Tests
-on: [push, pull_request]
+on: [pull_request]
 jobs:
   test:
     name: Cypress Run

--- a/.github/workflows/run.cypress.yml
+++ b/.github/workflows/run.cypress.yml
@@ -6,8 +6,6 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
-      matrix:
-        containers: [1,2,3,4,5]
     steps:
       - name: Checkout
         uses: actions/checkout@v1

--- a/.github/workflows/run.cypress.yml
+++ b/.github/workflows/run.cypress.yml
@@ -1,5 +1,5 @@
 name: Cypress Tests
-on: [push, pull-request]
+on: [push, pull_request]
 jobs:
   test:
     name: Cypress Run

--- a/.github/workflows/run.cypress.yml
+++ b/.github/workflows/run.cypress.yml
@@ -1,5 +1,5 @@
 name: Cypress Tests
-on: [push]
+on: [push, pull-request]
 jobs:
   test:
     name: Cypress Run

--- a/.github/workflows/run.cypress.yml
+++ b/.github/workflows/run.cypress.yml
@@ -1,0 +1,24 @@
+name: Cypress Tests
+on: [push]
+jobs:
+  test:
+    name: Cypress Run
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        containers: [1,2,3,4,5]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v1
+      - name: Cypress run
+        uses: cypress-io/github-action@v2
+        with:
+          record: true
+          parallel: true
+          group: crds-net-parallel
+          browser: chrome
+          headless: true
+          config-file: cypress/config/int_crossroads.json
+        env:
+          CYPRESS_RECORD_KEY: ${{ secrets.CYPRESS_RECORD_KEY }}

--- a/cypress/plugins/index.js
+++ b/cypress/plugins/index.js
@@ -18,8 +18,7 @@ const { addContentfulTasks } = require('./contentfulTasks');
 //Config files live in /config. To specify which one to use, open or run with command line argument:
 //"--config-file ./cypress/config/int_crossroads.json"
 module.exports = (on, config) => {
-  githubAction = process.env.IN_RUNNER
-  return loadConfig.loadConfigFromVault(config, githubAction)
+  return loadConfig.loadConfigFromVault(config)
     .then((newConfig) => {
       // Configure blacklisted hosts
       manageBlacklist(newConfig);

--- a/cypress/plugins/index.js
+++ b/cypress/plugins/index.js
@@ -18,7 +18,8 @@ const { addContentfulTasks } = require('./contentfulTasks');
 //Config files live in /config. To specify which one to use, open or run with command line argument:
 //"--config-file ./cypress/config/int_crossroads.json"
 module.exports = (on, config) => {
-  return loadConfig.loadConfigFromVault(config)
+  githubAction = process.env.IN_RUNNER
+  return loadConfig.loadConfigFromVault(config, githubAction)
     .then((newConfig) => {
       // Configure blacklisted hosts
       manageBlacklist(newConfig);


### PR DESCRIPTION
Converting cypress tests to run on PR and in github actions. We can kill the Travis builds off completely