### PR TITLE
DE8105 Onsite Group Links

### DIFF
--- a/_includes/groups/_meeting-details.html
+++ b/_includes/groups/_meeting-details.html
@@ -14,7 +14,7 @@
   {% endif %}
 </p>
 <p class="push-top font-size-smaller">
-  <a href="{{ meeting.registration_link }}">Learn more</a>
+  <a href="/groups/onsite/{{ group_slug.slug }}/{% if meeting.location.slug == 'anywhere' %}online{% else %}{{ meeting.location.slug }}{% endif %}">Learn more</a>
   {% if meeting.registration_link %}
   <span class="push-half-sides">/</span><a href="{{ meeting.registration_link }}" type="button">Register</a>
   {% endif %}


### PR DESCRIPTION
## Task 
Fix learn more link
On the updated /groups/onsite/LOCATION pages (ex https://www.crossroads.net/groups/onsite/mason/), the "learn more" and "register" links below each group meeting instance should go to two different places. 

The "learn more" link should go to the meeting detail page (ex https://www.crossroads.net/groups/onsite/fathers/mason/)

The "register" link should go to the registration link defined in the meeting detail in contentful (ex https://www.crossroads.net/sign-up/fathers-pm-mason/) 

