### PR TITLE
Remove imgix optimizer attributes

### DIFF
--- a/_layouts/established.html
+++ b/_layouts/established.html
@@ -202,8 +202,8 @@ layout: default
                 <div class="row row-no-gutters push-top">
                   <div class="d-flex col-sm-6 col-xs-8">
                     {% if page.student_ministry_leader_image %}
-                    <img class="img-circle img-size-4 object-fit-cover" src="{{ page.student_ministry_leader_image.url | imgix: site.imgix }}?{{ site.imgix_params.placeholder_square }}"
-                    sizes="{{ site.image_sizes.cards_4x }}"  alt="{{ page.student_ministry_leader_name }}" data-optimize-img />
+                    <img class="img-circle img-size-4 object-fit-cover" src="{{ page.student_ministry_leader_image.url | imgix: site.imgix }}"
+                    sizes="{{ site.image_sizes.cards_4x }}"  alt="{{ page.student_ministry_leader_name }}" />
                     {% else %}
                     <img class="img-border img-circle img-size-4" src="https://crossroads-media.imgix.net/images/avatar.svg"  alt="{{ page.student_ministry_leader_name }}" />
                     {% endif %}

--- a/_layouts/frontier.html
+++ b/_layouts/frontier.html
@@ -306,8 +306,8 @@ layout: default
                 <div class="row row-no-gutters push-top">
                   <div class="d-flex col-sm-6 col-xs-8">
                     {% if page.student_ministry_leader_image %}
-                    <img class="img-circle img-size-4 object-fit-cover" src="{{ page.student_ministry_leader_image.url | imgix: site.imgix }}?{{ site.imgix_params.placeholder_square }}"
-                    sizes="{{ site.image_sizes.cards_4x }}"  alt="{{ page.student_ministry_leader_name }}" data-optimize-img />
+                    <img class="img-circle img-size-4 object-fit-cover" src="{{ page.student_ministry_leader_image.url | imgix: site.imgix }}"
+                    sizes="{{ site.image_sizes.cards_4x }}"  alt="{{ page.student_ministry_leader_name }}" />
                     {% else %}
                     <img class="img-border img-circle img-size-4" src="https://crossroads-media.imgix.net/images/avatar.svg"  alt="{{ page.student_ministry_leader_name }}" />
                     {% endif %}


### PR DESCRIPTION
## Problem
Images for the Ministry Leader Image on location pages was broken.

## Solution
I removed the extra url parameters and removed the data-optimize-imgix attributes from the constructed url.

## Testing
Visit /georgetown and /eastside and confirm that the youth ministry leader image is visible.