### PR TITLE
US21034 Resi Times

### DIFF
--- a/_assets/javascripts/components/resi-player.js
+++ b/_assets/javascripts/components/resi-player.js
@@ -24,19 +24,26 @@ const isDayOfTheWeek = (day) => {
 
 const isServiceTime = () => {
   let isSunday = isDayOfTheWeek(0);
-  let serviceTimes = (
-    (getEstTime() >= 825 && getEstTime() <= 940) || 
-    (getEstTime() >= 955 && getEstTime() <= 1110) ||
-    (getEstTime() >= 1140 && getEstTime() <= 1255)
+  let isSaturday = isDayOfTheWeek(6);
+
+  let saturdayServiceTimes = (
+    (getEstTime() >= 1655 && getEstTime() <= 1815)
   );
 
-  return isSunday && serviceTimes;
+  let sundayServiceTimes = (
+    (getEstTime() >= 825 && getEstTime() <= 945) || 
+    (getEstTime() >= 955 && getEstTime() <= 1115) ||
+    (getEstTime() >= 1140 && getEstTime() <= 1300)
+  );
+
+  return (isSunday || isSaturday) && (saturdayServiceTimes || sundayServiceTimes);
 };
 
 const refreshPageForServiceStart = (hours, minutes, seconds) => {
   let isSunday = isDayOfTheWeek(0);
+  let isSaturday = isDayOfTheWeek(6);
 
-  if (!isSunday || !document.getElementById('location-page')) {
+  if ((!isSunday || !isSaturday) || !document.getElementById('location-page')) {
     return;
   }
 
@@ -68,6 +75,13 @@ if (!isServiceTime() && document.getElementById('resi-player')) {
   document.getElementById('resi-player').remove();
 }
 
-refreshPageForServiceStart(8,25,1);
-refreshPageForServiceStart(9,55,1);
-refreshPageForServiceStart(11,40,1);
+
+if (isDayOfTheWeek(6)) {
+  refreshPageForServiceStart(16,55,1);
+}
+
+if (isDayOfTheWeek(0)) {
+  refreshPageForServiceStart(8,25,1);
+  refreshPageForServiceStart(9,55,1);
+  refreshPageForServiceStart(11,40,1);
+}

--- a/_assets/javascripts/components/resi-player.js
+++ b/_assets/javascripts/components/resi-player.js
@@ -40,10 +40,7 @@ const isServiceTime = () => {
 };
 
 const refreshPageForServiceStart = (hours, minutes, seconds) => {
-  let isSunday = isDayOfTheWeek(0);
-  let isSaturday = isDayOfTheWeek(6);
-
-  if ((!isSunday || !isSaturday) || !document.getElementById('location-page')) {
+  if ((!document.getElementById('location-page'))) {
     return;
   }
 


### PR DESCRIPTION
## Task
May 22/23 weekend is our 25th Anniversary celebration and we're adding a service on Saturday in order to make room for people that weekend. Just want to get it on your radar. I also would like to extend our end time an additional 5 minutes on this weekend (just in case). 

Here's the schedule:
May 22:
5pm service
stream go live at 4:55pm - run until 6:15pm

May 23:
Normal service times, but I'd like to add 5 minutes on the end for run times...
stream go live 8:25am - run until 9:45am
stream go live 9:55am - run until 11:15am
stream go live 11:40pm - run until 1:00pm

The following weekend, we'll resume back to only Sunday streaming times. Thanks all, and let me know if you have any questions. 

## Solution
https://deploy-preview-2246--crds-net.netlify.app/oakley