### PR TITLE
Update Flickity Carousel on /live

### DIFF
--- a/_assets/javascripts/components/flickity-display.js
+++ b/_assets/javascripts/components/flickity-display.js
@@ -1,0 +1,4 @@
+$(document).ready(function() {
+  $(".card-deck.carousel").addClass("is-visible");
+  $(".carousel-cell").addClass("is-visible");
+});

--- a/_assets/javascripts/config.js
+++ b/_assets/javascripts/config.js
@@ -42,6 +42,7 @@ module.exports = [
       'components/countdown',
       'components/jumbotron-video',
       'components/filters',
+      'components/flickity-display',
       'components/smart-banner',
       'components/pagination',
       'components/tabs',

--- a/_assets/stylesheets/components/_flickity-display.scss
+++ b/_assets/stylesheets/components/_flickity-display.scss
@@ -1,0 +1,20 @@
+// Flickity Wrapper
+.card-deck.carousel {
+  max-height: 500px;
+}
+
+.card-deck.carousel.is-visible {
+  max-height: none;
+}
+
+// Flickity Cell
+.carousel-cell {
+  opacity: 0;
+  display: none;
+}
+
+.carousel-cell.is-visible {
+  display: flex;
+  opacity: 1;
+  transition: opacity 0.3s ease;
+}

--- a/_assets/stylesheets/components/_flickity-display.scss
+++ b/_assets/stylesheets/components/_flickity-display.scss
@@ -18,3 +18,8 @@
   opacity: 1;
   transition: opacity 0.3s ease;
 }
+
+// Update cursor
+.flickity-enabled.is-draggable .flickity-viewport {
+  cursor: auto !important;
+}

--- a/_assets/stylesheets/components/_modules.scss
+++ b/_assets/stylesheets/components/_modules.scss
@@ -26,3 +26,4 @@
 @import "./rollcall";
 @import "./signoff";
 @import "./accordion";
+@import "./flickity-display";


### PR DESCRIPTION
## Problem
[Rally task](https://rally1.rallydev.com/#/66096747656d/custom/24109743995?detail=%2Fdefect%2F489063345032)

## Solution
- Hide Flickity cells until javascript is done loading to prevent them from initially displaying vertically 
- Set cursor to `auto` instead of `grab` on Flickity viewport 
- These changes impact all `.card-deck.carousel` and `.carousel-cell` classes on the site. (Container classes for Flickity carousel.)

## Testing
/live 

See the grid/carousel under the "happening at crossroads" header. On page refresh, the cells should not load vertically and are hidden until the grid is ready. On hover, the cursor is either the `default` cursor or `pointer` on links.