### PR TITLE
US20708 Onsite Groups

### DIFF
--- a/_plugins/filters/onsite_groups_filters.rb
+++ b/_plugins/filters/onsite_groups_filters.rb
@@ -11,9 +11,7 @@ module Jekyll
     end
 
     def locations_with_onsite_groups(collection)
-      locations = site.collections['onsite_group_meetings'].docs.
-        select{|g| g.data.keys.include?('location') }.
-        collect{|m| m.data.dig('location','slug') }.compact.uniq
+      locations = utils.location_slugs
       collection.select{|location| locations.include? location.data['slug'] }
     end
 

--- a/_plugins/generators/onsite_groups_generator.rb
+++ b/_plugins/generators/onsite_groups_generator.rb
@@ -47,11 +47,15 @@ module Jekyll
         meetings = group.data['meetings'].nil? ? [] : group.data['meetings']
         meeting_ids = meetings.collect{|m| m['id'] }.compact
         group_meetings = groups.meetings_by_id(meeting_ids)
-        location_slugs = group_meetings.collect{|m| m.data.dig('location','slug') }.compact
+        location_slugs = group_meetings.collect{|m|
+          groups.location_slugs_for_meeting(m)
+        }.flatten
 
         location_slugs.collect do |location_slug|
           slug = location_slug == 'anywhere' ? 'online' : location_slug
-          meetings = group_meetings.select{|m| m.data.dig('location','slug') == location_slug }
+          meetings = group_meetings.select{|m|
+            groups.location_slugs_for_meeting(m).include? location_slug
+          }
           location = groups.location_by_slug(slug)
           category_slug = group.data["category"]["slug"] ? group.data["category"]["slug"] : "onsite";
           pages.create!("/groups/#{category_slug}/#{group_slug}/#{slug}", 'onsite-groups/detail.html', {

--- a/lib/crds/onsite_groups.rb
+++ b/lib/crds/onsite_groups.rb
@@ -4,32 +4,63 @@ module CRDS
 
     def initialize(site)
       @site = site
+
+      # Loop through all locations and add some new attributes for
+      # identifying & displaying these locations later
       site.collections['locations'].docs.each do |location|
          location.data['onsite_group_display_name'] = location.data['name']
          location.data['onsite_group_slug'] = location.data['slug'] != 'anywhere' ? location.data['slug'] : 'online'
       end
+
+      # Returns collections that are relevant to OSG (meetings, groups & categories)
       @collections = site.collections.select{|k,v| k.include?('onsite_group') }
+
+      # Create a reference to location objects so we can do things later
       @collections['locations'] = site.collections['locations']
-      (@collections['onsite_group_meetings'].docs.reject!{|m| !known_meeting_ids.include?(m['id']) } || [])
-        .each do |meeting|
-          group = group_by_meeting(meeting)
-          meeting.data['group_type'] = group.data.dig('category', 'slug')
-          meeting.data['group'] = group_by_meeting(meeting)
+
+      # Returns an array of any meeting IDs not returned from known_meeting_ids()
+      (
+        @collections['onsite_group_meetings']
+          .docs
+          .reject!{|m| !known_meeting_ids.include?(m['id']) } || []
+      )
+      .each do |meeting|
+        # For each of these meetings...
+        # Find group associated with this meeting instance
+        group = group_by_meeting(meeting)
+        # Set a couple reference variables on the meeting instance
+        meeting.data['group_type'] = group.data.dig('category', 'slug')
+        meeting.data['group'] = group_by_meeting(meeting)
       end
     end
 
+    ##
+    # Return all groups
+    # @return Array
+    #
     def all
       @all ||= @collections['onsite_groups'].docs
     end
 
+    ##
+    # Returns meetings organized by location slug
+    #   { "oakley" => [...], ... }
+    # @return Array
+    #
     def by_location
       @by_location ||= begin
         @collections['onsite_group_meetings'].docs.
+          # TODO
           select{|m| m.data.keys.include?('location') && m.data['location'].present? }.
           group_by{|m| m.data.dig('location','slug') }
       end
     end
 
+    ##
+    # Returns groups organized by category slug
+    #   { "site-based" => [...], ... }
+    # @return Array
+    #
     def by_category
       @by_category ||= begin
         @collections['onsite_groups'].docs.
@@ -37,14 +68,29 @@ module CRDS
       end
     end
 
+    ##
+    # Lookup location by it's slug value
+    # @param String
+    # @return Jekyll::Document
+    #
     def location_by_slug(slug)
       @collections['locations'].docs.detect{|l| l.data['onsite_group_slug'] === slug }
     end
 
+    ##
+    # Lookup category by it's slug value
+    # @param String
+    # @return Jekyll::Document
+    #
     def category_by_slug(slug)
       @collections['onsite_group_categories'].docs.detect{|c| c.data['slug'] === slug }
     end
 
+    ##
+    # Returns a unique array of meeting documents included in meeting_ids arg
+    # @param Array
+    # @return Array
+    #
     def meetings_by_id(meeting_ids)
       @collections['onsite_group_meetings'].
         docs.
@@ -53,21 +99,44 @@ module CRDS
         uniq
     end
 
+    ##
+    # Returns a unique array of all locations where a group's meetings are hosted
+    # @param Jekyll::Document
+    # @return Array
+    #
     def locations_by_group(group)
-      mettings = group.data.dig('meetings').nil? ? [] : group.data.dig('meetings')
-      ids = mettings.collect{|m| m['id'] }.compact
+
+      # Get ids for all of this group's meetings
+      ids = (
+          group.data.dig('meetings').nil? ? [] : group.data.dig('meetings')
+        )
+        .collect{|m| m['id'] }
+        .compact
+
+      # Reference for all the meeting objects
       meetings = meetings_by_id(ids)
+      # Reference for all location objects
       locations = @site.collections['locations'].docs
 
+      # For every meeting
       meetings.collect do |m|
+          # ...return it's location
+          # TODO
           slug = m.data.dig('location','slug')
           locations.detect{|l| l.data.dig('slug') == slug }
         end.
         compact.
+        # No dupes
         uniq{|m| m.data['id'] }.
+        # Sort the return value alphabetically
         sort{|a,b| a.data['name'] <=> b.data['name'] }
     end
 
+    ##
+    # Returns the group associated with a meeting
+    # @param Jekyll::Document
+    # @return Jekyll::Document
+    #
     def group_by_meeting(meeting)
       meeting_id = meeting.data.dig('id')
       @collections['onsite_groups'].docs.detect do |group|
@@ -77,6 +146,10 @@ module CRDS
 
     private
 
+      ##
+      # Returns an array containing every meeting id across all groups
+      # @return Array
+      #
       def known_meeting_ids
         @known_meeting_ids ||= begin
           @collections['onsite_groups'].docs.flat_map do |g|

--- a/lib/crds/onsite_groups.rb
+++ b/lib/crds/onsite_groups.rb
@@ -43,6 +43,14 @@ module CRDS
     end
 
     ##
+    # Return slugs for all locations hosting meetings
+    # @return Array
+    #
+    def location_slugs
+      @location_slugs ||= by_location.keys
+    end
+
+    ##
     # Returns meetings organized by location slug
     #   { "oakley" => [...], ... }
     # @return Array

--- a/lib/crds/onsite_groups.rb
+++ b/lib/crds/onsite_groups.rb
@@ -51,6 +51,17 @@ module CRDS
     end
 
     ##
+    # Returns all location slugs for a meeting document
+    # @param Jekyll::Document
+    # @return Array
+    #
+    def location_slugs_for_meeting(meeting)
+      slugs = (meeting.data.dig('locations') || []).collect{|l| l['slug']}
+      slugs << meeting.data.dig('location','slug')
+      slugs.compact.uniq
+    end
+
+    ##
     # Returns meetings organized by location slug
     #   { "oakley" => [...], ... }
     # @return Array


### PR DESCRIPTION
## Problem
Stakeholders would like to add multiple locations a single group meeting instance. 

## Solution
This PR updates the OSG logic to support both single location & multiple locations. The reason I'm handling it in this manner is so we can migrate content from the single-select field over to the multi-select field after we deploy the Contentful migrations to production. After we migrate the data, we should go back and remove the single-select specific logic. 

## Related PR

crdschurch/crds-contentful-migrations#260

## Testing
[Deployment Preview](https://6040f5176d42c32c19fbddf9--int-crds-net.netlify.app/groups/healing/)

Aside from manual QA at the above URL, the best way I've found to test these updates is to build the project and count the number of files in the `_site/groups` directory. 

```bash
$ find ./_site/groups -type f  | wc -l
    50
```

For example, let's say when building against `development` (e.g. single locations only) the total number of files in the groups directory is `50`. And let's say there are 5 locations represented on the `/groups/locations` page.

Then when adding a new meeting to Contentful, you associate that meeting with at least one new location (e.g. Florence) and any number of existing locations (e.g. Oakley, Columbus, etc). That would mean that after applying the changes contained in this PR, the total number of files should increase by two...

```bash
$ find ./_site/groups -type f  | wc -l
    52
```

That's one file for the new meeting and one new file for `/groups/florence`. 
This is workflow I've been using locally to test... 

1. Get a list of all files in the groups directory

```bash
$ find ./_site/groups -type f > groups.txt
```

2. Create or edit a meeting in Contentful and rebuild the project

```bash
$ bundle exec jekyll contentful --sites www.crossroads.net -f
$ bundle exec jekyll clean && bundle exec jekyll build
```

3. Diff the build with the list of files from step one. The following indicates that after I edited the 'nullam-venenatis-condimentum' meeting in Contentful, the build generated two files.  

```bash
$ diff <(cat groups.txt) <(find ./_site/groups -type f)
37a38
> ./_site/groups/florence/index.html
55a57
> ./_site/groups/healing/nullam-venenatis-condimentum/florence/index.html
```