### PR TITLE
DE8434 Jumbotron Video Close Button Spacing

### DIFF
--- a/_assets/stylesheets/components/_jumbotron.scss
+++ b/_assets/stylesheets/components/_jumbotron.scss
@@ -84,6 +84,16 @@
       .jumbotron-background-cover {
         z-index: 2;
       }
+
+      .close-video {
+        margin-top: 1.5rem;
+      }
+      
+      .inline-video-player {
+        @media screen and (min-width: $screen-sm) {
+          margin-top: 1.5rem;
+        }
+      }
     }
 
     .bg-video-player {


### PR DESCRIPTION
## Problem
[Rally Task](https://rally1.rallydev.com/#/66096747656d/custom/24109743995?detail=%2Fdefect%2F603091758495)
This bug appears on both mobile ask desktop. On desktop, the top of the video is cut off by the navigation as well.

## Solution
Add top margin to `.close-video` and `.inline-video-player` to compensate for existing `top: -1.5rem` value on jumbotron container. (Removing the negative positioning value on the  jumbotron impacts other content, not just the inline video, so I left that value as-is.)

## Testing
Location: Jumbotron on the home page 

Click on the play button inside the jumbotron to view the inline video player. The nav bar no longer covers:
- The close button on mobile
- The close button and top of video on desktop

The breakpoint between mobile and desktop values is at `$screen-sm` (768px).