### PR TITLE
feature/US20909 Fix Site Title

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,7 +15,7 @@ group :jekyll_plugins do
   # gem 'jekyll-contentful', path: File.expand_path('../jekyll-contentful', __dir__)
   gem "jekyll-contentful", git: 'https://github.com/crdschurch/jekyll-contentful.git', tag: '3.0.0'
   # gem 'jekyll-crds', path: File.expand_path('../jekyll-crds', __dir__)
-  gem "jekyll-crds", git: 'https://github.com/crdschurch/jekyll-crds.git', tag: '2.3.1'
+  gem "jekyll-crds", git: 'https://github.com/crdschurch/jekyll-crds.git', tag: '2.3.2'
   # gem 'jekyll-placeholders', path: File.expand_path('../jekyll-placeholders', __dir__)
   gem "jekyll-placeholders", git: 'https://github.com/ample/jekyll-placeholders', tag: '1.0.0'
   # gem 'paging-mister-hyde', path: File.expand_path('../paging-mister-hyde', __dir__)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -39,10 +39,10 @@ GIT
 
 GIT
   remote: https://github.com/crdschurch/jekyll-crds.git
-  revision: acabcfcf782beab72f8dcf87b06500fe4fa39892
-  tag: 2.3.1
+  revision: e79f425439d32b50db30efbbb31da80ee1b5efdc
+  tag: 2.3.2
   specs:
-    jekyll-crds (2.3.1)
+    jekyll-crds (2.3.2)
       activesupport
       httparty
       jekyll
@@ -246,4 +246,4 @@ DEPENDENCIES
   webmock
 
 BUNDLED WITH
-   2.0.1
+   2.2.14


### PR DESCRIPTION
## Problem
Currently the website title is not structured the way the insights team would prefer. For some articles, the title is missing "| Crossroads Media" after the name of the article.

## Solution
Adjustments were made to the `jekyll-crds` library and a bugfix version was released. This pull request updates the `Gemfile` to point to the most recent bugfix version (2.3.2)

### Corresponding Branch
There is a corresponding branch on the `crds-media` project:

https://github.com/crdschurch/crds-media/pull/1147

## Testing
Previously the `/media/articles/asian-stereotypes-silence-is-complicity` article was not rendering the title correctly. Now you should be able to go to https://int.crossroads.net/media/articles/asian-stereotypes-silence-is-complicity, hover over the browser tab and see a title format of "Article Title | Crossroads Media"