### PR TITLE
DE8154 Onsite Groups have incorrect default when a meeting room is not selection 

### DIFF
--- a/_includes/groups/_meeting-details-card.html
+++ b/_includes/groups/_meeting-details-card.html
@@ -15,13 +15,6 @@
       <crds-icon name="map-marker" color="gray-light" size="16"></crds-icon>
       Room {{ meeting.room }}
     </p>
-    
-    {% else %}
-    <p class="font-size-small">Once you register, the leader will email you a meeting link.</p>
-    <p class="align-items-center d-flex text-gray-light font-size-smaller">
-      <crds-icon name="map-marker" color="gray-light" size="16"></crds-icon>
-      Online via Zoom
-    </p>
     {% endif %}
   
     {% if meeting.childcare %}


### PR DESCRIPTION
## Problem
When editing an Onsite Group Meeting, if the "Room" field is left null, the display on the front end defaults to "online via Zoom." This is not correct behavior. The "online via Zoom" should not display - if the field is left null, nothing should show on the front end.  

