### PR TITLE
Feature/us20909 fix site title

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,7 +15,7 @@ group :jekyll_plugins do
   # gem 'jekyll-contentful', path: File.expand_path('../jekyll-contentful', __dir__)
   gem "jekyll-contentful", git: 'https://github.com/crdschurch/jekyll-contentful.git', tag: '3.0.0'
   # gem 'jekyll-crds', path: File.expand_path('../jekyll-crds', __dir__)
-  gem "jekyll-crds", git: 'https://github.com/crdschurch/jekyll-crds.git', tag: '2.3.1'
+  gem "jekyll-crds", git: 'https://github.com/crdschurch/jekyll-crds.git', tag: '2.3.2'
   # gem 'jekyll-placeholders', path: File.expand_path('../jekyll-placeholders', __dir__)
   gem "jekyll-placeholders", git: 'https://github.com/ample/jekyll-placeholders', tag: '1.0.0'
   # gem 'paging-mister-hyde', path: File.expand_path('../paging-mister-hyde', __dir__)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -39,10 +39,10 @@ GIT
 
 GIT
   remote: https://github.com/crdschurch/jekyll-crds.git
-  revision: acabcfcf782beab72f8dcf87b06500fe4fa39892
-  tag: 2.3.1
+  revision: e79f425439d32b50db30efbbb31da80ee1b5efdc
+  tag: 2.3.2
   specs:
-    jekyll-crds (2.3.1)
+    jekyll-crds (2.3.2)
       activesupport
       httparty
       jekyll
@@ -246,4 +246,4 @@ DEPENDENCIES
   webmock
 
 BUNDLED WITH
-   2.0.1
+   2.2.14

--- a/_assets/stylesheets/_fonts.scss
+++ b/_assets/stylesheets/_fonts.scss
@@ -26,7 +26,7 @@
  *   - http://typekit.com/eulas/00000000000000003b9b402f
  *   - http://typekit.com/eulas/00000000000000003b9b4030
  *
- * © 2009-2020 Adobe Systems Incorporated. All Rights Reserved.
+ * © 2009-2021 Adobe Systems Incorporated. All Rights Reserved.
  */
 /*{"last_published":"2020-11-19 15:53:32 UTC"}*/
 

--- a/redirects.csv
+++ b/redirects.csv
@@ -74,7 +74,22 @@ https://discipleship.crossroads.net/*,https://www.crossroads.net/huddle,301!,mas
 /series/* autoPlay=:autoPlay,/media/series/:splat?autoPlay=:autoPlay,302!
 /series/* sound=:sound,/media/series/:splat?sound=:sound,302!
 /series/*,/media/series/:splat,302!
-/articles/*,/media/articles/:splat,302!
+/media/articles/filters//page/10,https://${env:CRDS_MEDIA_ENDPOINT}/articles/page/10,301!
+/media/articles/filters//page/2,https://${env:CRDS_MEDIA_ENDPOINT}/articles/page/2,301!
+/media/articles/filters//page/2,https://${env:CRDS_MEDIA_ENDPOINT}/articles/page/4,301!
+/media/articles/filters//page/2,https://${env:CRDS_MEDIA_ENDPOINT}/articles/page/5,301!
+/media/articles/filters//page/2,https://${env:CRDS_MEDIA_ENDPOINT}/articles/page/6,301!
+/media/articles/filters//page/2,https://${env:CRDS_MEDIA_ENDPOINT}/articles/page/7,301!
+/media/articles/filters//page/2,https://${env:CRDS_MEDIA_ENDPOINT}/articles/page/8,301!
+/media/articles/filters//page/2,https://${env:CRDS_MEDIA_ENDPOINT}/articles/page/9,301!
+/media/articles/filters//page/2,https://${env:CRDS_MEDIA_ENDPOINT}/articles/page/12,301!
+/media/articles/filters//page/2,https://${env:CRDS_MEDIA_ENDPOINT}/articles/page/13,301!
+/media/articles/filters//page/2,https://${env:CRDS_MEDIA_ENDPOINT}/articles/page/14,301!
+/media/articles/filters//page/2,https://${env:CRDS_MEDIA_ENDPOINT}/articles/page/15,301!
+/media/articles/filters/+,https://${env:CRDS_MEDIA_ENDPOINT}/articles/,301!
+/media/articles/filters/+/page/2,https://${env:CRDS_MEDIA_ENDPOINT}/articles/page/2,301!
+/media/articles/filters/+/page/3,https://${env:CRDS_MEDIA_ENDPOINT}/articles/page/3,301!
+/articles/*,/media/articles/:splat,301!
 /podcasts/*,/media/podcasts/:splat,302!
 /videos/*,/media/videos/:splat,302!
 /message/*,/media/message/:splat,302!
@@ -174,4 +189,7 @@ https://discipleship.crossroads.net/*,https://www.crossroads.net/huddle,301!,mas
 /groups/onsite-groups/*,/groups/onsite,301!
 /groups/onsite,/groups/site-based,301!
 /groups/onsite/*,/groups/site-based/:splat,301!
+/care/communitycare,/care,301!
+/adventure,https://${env:CRDS_MEDIA_ENDPOINT}/series/the-adventurous-life,301!
+/weeklyworship,/reopen,301!
 /*,/404.html,404


### PR DESCRIPTION
## Problem
Currently the website title is not structured the way the insights team would prefer. For some articles, the title is missing "| Crossroads Media" after the name of the article.

## Solution
Adjustments were made to the `jekyll-crds` library and a bugfix version was released. This pull request updates the `Gemfile` to point to the most recent bugfix version (2.3.2)

### Corresponding Branch
There is a corresponding branch on the `crds-media` project:

https://github.com/crdschurch/crds-media/pull/1146

## Testing
Previously the `/media/articles/asian-stereotypes-silence-is-complicity` article was not rendering the title correctly. Now you should be able to go to https://int.crossroads.net/media/articles/asian-stereotypes-silence-is-complicity, hover over the browser tab and see a title format of "Article Title | Crossroads Media"