### PR TITLE
DEXXXX Shows Redirect

### DIFF
--- a/redirects.csv
+++ b/redirects.csv
@@ -90,6 +90,7 @@ https://discipleship.crossroads.net/*,https://www.crossroads.net/huddle,301!,mas
 /event-checkin/*,https://${env:CRDS_EVENT_CHECKIN_ENDPOINT}/:splat,200!
 /media/music/,${env:CRDS_MUSIC_ENDPOINT},301!
 /music/,${env:CRDS_MUSIC_ENDPOINT},301!
+/shows,/media/shows,301!
 /anywhere,/live,301!
 /media/songs/god-of-the-breakthrough,${env:CRDS_MUSIC_ENDPOINT}/music/god-of-the-breakthrough/god-of-the-breakthrough,301!
 /media/songs/oh-the-power,${env:CRDS_MUSIC_ENDPOINT}/music/oh-the-power/oh-the-power,301!


### PR DESCRIPTION
## Problem
When going to crossroads.net/media/shows/ you sometimes get redirected to crossroads.net/shows/ which is a 404. I can recreate this issue 2/10 time in an incognito window

## Solution
Add a redirect for `/shows` to goto `/media/shows` for the small percentage of times it is redirected to `/shows`