### PR TITLE
US20479 Location Tab

### DIFF
--- a/_assets/stylesheets/pages/_onsite-group.scss
+++ b/_assets/stylesheets/pages/_onsite-group.scss
@@ -1,6 +1,6 @@
 .osg-location-card {
   @include make-sm-column(6);
-  @include make-md-column(3);
+  @include make-md-column(4);
 
   display: block;
   position: relative;
@@ -62,9 +62,20 @@
   }
 
   .osg-tabs {
-    text-align: center;
+    align-items: center;
     border: none;
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
     margin-top: 50px;
+    padding-bottom: 50px;
+    text-align: center;
+    white-space: nowrap;
+    
+    @media (min-width: $screen-sm) {
+      flex-direction: row;
+      padding-bottom: 0;
+    }
 
     > li {
       display: inline-block;
@@ -82,18 +93,17 @@
       }
 
       a {
-        padding: 0.25rem 1.25rem;
-        display: block;
         color: $cr-orange;
+        display: block;
         font-family: $condensed-extra-font-face;
+        font-size: 180%;
         font-weight: 300;
-        font-size: 140%;
+        padding: 0.25rem 1.25rem;
+        text-transform: uppercase;
 
-        @media only screen and (min-width: $screen-sm-min) {
+        @media (min-width: $screen-sm) {
           font-size: 200%;
         }
-
-        text-transform: uppercase;
       }
     }
   }

--- a/_includes/groups/_osg-tabs.html
+++ b/_includes/groups/_osg-tabs.html
@@ -1,0 +1,8 @@
+<ul class="nav nav-tabs osg-tabs">
+{% assign page_categories = page.categories | sort | reverse %}
+{% for category in page_categories %}
+  {% capture category_path %}/groups/{{ category.slug }}{% endcapture %}
+  <li class="{% if page.path == category_path %}active{% endif %}"><a href="{{ category_path }}">{{ category.title }}</a></li>
+{% endfor %}
+  <li class="{% if page.path == '/groups/locations' %}active{% endif %}"><a href="/groups/locations">By Location</a></li>
+</ul>

--- a/_layouts/location.html
+++ b/_layouts/location.html
@@ -12,6 +12,14 @@ layout: default
     {{ page.featured_section }}
   </div>
 {% endif %}
+<section>
+  <div class="container">
+    <div class="soft bg-black">
+      <div id="resi-video-player" data-embed-id="25ddacd0-8be8-4b31-9df0-f7064eb48437"></div>
+      <script type="application/javascript" src="https://control.resi.io/webplayer/loader.min.js"></script>
+    </div>
+  </div>
+</section>
 
 <!-- Jumbotron section -->
 <div class="jumbotron jumbotron-xl flush-bottom width-100" style="background-image: url('{{ page.bg_image.url | imgix: site.imgix }}?{{ site.imgix_params.placeholder }}')"

--- a/_layouts/location.html
+++ b/_layouts/location.html
@@ -12,14 +12,6 @@ layout: default
     {{ page.featured_section }}
   </div>
 {% endif %}
-<section>
-  <div class="container">
-    <div class="soft bg-black">
-      <div id="resi-video-player" data-embed-id="25ddacd0-8be8-4b31-9df0-f7064eb48437"></div>
-      <script type="application/javascript" src="https://control.resi.io/webplayer/loader.min.js"></script>
-    </div>
-  </div>
-</section>
 
 <!-- Jumbotron section -->
 <div class="jumbotron jumbotron-xl flush-bottom width-100" style="background-image: url('{{ page.bg_image.url | imgix: site.imgix }}?{{ site.imgix_params.placeholder }}')"

--- a/_layouts/onsite-groups/index.html
+++ b/_layouts/onsite-groups/index.html
@@ -17,14 +17,7 @@ snail_trail: connect
           </div>
         </div>
       </div>
-      <ul class="nav nav-tabs osg-tabs">
-      {% assign page_categories = page.categories | sort | reverse %}
-      {% for category in page_categories %}
-        {% capture category_path %}/groups/{{ category.slug }}{% endcapture %}
-        <li class="{% if page.path == category_path %}active{% endif %}"><a href="{{ category_path }}">{{ category.title }}</a></li>
-      {% endfor %}
-        <li class="{% if page.path == 'test' %}active{% endif %}"><a href="/groups/locations">By Location</a></li>
-      </ul>
+      {% include groups/_osg-tabs.html %}
     </div>
   </section>
 

--- a/_layouts/onsite-groups/index.html
+++ b/_layouts/onsite-groups/index.html
@@ -55,23 +55,4 @@ snail_trail: connect
       {% endfor %}
     </section>
   </main>
-
-  <section class="container push-ends" id="groups-by-location" id="locations">
-    <div class="row push-bottom">
-      <div class="col-md-8 col-md-offset-2 text-center">
-        {% content_block osg-locations-header %}
-      </div>
-    </div>
-    <div class="row">
-    {% assign locations = site['locations'] | locations_with_onsite_groups %}
-    {% for location in locations %}
-      <div class="osg-location-card">
-        <a href="/groups/onsite/{{ location.onsite_group_slug }}">
-          <span class="text-center text-white">{{ location.onsite_group_display_name }}</span>
-          <img class="img-responsive " src="{{ location.image.url | imgix: site.imgix }}?{{ site.imgix_params.placeholder_sixteen_nine }}" alt="{{ location.onsite_group_display_name }}" sizes="{{ site.image_sizes.one_fourth }}" data-optimize-img/>
-        </a>
-      </div>
-    {% endfor %}
-    </div>
-  </section>
 </div>

--- a/_layouts/onsite-groups/location-index.html
+++ b/_layouts/onsite-groups/location-index.html
@@ -17,15 +17,7 @@ snail_trail: connect
           </div>
         </div>
       </div>
-      <ul class="nav nav-tabs osg-tabs">
-      {% assign page_categories = page.categories | sort | reverse %}
-      {% for category in page_categories %}
-        {% capture category_path %}/groups/{{ category.slug }}{% endcapture %}
-        <li class="{% if page.path == category_path %}active{% endif %}"><a href="{{ category_path }}">{{ category.title }}</a></li>
-        {% endfor %}
-        <li class="{% if page.path != category_path %}active{% endif %}"><a href="/groups/locations">By Location</a></li>
-        
-      </ul>
+      {% include groups/_osg-tabs.html %}
     </div>
   </section>
 

--- a/_layouts/onsite-groups/location-index.html
+++ b/_layouts/onsite-groups/location-index.html
@@ -35,8 +35,9 @@ snail_trail: connect
         <div class="col-md-8 col-md-offset-2 text-center push-ends">We’re all about groups here and want you to have great friends. These are some of our groups that foucsed on building bonds and meeting likemind people.</div>
       </div>
     </section>
-    <section class="container bg-white soft-top">
-      <div class="row push-ends">
+
+    <section class="container bg-white soft-top push-bottom">
+      <div class="row row-no-gutters push-ends">
       {% assign locations = site['locations'] | locations_with_onsite_groups %}
       {% for location in locations %}
         <div class="osg-location-card">
@@ -49,23 +50,4 @@ snail_trail: connect
       </div>
     </section>
   </main>
-
-  <section class="container push-ends" id="groups-by-location" id="locations">
-    <div class="row push-bottom">
-      <div class="col-md-8 col-md-offset-2 text-center">
-        {% content_block osg-locations-header %}
-      </div>
-    </div>
-    <div class="row">
-    {% assign locations = site['locations'] | locations_with_onsite_groups %}
-    {% for location in locations %}
-      <div class="osg-location-card">
-        <a href="/groups/onsite/{{ location.onsite_group_slug }}">
-          <span class="text-center text-white">{{ location.onsite_group_display_name }}</span>
-          <img class="img-responsive " src="{{ location.image.url | imgix: site.imgix }}?{{ site.imgix_params.placeholder_sixteen_nine }}" alt="{{ location.onsite_group_display_name }}" sizes="{{ site.image_sizes.one_fourth }}" data-optimize-img/>
-        </a>
-      </div>
-    {% endfor %}
-    </div>
-  </section>
 </div>

--- a/_layouts/onsite-groups/location-index.html
+++ b/_layouts/onsite-groups/location-index.html
@@ -29,7 +29,7 @@ snail_trail: connect
     </section>
 
     <section class="container push-bottom">
-      <div class="bg-white row row-no-gutters soft-half-sides soft-top">
+      <div class="bg-white row row-no-gutters soft-half-sides soft-top col-sm-10 col-sm-offset-1">
       {% assign locations = site['locations'] | locations_with_onsite_groups %}
       {% for location in locations %}
         <div class="osg-location-card">

--- a/_layouts/onsite-groups/location-index.html
+++ b/_layouts/onsite-groups/location-index.html
@@ -28,8 +28,8 @@ snail_trail: connect
       </div>
     </section>
 
-    <section class="container bg-white soft-top push-bottom">
-      <div class="row row-no-gutters push-ends">
+    <section class="container push-bottom">
+      <div class="bg-white row row-no-gutters soft-half-sides soft-top">
       {% assign locations = site['locations'] | locations_with_onsite_groups %}
       {% for location in locations %}
         <div class="osg-location-card">

--- a/_layouts/onsite-groups/location-index.html
+++ b/_layouts/onsite-groups/location-index.html
@@ -22,8 +22,9 @@ snail_trail: connect
       {% for category in page_categories %}
         {% capture category_path %}/groups/{{ category.slug }}{% endcapture %}
         <li class="{% if page.path == category_path %}active{% endif %}"><a href="{{ category_path }}">{{ category.title }}</a></li>
-      {% endfor %}
-        <li class="{% if page.path == 'test' %}active{% endif %}"><a href="/groups/locations">By Location</a></li>
+        {% endfor %}
+        <li class="{% if page.path != category_path %}active{% endif %}"><a href="/groups/locations">By Location</a></li>
+        
       </ul>
     </div>
   </section>
@@ -31,28 +32,21 @@ snail_trail: connect
   <main class="bg-blue bg-topo soft-ends">
     <section class="container">
       <div class="row push-bottom">
-        <div class="col-md-8 col-md-offset-2 text-center push-ends">{{ page.category.description }}</div>
+        <div class="col-md-8 col-md-offset-2 text-center push-ends">We’re all about groups here and want you to have great friends. These are some of our groups that foucsed on building bonds and meeting likemind people.</div>
       </div>
-      {% for groups in page.groups %}
-      <div class="osg-row">
-        {% for group in groups %}
-        <div class="onsite-group bg-white">
-          <div class="text-gray-dark soft push-bottom" data-id="{{ group.contentful_id }}">
-            <h4 class="font-family-condensed-extra text-uppercase">
-              {{ group.title }}
-            </h4>
-            <div class="text-gray small">{{ group.description | markdownify | strip_html | truncate: 275 }}</div>
-            {% assign locations = group | locations_for_meeting %}
-            <ul class="text-gray small list-inline push-quarter-top osg-locations">
-            {% for location in locations %}
-              <li><a href="/groups/onsite/{{ group.slug }}/{{ location.onsite_group_slug }}">{{ location.onsite_group_display_name }}</a></li>
-            {% endfor %}
-            </ul>
-          </div>
+    </section>
+    <section class="container bg-white soft-top">
+      <div class="row push-ends">
+      {% assign locations = site['locations'] | locations_with_onsite_groups %}
+      {% for location in locations %}
+        <div class="osg-location-card">
+          <a href="/groups/onsite/{{ location.onsite_group_slug }}">
+            <span class="text-center text-white">{{ location.onsite_group_display_name }}</span>
+            <img class="img-responsive " src="{{ location.image.url | imgix: site.imgix }}?{{ site.imgix_params.placeholder_sixteen_nine }}" alt="{{ location.onsite_group_display_name }}" sizes="{{ site.image_sizes.one_fourth }}" data-optimize-img/>
+          </a>
         </div>
-        {% endfor %}
-      </div>
       {% endfor %}
+      </div>
     </section>
   </main>
 

--- a/_plugins/generators/onsite_groups_generator.rb
+++ b/_plugins/generators/onsite_groups_generator.rb
@@ -20,10 +20,9 @@ module Jekyll
         })
       end
 
-      # Locations index landing
+      # Locations index landings
       groups_by_category.each do |slug, category_groups|
         pages.create!("/groups/locations", 'onsite-groups/location-index.html', {
-          'groups': category_groups.each_slice(2).to_a,
           'category': groups.category_by_slug(slug),
           'categories': categories,
           'path': "/groups/locations"

--- a/_plugins/generators/onsite_groups_generator.rb
+++ b/_plugins/generators/onsite_groups_generator.rb
@@ -20,6 +20,16 @@ module Jekyll
         })
       end
 
+      # Locations index landing
+      groups_by_category.each do |slug, category_groups|
+        pages.create!("/groups/locations", 'onsite-groups/location-index.html', {
+          'groups': category_groups.each_slice(2).to_a,
+          'category': groups.category_by_slug(slug),
+          'categories': categories,
+          'path': "/groups/locations"
+        })
+      end
+
       # Location landings
       groups.by_location.each do |slug, meetings|
         slug = slug == 'anywhere' ? 'online' : slug


### PR DESCRIPTION
## Problem
On the Onsite Groups landing, please add a tab on the far right (next to the category tabs) that displays the grid of locations that current live at the bottom of the page.
[Design](https://invis.io/6BZOS8ZSE2Y#/441609702_03-01d-Site-Based-Groups-Location)

## Solution
[Preview](https://deploy-preview-1989--int-crds-net.netlify.app/groups/locations/)
