### PR TITLE
remove excessive padding on mobile rosters

### DIFF
--- a/_assets/stylesheets/pages/_superbowl.scss
+++ b/_assets/stylesheets/pages/_superbowl.scss
@@ -2,8 +2,7 @@
   width: 70%;
 }
 
-.hr-white
-{
+.hr-white {
   border-top-color: white;
 }
 
@@ -12,5 +11,8 @@
 }
 
 .stats-column {
-  padding: 0 100px;
+  padding: 0;
+  @media (min-width: $screen-sm) {
+    padding: 0 100px;
+  }
 }


### PR DESCRIPTION
## Problem
Too much padding on roster text on mobile

## Solution
Make padding only show on larger screen sizes

## Testing
Pull screen from mobile to large to see change
