### PR TITLE
Initial fix to display author picutre and bio

### DIFF
--- a/_layouts/author.html
+++ b/_layouts/author.html
@@ -2,8 +2,7 @@
 layout: default
 ---
 
-{% assign author = site.authors | where: 'full_name', page.title | first %}
-
+{% assign author = page %}
 <div class="container push-bottom">
   {% include _author-bio.html %}
 


### PR DESCRIPTION
## Problem
Previously, on an Author page, some authors had missing pictures and bio information.

## Solution
By assigning the author to the page variable, we were able to get the author image and bio information to display correctly, without negatively impacting any of the authors whose pages were working correctly.

### Corresponding Branch
No corresponding branch.

## Testing
Visit the following authors to confirm their information is displaying correctly:

Allie Janszen
Animaesh Manglik
Nicole McDaniel