### PR TITLE
Removed redirect for angular/signin

### DIFF
--- a/redirects.csv
+++ b/redirects.csv
@@ -96,7 +96,6 @@ https://discipleship.crossroads.net/*,https://www.crossroads.net/huddle,301!,mas
 /authors/*,/media/authors/:splat,302!
 /songs/*,/media/songs/:splat,302!
 /oktasignin*,https://${env:CRDS_OKTA_SIGNIN_ENDPOINT}:splat,200!
-/signin/*,https://${env:CRDS_ANGULAR_ENDPOINT}/signin/:splat,200!
 /event-checkin/*,https://${env:CRDS_EVENT_CHECKIN_ENDPOINT}/:splat,200!
 /media/music/,${env:CRDS_MUSIC_ENDPOINT},301!
 /music/,${env:CRDS_MUSIC_ENDPOINT},301!


### PR DESCRIPTION
## Problem
*Document current behavior and why it's undesirable here.*
/signin was redirecting to an old angular sign in page, not to the /signin page created in contentful

## Solution
*Document how the behavior was fixed or enhanced here.*
Removed _/signin,https://${env:CRDS_ANGULAR_ENDPOINT}/signin,200!_ from redirect file.

### Corresponding Branch
*Add link to crdschurch/repo-name-here#issue-number (if applicable). This helps the code reviewer know that corresponding work exists and where to find it.*

## Testing
*Include information on how to test your work here (if applicable).*
got to int.crossroads.net/signin and it should display content from the /signin page in contentful