### PR TITLE
remove overlay text styles

### DIFF
--- a/_assets/stylesheets/pages/_articles.scss
+++ b/_assets/stylesheets/pages/_articles.scss
@@ -178,12 +178,4 @@
       }
     }
   }
-  .overlay-card .overlay-card-title {
-    @media screen and (min-width: $screen-sm) {
-      font-size: 3.1vw;
-    }
-    @media screen and (min-width: $screen-lg) {
-      font-size: 2.9rem;
-    }
-  }
 }


### PR DESCRIPTION
## Problem
fix text issue on cards on this page https://int.crossroads.net/media/articles/

## Solution
Remove text overlay styles that were only being applied to these cards.

## Testing
Test other article cards to make sure their styling isn't affected.