### PR TITLE
US21035 Osano Remove Cookies Ask From /atriumevents Pages

### DIFF
--- a/_includes/_head.html
+++ b/_includes/_head.html
@@ -1,8 +1,10 @@
 <head>
+  {% if page.title != "Atrium Events" %}
   {% if site.jekyll_env == 'production' %}
     <script src="https://cmp.osano.com/6olYRSI8uN8V3oE3/ee6703e4-e14a-4e11-bf03-f5b7b37c7061/osano.js"></script>
   {% elsif site.jekyll_env == 'int' %}
     <script src="https://cmp.osano.com/6olYRSI8uN8V3oE3/65a23ab1-e0ce-4ccd-bc3c-2c8b89cb18f5/osano.js"></script>
+  {% endif %}
   {% endif %}
 
   <meta name="Netlify" content="This page was rendered with Netlify">


### PR DESCRIPTION
## Task

Removes Osano from `/atriumevents` pages.

[US21035](https://rally1.rallydev.com/#/66096747656d/custom/24109743995?detail=%2Fuserstory%2F602981034164)

## Preview

[Preview Link](https://us21035-int--int-crds-net.netlify.app/atriumevents/?site=east%20side)