### PR TITLE
 Hide Jumbotron Videos on Mobile

### DIFF
--- a/_assets/stylesheets/components/_jumbotron.scss
+++ b/_assets/stylesheets/components/_jumbotron.scss
@@ -86,6 +86,14 @@
       }
     }
 
+    .close-video,
+    .inline-video-player,
+    .bg-video-player {
+      @media screen and (max-width: $screen-xs) {
+        display: none;
+      }
+    }
+
     &.grid-overlay:before {
       z-index: 1;
     }


### PR DESCRIPTION
## Problem
[Rally Task](https://rally1.rallydev.com/#/66096747656d/custom/24109743995?detail=%2Fuserstory%2F492688786312)

## Solution
Set jumbotron video containers to `display: none` below `$screen-xs` (480px).

## Testing
On homepage