### PR TITLE
Article Index Pagination

### DIFF
--- a/_assets/javascripts/components/pagination.js
+++ b/_assets/javascripts/components/pagination.js
@@ -83,4 +83,53 @@ CRDS.PageLoader.prototype.activatePage = function(type) {
 
 $(document).ready(function() {
   new CRDS.Pagination();
+
+  const currentPage = parseInt(paginationInput.getAttribute("placeholder"));
+  const host = window.location.host;
+  const pageNumber = parseInt(paginationInput.value);
+  const paginationInput = document.getElementById("pagination-current-page");
+  const paginationNextButton = document.getElementById("pagination-next-button");
+  const paginationPrevButton = document.getElementById("pagination-previous-button");
+  const paginationSubmitButton = document.getElementById("pagination-submit-button");
+  const protocol = window.location.protocol;
+  const protocolAndHost = `${protocol}//${host}`
+  const totalPaginatedPages = parseInt(document.getElementById("total_pages").innerText);
+
+  paginationSubmitButton.addEventListener("click", function(e) {
+    if (pageNumber > 1 && pageNumber <= totalPaginatedPages) {
+        window.location.href = `${protocolAndHost}/media/articles/page/${paginationInput.value}/`;
+    } else if (pageNumber == 1) {
+        window.location.href = `${protocolAndHost}/media/articles/`;
+    } else {
+      console.log('Cant navigate past bounds of paginated collection');
+    }
+  }, false);
+
+  paginationInput.addEventListener("keyup", function(e) {
+    if (e.key == 'Enter') {
+      if (pageNumber > 1 && pageNumber <= totalPaginatedPages) {
+          window.location.href = `${protocolAndHost}/media/articles/page/${paginationInput.value}/`;
+      } else if (pageNumber == 1) {
+          window.location.href = `${protocolAndHost}/media/articles/`;
+      } else {
+        console.log('Cant navigate past bounds of paginated collection');
+      }
+    }
+  }, false);
+
+  paginationPrevButton.addEventListener("click", function(e) {
+    if (currentPage > 2) {
+      window.location.href = `${protocolAndHost}/media/articles/page/${currentPage - 1}/`;
+    } else {
+      window.location.href = `${protocolAndHost}/media/articles/`;
+    }
+  }, false);
+
+  paginationNextButton.addEventListener("click", function(e) {
+    if (currentPage < totalPaginatedPages) {
+      window.location.href = `${protocolAndHost}/media/articles/page/${parseInt(currentPage) + 1}/`;
+    } else {
+      window.location.href = `${protocolAndHost}/media/articles/page/${totalPaginatedPages}`;
+    }
+  }, false);
 });

--- a/_includes/_article_index.html
+++ b/_includes/_article_index.html
@@ -13,5 +13,5 @@
 </div>
 
 <div class="push-top">
-  {% include _pagination.html collection="articles" remote=true label="" link_root=include.link_root %}
+  {% include _pagination.html collection="articles" n_of_total_pagination="true" label="" link_root=include.link_root %}
 </div>

--- a/_includes/_pagination.html
+++ b/_includes/_pagination.html
@@ -9,12 +9,25 @@
     {% assign root = include.collection | prepend: 'media/' %}
   {% endif %}
 
+  <!-- For "Load More" pagination -->
   {% if include.remote == true %}
   <div class="load-more">
     <button class="btn {% if include.btn-type == 'white-outline' %}btn-white btn-outline{% else %}btn-blue{% endif %}" data-role="load-more" data-paginate="{{ include.collection }}">Load more{{ include.label | prepend: ' ' }}</button>
   </div>
-  {% endif %}
+  <!-- End "Load More" pagination -->
 
+  {% elsif include.n_of_total_pagination == "true" %}
+  <div class="text-center">
+    <button id="pagination-previous-button"><<</button>
+    <input type="text" id="pagination-current-page" placeholder="{{paginator.page}}">
+    <span>of</span>
+    <span id="total_pages">{{paginator.total_pages}}</span>
+    <button id="pagination-submit-button">Go!</button>
+    <button id="pagination-next-button">>></button>
+  </div>
+
+  {% else %}
+  <!-- For Enumerated pagination -->
   <div class="text-center{% if include.remote == true %} hide{% endif %}">
     <ul class="pagination" data-pagination="{{ include.collection }}">
     {% if paginator.previous_page %}
@@ -53,4 +66,6 @@
     {% endif %}
     </ul>
   </div>
+  <!-- End Enumerated pagination -->
+  {% endif %}
 {% endif %}


### PR DESCRIPTION
Pagination on the article index is now in the format of [n] of NN, where
"n" is the current page your are on, "[]" is the input field that allows
you to change which page you are on, and "NN" is the total number of
paginated pages.

## Problem
It was requested that we do a more traditional pagination solution for
the articles index page.

## Solution
This PR adds in code to provide a more traditional pagination experience.

### Corresponding Branch
No corresponding branches.

## Testing
Visit /media/articles/ and use the navigation provided at the bottom of the page.