### PR TITLE
US20588 Change Resi Live Stream Times

### DIFF
--- a/_assets/javascripts/components/resi-player.js
+++ b/_assets/javascripts/components/resi-player.js
@@ -24,25 +24,19 @@ const isDayOfTheWeek = (day) => {
 
 const isServiceTime = () => {
   let isSunday = isDayOfTheWeek(0);
-  let isSaturday = isDayOfTheWeek(6);
-  let saturdayServiceTimes = (
-    (getEstTime() >= 1650 && getEstTime() <= 1820)
+  let serviceTimes = (
+    (getEstTime() >= 825 && getEstTime() <= 940) || 
+    (getEstTime() >= 955 && getEstTime() <= 1110) ||
+    (getEstTime() >= 1140 && getEstTime() <= 1255)
   );
 
-  let sundayServiceTimes = (
-    (getEstTime() >= 820 && getEstTime() <= 950) || 
-    (getEstTime() >= 1020 && getEstTime() <= 1150) ||
-    (getEstTime() >= 1220 && getEstTime() <= 1350)
-  );
-
-  return (isSunday || isSaturday) && (saturdayServiceTimes || sundayServiceTimes);
+  return isSunday && serviceTimes;
 };
 
 const refreshPageForServiceStart = (hours, minutes, seconds) => {
   let isSunday = isDayOfTheWeek(0);
-  let isSaturday = isDayOfTheWeek(6);
 
-  if ((!isSunday || !isSaturday) || !document.getElementById('location-page')) {
+  if (!isSunday || !document.getElementById('location-page')) {
     return;
   }
 
@@ -65,12 +59,6 @@ if (!isServiceTime() && document.getElementById('resi-player')) {
   document.getElementById('resi-player').remove();
 }
 
-if (isDayOfTheWeek(6)) {
-  refreshPageForServiceStart(16,50,1);
-}
-
-if (isDayOfTheWeek(0)) {
-  refreshPageForServiceStart(8,20,1);
-  refreshPageForServiceStart(10,20,1);
-  refreshPageForServiceStart(12,20,1);
-}
+refreshPageForServiceStart(8,25,1);
+refreshPageForServiceStart(9,55,1);
+refreshPageForServiceStart(11,40,1);


### PR DESCRIPTION
## Task
Starting Feb 14th, Oakley is adding a service time, so the times are changing for the foreseeable future. They will be 8:30a, 10a, & 11:45a.

I'd like to make the live times:
stream go live 8:25am - run until 9:40am
stream go live 9:55am - run until 11:10am
stream go live 11:40pm - run until 12:55pm