### PR TITLE
Testing Bugfix - Defect/us21210 view all happenings

### DIFF
--- a/_layouts/established.html
+++ b/_layouts/established.html
@@ -55,7 +55,9 @@ layout: default
             <div class="col-sm-8 push-bottom soft-bottom">
 
               <!-- Featured Section - Below Jumbotron -->
+              {% assign hasPromo = false %}
               {% if page.featured_below.size > 0 %}
+              {% assign hasPromo = true %}
               <div class="overflow-hidden push-bottom">
                 {{ page.featured_below }}
               </div>
@@ -74,7 +76,7 @@ layout: default
                 color="orange"></crds-button>
             </div>
             <div class="col-sm-4 push-bottom soft-bottom">
-              <crds-site-happenings-locations location="{{ page.name }}" show-limit="5"></crds-site-happenings-locations>
+              <crds-site-happenings-locations location="{{ page.name }}" show-limit="5" has-promo="{{ hasPromo }}"></crds-site-happenings-locations>
             </div>
           </div>
         </div>

--- a/_layouts/frontier.html
+++ b/_layouts/frontier.html
@@ -98,7 +98,9 @@ layout: default
 
             <div class="col-sm-8 push-bottom soft-bottom">
               <!-- Featured Section - Below Jumbotron -->
+              {% assign hasPromo = false %}
               {% if page.featured_below.size > 0 %}
+              {% assign hasPromo = true %}
               <div class="overflow-hidden push-bottom">
                 {{ page.featured_below }}
               </div>
@@ -133,7 +135,7 @@ layout: default
                   <crds-button href="{{ page.google_calendar_link }}" color="white" display="outline" text="View Calendar" target="_blank"></crds-button>
                 </div>
               </div>
-              <crds-site-happenings-locations location="{{ page.name }}" show-limit="4"></crds-site-happenings-locations>
+              <crds-site-happenings-locations location="{{ page.name }}" show-limit="4" has-promo="{{ hasPromo }}"></crds-site-happenings-locations>
             </div>
           </div>
         </div>


### PR DESCRIPTION
"If there is a featured promo only show 5 and then View More to expand others"
previously I had hard coded locations with monetate content to auto display all happenings. However they will not be using monetate content on the locations pages in the future, so this is now keying off of a "hasPromo" prop and is now dynamic

[Asana Task](https://rally1.rallydev.com/#/66096747656d/dashboard?detail=%2Fuserstory%2F600916034915)