### PR TITLE
Fix oops 404 page help section link.

### DIFF
--- a/404.html
+++ b/404.html
@@ -14,7 +14,7 @@ permalink: /404.html
     <p class="push-top">
       <strong>Still need help?</strong>
       <br />Browse our
-      <a href="help">help section</a>,
+      <a href="/help">help section</a>,
       <a href='m&#97;&#105;lto&#58;websu&#112;po&#114;&#116;&#64;%&#54;3&#114;os&#37;73r&#111;%&#54;1ds%2E&#110;et'>email
         us</a> or give us a call at 513‑731‑7400.
     </p>


### PR DESCRIPTION
Update link to use /help as the root instead of just appending help relative to the path.

## Problem
Navigate to crossroads.net/oops and click on "help section" link - you will be redirected to https://www.crossroads.net/oops/help, instead of https://www.crossroads.net/help/

## Solution
Fixed link to be /help instead of help.

### Corresponding Branch

## Testing
Go to https://www.crossroads.net/oops click on the help section link.  It should take you to https://www.crossroads.net/help/
