### PR TITLE
Feature/US20639 Update media 302 redirects

### DIFF
--- a/_assets/stylesheets/_fonts.scss
+++ b/_assets/stylesheets/_fonts.scss
@@ -26,7 +26,7 @@
  *   - http://typekit.com/eulas/00000000000000003b9b402f
  *   - http://typekit.com/eulas/00000000000000003b9b4030
  *
- * © 2009-2020 Adobe Systems Incorporated. All Rights Reserved.
+ * © 2009-2021 Adobe Systems Incorporated. All Rights Reserved.
  */
 /*{"last_published":"2020-11-19 15:53:32 UTC"}*/
 

--- a/redirects.csv
+++ b/redirects.csv
@@ -74,7 +74,22 @@ https://discipleship.crossroads.net/*,https://www.crossroads.net/huddle,301!,mas
 /series/* autoPlay=:autoPlay,/media/series/:splat?autoPlay=:autoPlay,302!
 /series/* sound=:sound,/media/series/:splat?sound=:sound,302!
 /series/*,/media/series/:splat,302!
-/articles/*,/media/articles/:splat,302!
+/media/articles/filters//page/10,https://${env:CRDS_MEDIA_ENDPOINT}/articles/page/10,301!
+/media/articles/filters//page/2,https://${env:CRDS_MEDIA_ENDPOINT}/articles/page/2,301!
+/media/articles/filters//page/2,https://${env:CRDS_MEDIA_ENDPOINT}/articles/page/4,301!
+/media/articles/filters//page/2,https://${env:CRDS_MEDIA_ENDPOINT}/articles/page/5,301!
+/media/articles/filters//page/2,https://${env:CRDS_MEDIA_ENDPOINT}/articles/page/6,301!
+/media/articles/filters//page/2,https://${env:CRDS_MEDIA_ENDPOINT}/articles/page/7,301!
+/media/articles/filters//page/2,https://${env:CRDS_MEDIA_ENDPOINT}/articles/page/8,301!
+/media/articles/filters//page/2,https://${env:CRDS_MEDIA_ENDPOINT}/articles/page/9,301!
+/media/articles/filters//page/2,https://${env:CRDS_MEDIA_ENDPOINT}/articles/page/12,301!
+/media/articles/filters//page/2,https://${env:CRDS_MEDIA_ENDPOINT}/articles/page/13,301!
+/media/articles/filters//page/2,https://${env:CRDS_MEDIA_ENDPOINT}/articles/page/14,301!
+/media/articles/filters//page/2,https://${env:CRDS_MEDIA_ENDPOINT}/articles/page/15,301!
+/media/articles/filters/+,https://${env:CRDS_MEDIA_ENDPOINT}/articles/,301!
+/media/articles/filters/+/page/2,https://${env:CRDS_MEDIA_ENDPOINT}/articles/page/2,301!
+/media/articles/filters/+/page/3,https://${env:CRDS_MEDIA_ENDPOINT}/articles/page/3,301!
+/articles/*,/media/articles/:splat,301!
 /podcasts/*,/media/podcasts/:splat,302!
 /videos/*,/media/videos/:splat,302!
 /message/*,/media/message/:splat,302!
@@ -174,4 +189,7 @@ https://discipleship.crossroads.net/*,https://www.crossroads.net/huddle,301!,mas
 /groups/onsite-groups/*,/groups/onsite,301!
 /groups/onsite,/groups/site-based,301!
 /groups/onsite/*,/groups/site-based/:splat,301!
+/care/communitycare,/care,301!
+/adventure,https://${env:CRDS_MEDIA_ENDPOINT}/series/the-adventurous-life,301!
+/weeklyworship,/reopen,301!
 /*,/404.html,404


### PR DESCRIPTION
## Problem
Traffic pointed at `/articles` was 302 redirecting to `/media/articles`. The organization
wanted those redirects has 301 redirects.

## Solution
The `redirects.csv` file has been updated to redirect all traffic coming
in at `/articles` as a 301 to `/media/articles`.

### Corresponding Branch
There is no corresponding branch associated with this work.

## Testing
To test, open your inspect tools, go to the network tab, then navigate to an article (e.g. int.crossroads.net/articles/10-minutes-to-more-hope-advent-week-1). You should see 2 requests for 10-minutes-to-more-hope-advent-week-1. The first should resolve as a 301 redirect, _not a 302 redirect_. The second request should resolve to /media/articles/10-minutes-to-more-hope-advent-week-1 as a 200.
