### PR TITLE
Remove onPostBuild hook to rename ga references

### DIFF
--- a/_includes/_head.html
+++ b/_includes/_head.html
@@ -103,15 +103,6 @@
   <script>
   var CRDS = window.CRDS || {};
 
-  // GOOGLE ANALYTICS
-  window.dataLayer = window.dataLayer || [];
-  function gtag(){dataLayer.push(arguments);}
-  gtag('js', new Date());
-  gtag('config', 'UA-2977073-1');
-
-  // Tell GTM to not use Universal Analytics
-  window.dataLayer.push({"_event": "GtagWrapperIsActive", "gtagWrapperActive": true})
-
   CRDS.rollCall = {
     formUrl: '{{ site.ENV.ROLL_CALL_FORM_URL }}',
     totalFieldId: '{{ site.ENV.ROLL_CALL_TOTAL_FIELD_ID }}',

--- a/netlify.toml
+++ b/netlify.toml
@@ -32,9 +32,6 @@ package = "@helloample/netlify-plugin-redirects"
 [[plugins]]
 package = "./_plugins/netlify-plugin-health-check"
 
-[[plugins]]
-  package="./_plugins/rename-ga-references"
-
 [dev]
   BASEURL="/"
   CRDS_COMPONENTS_ENDPOINT="components-int.crossroads.net"


### PR DESCRIPTION
## Problem
Our previous implementation of gtag.js was resulting in double reporting to google analytics

## Solution
This code removes the code that renamed all the references to `ga()` to `gtag()`.

### Corresponding Branch
No corresponding branches.

## Testing
This will be done manually by inspecting realtime traffic to our google analytics instance.