### PR TITLE
Feature/us20697 netlify training proof of concept

### DIFF
--- a/redirects.csv
+++ b/redirects.csv
@@ -174,4 +174,7 @@ https://discipleship.crossroads.net/*,https://www.crossroads.net/huddle,301!,mas
 /groups/onsite-groups/*,/groups/onsite,301!
 /groups/onsite,/groups/site-based,301!
 /groups/onsite/*,/groups/site-based/:splat,301!
+/training/listening/*,https://listening-training.netlify.app/:splat,200!
+/training/lib/*,https://listening-training.netlify.app/lib/:splat,200!
+/training/assets/*,https://listening-training.netlify.app/assets/:splat,200!
 /*,/404.html,404


### PR DESCRIPTION
## Problem
Training team needs a way to show uploaded trainings from the Rise LMS system that have been deployed to Netlify.

## Solution
Update the redirects.csv file to provide a redirect that shows the training that is hosted on Netlify

## Testing
Visit www.crossroads.net/training/listening and confirm the listening training is visible and interactive.
