### PR TITLE
Reverted /signin to MP signin page

### DIFF
--- a/redirects.csv
+++ b/redirects.csv
@@ -83,7 +83,7 @@ https://discipleship.crossroads.net/*,https://www.crossroads.net/huddle,301!,mas
 /authors/*,/media/authors/:splat,302!
 /songs/*,/media/songs/:splat,302!
 /oktasignin*,https://${env:CRDS_OKTA_SIGNIN_ENDPOINT}:splat,200!
-/signin/*,https://${env:CRDS_OKTA_SIGNIN_ENDPOINT}/signin/:splat,200!
+/signin/*,https://${env:CRDS_ANGULAR_ENDPOINT}/signin/:splat,200!
 /event-checkin/*,https://${env:CRDS_EVENT_CHECKIN_ENDPOINT}/:splat,200!
 /media/music/,${env:CRDS_MUSIC_ENDPOINT},301!
 /music/,${env:CRDS_MUSIC_ENDPOINT},301!


### PR DESCRIPTION
## Problem
*Prod /signin page was directed to the Okta signin page (which we don't want yet).*

## Solution
*Correct /signin page redirect.*

## Testing
*Once merged, check /signin page in Prod is redirecting to MP siginin page (check that the /oktasignin and /signin page are different)*
