### PR TITLE
Adds updated facebook meta tag

### DIFF
--- a/_includes/_meta-tags.html
+++ b/_includes/_meta-tags.html
@@ -14,5 +14,5 @@
 <meta property="og:site_name" content="{{ site.title | escape }}">
 <meta name="apple-itunes-app" content="app-id=1029478803">
 <meta name="google-play-app" content="app-id=net.crossroads.crossroads">
-<meta name="facebook-domain-verification" content="n8c17x6iuikwwrvdt4f80xwr72ql8t" />
+<meta name="facebook-domain-verification" content="n8c17x6iuikwwrvdt4f80xwr72ql8t">
 <title>{{ page | meta_title }}</title>

--- a/_includes/_meta-tags.html
+++ b/_includes/_meta-tags.html
@@ -14,4 +14,5 @@
 <meta property="og:site_name" content="{{ site.title | escape }}">
 <meta name="apple-itunes-app" content="app-id=1029478803">
 <meta name="google-play-app" content="app-id=net.crossroads.crossroads">
+<meta name="facebook-domain-verification" content="n8c17x6iuikwwrvdt4f80xwr72ql8t" />
 <title>{{ page | meta_title }}</title>


### PR DESCRIPTION
## Task 
Because of the new Google and Apple privacy things, FB is making us verify our URL.
It is asking to include the meta tag to the homepage. 
`<meta name="facebook-domain-verification" content="n8c17x6iuikwwrvdt4f80xwr72ql8t" />`

[Asana](https://app.asana.com/0/1198951831278010/1200235128591069)

