### PR TITLE
Fix HP grid overlay image issue

### DIFF
--- a/_includes/home/_jumbotron.html
+++ b/_includes/home/_jumbotron.html
@@ -1,5 +1,5 @@
 <section>
-  <div class="jumbotron jumbotron-xl inline-video bg-video grid-overlay flush jumbotron-home" style="top: -1.5rem; background-image: url('//crds-media.imgix.net/47HugzxZ1gGwfdZg2JSFNC/e047f199c71a18f3d9b2ef8af06cc6c0/crossroads-collage-new2.jpg?{{ site.imgix_params.placeholder_sixteen_nine }}');" data-optimize-bg-img>
+  <div class="jumbotron jumbotron-xl inline-video bg-video grid-overlay-light flush jumbotron-home" style="top: -1.5rem; background-image: url('//crds-media.imgix.net/47HugzxZ1gGwfdZg2JSFNC/e047f199c71a18f3d9b2ef8af06cc6c0/crossroads-collage-new2.jpg?{{ site.imgix_params.placeholder_sixteen_nine }}');" data-optimize-bg-img>
     <div class="inline-video-player"></div>
     <div class="bg-video-player">
       <video


### PR DESCRIPTION
## Problem
Grid overlay showing default image. (You will only see this issue when the video is not on the page yet)
![Screen Shot 2021-06-14 at 9 44 12 AM](https://user-images.githubusercontent.com/32345656/121902182-16698500-ccf5-11eb-8513-91dbb46b7ef3.png)


## Solution
Change class from `grid-overlay` to `grid-overlay-light` because the light image does not have this issue