### PR TITLE
Change video.title to message.title

### DIFF
--- a/_layouts/author.html
+++ b/_layouts/author.html
@@ -163,7 +163,8 @@ layout: default
                   </a>
                   <div class="card-block hard">
                     <a href="{{ message | media_url }}">
-                      <h5 class="card-title font-size-smaller push-quarter-bottom">{{ video.title }}</h5>
+                      <h5 class="card-title font-size-smaller
+                        push-quarter-bottom">{{ message.title }}</h5>
                       <div class="font-size-smaller push-quarter-top push-half-bottom">
                         {{ message.description | markdownify | strip_html | truncatewords: 15 }}
                       </div>


### PR DESCRIPTION
## Problem
Under the messages tab on an author's page, the titles were the same for all messages.

## Solution
I changed `video.title` to `message.title` in the author.html layout. 

## Testing
Visit any author's page, click the "messages" tab, and confirm that all the messages don't have the same title.