### PR TITLE
Fix group meeting links on meetings that have multiple locations

### DIFF
--- a/_includes/groups/_meeting-details.html
+++ b/_includes/groups/_meeting-details.html
@@ -14,7 +14,7 @@
   {% endif %}
 </p>
 <p class="push-top font-size-smaller">
-  <a href="/groups/{{ category_slug }}/{{ group_slug.slug }}/{% if meeting.location.slug == 'anywhere' %}online{% else %}{{ meeting.location.slug }}{% endif %}">Learn more</a>
+  <a href="/groups/{{ category_slug }}/{{ group_slug.slug }}/{% if meeting.location.slug == 'anywhere' %}online{% else %}{{ page.location.slug }}{% endif %}">Learn more</a>
   {% if meeting.registration_link %}
   <span class="push-half-sides">/</span><a href="{{ meeting.registration_link }}" type="button">Register</a>
   {% endif %}

--- a/_layouts/onsite-groups/location.html
+++ b/_layouts/onsite-groups/location.html
@@ -46,7 +46,7 @@ snail_trail: connect
           <h4 class="font-family-condensed-extra text-uppercase">
             {% assign group_slug = meeting | group_for_meeting %}
             {% if group_slug %}
-            <a href="/groups/{{ category_slug }}/{{ group_slug.slug }}/{% if meeting.location.slug == 'anywhere' %}online{% else %}{{ meeting.location.slug }}{% endif %}">
+            <a href="/groups/{{ category_slug }}/{{ group_slug.slug }}/{% if meeting.location.slug == 'anywhere' %}online{% else %}{{ page.location.slug }}{% endif %}">
               {{ meeting.title }}
             </a>
             {% else %}


### PR DESCRIPTION
## Problem
[Rally Task](https://rally1.rallydev.com/#/66096747656d/custom/24109743995?detail=%2Fdefect%2F508478843188)

## Solution
I updated the "Title" and "Learn More" links to use `page.location.slug` instead of the `meeting.location.slug`. 

Right now each meeting includes a `locations` array with all possible locations for a meeting. The `meeting.location` object is assigned to the first alphabetically instead of matching the page it was called from. (See screenshot below, rendered on the "Dayton" page.) I'm not sure if this is something that needs to be fixed.

`Meetings` data is being assigned here:
https://github.com/crdschurch/crds-net/blob/5de7a8eee8572f5240b90ce839bbd8d4b0b91ad3/_plugins/generators/onsite_groups_generator.rb#L38

<img src="https://user-images.githubusercontent.com/13209343/128875294-74e6c6c3-6c1b-454e-8002-af145f9563de.png" width="500" />

## Testing
Links are updated in each location's page inside `/groups/locations/`. Links on the "Site Based" and "Healing" tabs are unchanged.
