### PR TITLE
US20611 Hide Jumbotron Videos on Mobile - pt 2

### DIFF
--- a/_assets/javascripts/components/jumbotron-video.js
+++ b/_assets/javascripts/components/jumbotron-video.js
@@ -1,5 +1,24 @@
 (function() {
   window.$(document).ready(function() {
     new window.CRDS.JumbotronVideos();
+
+    // Prevent background video from loading on mobile
+    const mediaQuery = window.matchMedia('(min-width: 480px)');
+    mediaQuery.addEventListener('change', handleScreenChange);
+
+    // Check screen size on load
+    handleScreenChange(mediaQuery);
+
+    function handleScreenChange(e) {
+      var bgVideo = document.getElementById('jumbotron-bg-video');
+
+      if (e.matches) {
+        bgVideo.setAttribute('src', bgVideo.getAttribute('data-src'));
+      } else {
+        if (!bgVideo.hasAttribute('data-src')) {
+          bgVideo.setAttribute('data-src', bgVideo.getAttribute('src'));
+        }
+      }
+    }
   });
 })();

--- a/_assets/javascripts/components/jumbotron-video.js
+++ b/_assets/javascripts/components/jumbotron-video.js
@@ -2,22 +2,22 @@
   window.$(document).ready(function() {
     new window.CRDS.JumbotronVideos();
 
-    // Prevent background video from loading on mobile
-    const mediaQuery = window.matchMedia('(min-width: 480px)');
-    mediaQuery.addEventListener('change', handleScreenChange);
+    // ---------------------------------------- Prevent bg video from loading on mobile
+    const bgVideo = document.getElementById('jumbotron-bg-video');
 
-    // Check screen size on load
-    handleScreenChange(mediaQuery);
+    if (bgVideo) {
+      const mediaQuery = window.matchMedia('(min-width: 480px)');
+      mediaQuery.addEventListener('change', handleScreenChange);
+
+      // Check screen size on load
+      handleScreenChange(mediaQuery);
+    }
 
     function handleScreenChange(e) {
-      var bgVideo = document.getElementById('jumbotron-bg-video');
-
       if (e.matches) {
         bgVideo.setAttribute('src', bgVideo.getAttribute('data-src'));
-      } else {
-        if (!bgVideo.hasAttribute('data-src')) {
-          bgVideo.setAttribute('data-src', bgVideo.getAttribute('src'));
-        }
+      } else if (!bgVideo.hasAttribute('data-src')) {
+        bgVideo.setAttribute('data-src', bgVideo.getAttribute('src'));
       }
     }
   });

--- a/_assets/stylesheets/components/_jumbotron.scss
+++ b/_assets/stylesheets/components/_jumbotron.scss
@@ -86,8 +86,6 @@
       }
     }
 
-    .close-video,
-    .inline-video-player,
     .bg-video-player {
       @media screen and (max-width: $screen-xs) {
         display: none;

--- a/_includes/home/_jumbotron.html
+++ b/_includes/home/_jumbotron.html
@@ -3,6 +3,7 @@
     <div class="inline-video-player"></div>
     <div class="bg-video-player">
       <video
+        id="jumbotron-bg-video"
         width="1800"
         height="1013"
         class="bg-jumbotron-video hide"
@@ -10,7 +11,7 @@
         loop="loop"
         muted
         playsinline
-        src="https://videos.ctfassets.net/y3a9myzsdjan/1dlAxfTYOpooJHCljHKwaO/d752149378a462ec274803c1184eee68/spiritual-outfitters-loop-comp.mp4"
+        data-src="https://videos.ctfassets.net/y3a9myzsdjan/1dlAxfTYOpooJHCljHKwaO/d752149378a462ec274803c1184eee68/spiritual-outfitters-loop-comp.mp4"
       ></video>
     </div>
     <div class="container">


### PR DESCRIPTION
## Problem
PR #2329 hides the video container on mobile but does not prevent video from loading in background. It also hide the inline-video and controls after user clicks the in-jumbotron play button.

## Solution
- Remove `close-video` and `inline-video-player` from `display: none` list
- Handle video loading in javascript:
    - the video `src=""` attribute is now `data-src=""` by default and won't load the background video
    - An event listener tracks the 480px media query
    - When the page is above 480px, `data-source=""` changes to `src=""` and the video loads
    - `src=""` changes back to `data-src=""` when the page crosses below 480px and the video unloads

### Corresponding Branch
PR #2329 which was previously merged into `development`.

## Testing
Test the home page below and above 480px wide. 
- Starting below 480px, the source file `spiritual-outfitters-loop-comp.mp4` won't show up in the network tab in the inspector until the page is resized above 480px.
- Resizing back below 480px will unload the video and it will re-start from the beginning the next time the window is resized above mobile.