### PR TITLE
Fix author bio and image

### DIFF
--- a/_layouts/author.html
+++ b/_layouts/author.html
@@ -2,7 +2,7 @@
 layout: default
 ---
 
-{% assign author = site.authors | where: 'full_name', page.title | first %}
+{% assign author = page %}
 
 <div class="container push-bottom">
   {% include _author-bio.html %}


### PR DESCRIPTION
## Problem
Currently some authors' bios are not displaying correctly.

## Solution
By assigning the author to the page variable in the author.html layout, author information is now displaying correctly for previously broken author profiles without negatively affecting previously working author pages.

### Corresponding Branch
No corresponding branches

## Testing
Do a spot check of various authors, ensuring you also view the page for author Allie Janszen.