### PR TITLE
DE8198 fix group detail into dev

### DIFF
--- a/_includes/groups/_meeting-details-card.html
+++ b/_includes/groups/_meeting-details-card.html
@@ -1,5 +1,11 @@
 <div class="col-sm-4 push-top">
   <div class="border border-light-gray soft-half full-height">
+
+    <p class="font-family-base-bold font-size-small push-quarter-top">
+      {{ meeting.title }}
+    </p>
+
+
     {% if meeting.starts_at %}
     <p class="font-family-base-bold font-size-small push-quarter-top">
       Starts {{ meeting.starts_at | date: "%B %-d" }} - {{ meeting.starts_at | date: "%A" }}s

--- a/_layouts/onsite-groups/detail.html
+++ b/_layouts/onsite-groups/detail.html
@@ -9,15 +9,25 @@ layout: container-fluid
         <div class="container">
           <div class="col-sm-7 text-left">
             <h1 class="font-family-condensed-extra font-size-h2 text-uppercase">
+              {% if page.group.title %}
               {{ page.group.title }}
+              {% else %}
+              {{ page.title }}
+              {% endif %}
             </h1>
             <p class="font-size-smaller text-uppercase">{{ page.location.onsite_group_display_name }}</p>
+            {% if page.group.detail %}
             <p class="font-size-small"><strong>Perfect for:</strong> {{ page.group.detail }}</p>
+            {% else %}
+            <p class="font-size-small"><strong>Perfect for:</strong> {{ page.detail }}</p>
+            {% endif %}
           </div>
           <div class="col-sm-5">
+            {% if page.location.image.url %}
             <img class="width-100"
               src="{{ page.location.image.url | imgix: site.imgix }}?{{ site.imgix_params.placeholder_sixteen_nine }}"
               sizes="{{ site.image_sizes.one_fourth }}" data-optimize-img />
+            {% endif %}
           </div>
         </div>
       </div>
@@ -25,18 +35,22 @@ layout: container-fluid
   </section>
 
   <section class="container bg-white text-gray-dark soft-ends">
-    <div class="container">
+    <div class="soft-half-sides">
       {% if page.group.length %}
       <div class="push-bottom font-size-small"><strong>How Long:</strong><br> {{ page.group.length }}</div>
+      {% else %}
+      <div class="push-bottom font-size-small"><strong>How Long:</strong><br> {{ page.length }}</div>
       {% endif %}
 
       {% if page.group.description %}
       <div class="push-bottom font-size-small"><strong>Details:</strong>{{ page.group.description | markdownify }}</div>
+      {% else %}
+      <div class="push-bottom font-size-small"><strong>Details:</strong>{{ page.description | markdownify }}</div>
       {% endif %}
 
       <h2 class="font-family-condensed-extra font-size-h3 text-uppercase">Meeting times</h2>
 
-      <div class="d-flex flex-column flex-sm-row row">
+      <div class="row">
         {% for meeting in page.meetings %}
           {% include groups/_meeting-details-card.html meeting=meeting %}
         {% endfor %}


### PR DESCRIPTION
## Task
When looking at the detail page at the Group-level, for groups with multiple locations, the layout is broken.

Example of how you can find it in the wild:
1. Go to /groups/locations 
2. Click on Uptown
3. If you click on "Learn More" for any of the site-based groups (which are assigned to a single location), you'll see the CORRECT group detail. If you click on "Learn More" next to Grief support in the Healing Groups section, you'll see a busted layout. This group has multiple locations assigned to it. 

## Solution
[Broken in Prod](https://www.crossroads.net/groups/site-based/alpha) --> [Fixed Preview](https://deploy-preview-2089--crds-net.netlify.app/groups/site-based/alpha)