### PR TITLE
add redirect for online registrants

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -58,6 +58,8 @@ package = "./_plugins/netlify-plugin-health-check"
   CRDS_GROUPS_LEGACY_ENDPOINT = "crds-groups-legacy-int.netlify.app"
   CRDS_INVOICES = "crds-invoices-int.netlify.app"
   CRDS_VOLUNTEER = "https://crds-volunteer-int.netlify.app/"
+  CRDS_ONLINE_DOMAIN = "int-crds-online.netlify.app"
+
 
 [context.deploy-preview.environment]
   CRDS_PEOPLE_DOMAIN = "crds-people-int.netlify.app"
@@ -80,6 +82,8 @@ package = "./_plugins/netlify-plugin-health-check"
   CRDS_GROUPS_LEGACY_ENDPOINT = "crds-groups-legacy-int.netlify.app"
   CRDS_INVOICES = "crds-invoices-int.netlify.app"
   CRDS_VOLUNTEER = "https://crds-volunteer-int.netlify.app/"
+  CRDS_ONLINE_DOMAIN = "int-crds-online.netlify.app"
+
 
 [context.development.environment]
   CRDS_PEOPLE_DOMAIN = "crds-people-int.netlify.app"
@@ -103,6 +107,8 @@ package = "./_plugins/netlify-plugin-health-check"
   CRDS_INVOICES = "crds-invoices-int.netlify.app"
   CRDS_CORKBOARD_ENDPOINT = "crds-corkboard-int.netlify.app"
   CRDS_VOLUNTEER = "https://crds-volunteer-int.netlify.app/"
+  CRDS_ONLINE_DOMAIN = "int-crds-online.netlify.app"
+  
 
 [context.runway.environment]
   CRDS_PEOPLE_DOMAIN = "crds-people-int.netlify.app"
@@ -125,6 +131,8 @@ package = "./_plugins/netlify-plugin-health-check"
   CRDS_GROUPS_LEGACY_ENDPOINT = "crds-groups-legacy-int.netlify.app"
   CRDS_INVOICES = "crds-invoices-int.netlify.app"
   CRDS_VOLUNTEER = "https://crds-volunteer-int.netlify.app/"
+  CRDS_ONLINE_DOMAIN = "int-crds-online.netlify.app"
+
 
 
 [context.release.environment]
@@ -148,6 +156,8 @@ package = "./_plugins/netlify-plugin-health-check"
   CRDS_GROUPS_LEGACY_ENDPOINT = "crds-groups-legacy-demo.netlify.app"
   CRDS_INVOICES = "crds-invoices-demo.netlify.app"
   CRDS_VOLUNTEER = "https://crds-volunteer-demo.netlify.app/"
+  CRDS_ONLINE_DOMAIN = "demo-crds-online.netlify.app"
+
 
 [context.master.environment]
   CRDS_PEOPLE_DOMAIN = "crds-people.netlify.app"
@@ -171,6 +181,8 @@ package = "./_plugins/netlify-plugin-health-check"
   CRDS_INVOICES = "crds-invoices.netlify.app"
   CRDS_CORKBOARD_ENDPOINT = "crds-corkboard.netlify.app"
   CRDS_VOLUNTEER = "https://crds-volunteer.netlify.app/"
+  CRDS_ONLINE_DOMAIN = "crds-online.netlify.app"
+
 
 [context.rebrand.environment]
   CRDS_PEOPLE_DOMAIN = "crds-people-int.netlify.app"
@@ -193,3 +205,5 @@ package = "./_plugins/netlify-plugin-health-check"
   CRDS_GROUPS_LEGACY_ENDPOINT = "crds-groups-legacy-int.netlify.app"
   CRDS_INVOICES = "crds-invoices-int.netlify.app"
   CRDS_VOLUNTEER = "https://crds-volunteer-int.netlify.app/"
+  CRDS_ONLINE_DOMAIN = "int-crds-online.netlify.app"
+

--- a/netlify.toml
+++ b/netlify.toml
@@ -58,7 +58,7 @@ package = "./_plugins/netlify-plugin-health-check"
   CRDS_GROUPS_LEGACY_ENDPOINT = "crds-groups-legacy-int.netlify.app"
   CRDS_INVOICES = "crds-invoices-int.netlify.app"
   CRDS_VOLUNTEER = "https://crds-volunteer-int.netlify.app/"
-  CRDS_ONLINE_DOMAIN = "int-crds-online.netlify.app"
+  CRDS_ONLINE_DOMAIN = "https://online-int.crossroads.net"
 
 
 [context.deploy-preview.environment]
@@ -82,7 +82,7 @@ package = "./_plugins/netlify-plugin-health-check"
   CRDS_GROUPS_LEGACY_ENDPOINT = "crds-groups-legacy-int.netlify.app"
   CRDS_INVOICES = "crds-invoices-int.netlify.app"
   CRDS_VOLUNTEER = "https://crds-volunteer-int.netlify.app/"
-  CRDS_ONLINE_DOMAIN = "int-crds-online.netlify.app"
+  CRDS_ONLINE_DOMAIN = "https://online-int.crossroads.net"
 
 
 [context.development.environment]
@@ -107,7 +107,7 @@ package = "./_plugins/netlify-plugin-health-check"
   CRDS_INVOICES = "crds-invoices-int.netlify.app"
   CRDS_CORKBOARD_ENDPOINT = "crds-corkboard-int.netlify.app"
   CRDS_VOLUNTEER = "https://crds-volunteer-int.netlify.app/"
-  CRDS_ONLINE_DOMAIN = "int-crds-online.netlify.app"
+  CRDS_ONLINE_DOMAIN = "https://online-int.crossroads.net"
   
 
 [context.runway.environment]
@@ -131,7 +131,7 @@ package = "./_plugins/netlify-plugin-health-check"
   CRDS_GROUPS_LEGACY_ENDPOINT = "crds-groups-legacy-int.netlify.app"
   CRDS_INVOICES = "crds-invoices-int.netlify.app"
   CRDS_VOLUNTEER = "https://crds-volunteer-int.netlify.app/"
-  CRDS_ONLINE_DOMAIN = "int-crds-online.netlify.app"
+  CRDS_ONLINE_DOMAIN = "https://online-int.crossroads.net"
 
 
 
@@ -156,7 +156,7 @@ package = "./_plugins/netlify-plugin-health-check"
   CRDS_GROUPS_LEGACY_ENDPOINT = "crds-groups-legacy-demo.netlify.app"
   CRDS_INVOICES = "crds-invoices-demo.netlify.app"
   CRDS_VOLUNTEER = "https://crds-volunteer-demo.netlify.app/"
-  CRDS_ONLINE_DOMAIN = "demo-crds-online.netlify.app"
+  CRDS_ONLINE_DOMAIN = "https://online-demo.crossroads.net"
 
 
 [context.master.environment]
@@ -181,7 +181,7 @@ package = "./_plugins/netlify-plugin-health-check"
   CRDS_INVOICES = "crds-invoices.netlify.app"
   CRDS_CORKBOARD_ENDPOINT = "crds-corkboard.netlify.app"
   CRDS_VOLUNTEER = "https://crds-volunteer.netlify.app/"
-  CRDS_ONLINE_DOMAIN = "crds-online.netlify.app"
+  CRDS_ONLINE_DOMAIN = "https://online.crossroads.net"
 
 
 [context.rebrand.environment]
@@ -205,5 +205,5 @@ package = "./_plugins/netlify-plugin-health-check"
   CRDS_GROUPS_LEGACY_ENDPOINT = "crds-groups-legacy-int.netlify.app"
   CRDS_INVOICES = "crds-invoices-int.netlify.app"
   CRDS_VOLUNTEER = "https://crds-volunteer-int.netlify.app/"
-  CRDS_ONLINE_DOMAIN = "int-crds-online.netlify.app"
+  CRDS_ONLINE_DOMAIN = "https://online-int.crossroads.net"
 

--- a/redirects.csv
+++ b/redirects.csv
@@ -196,6 +196,6 @@ https://discipleship.crossroads.net/*,https://www.crossroads.net/huddle,301!,mas
 /online/getstarted,https://online.crossroads.net/,301!
 /getstarted/thank-you,https://online.crossroads.net/,301!
 /live,https://online.crossroads.net/,301!
-/*,/404.html,404
 /signin,/https://online-int.crossroads.net,301 Cookie=fromOnline
+/*,/404.html,404
 

--- a/redirects.csv
+++ b/redirects.csv
@@ -196,6 +196,6 @@ https://discipleship.crossroads.net/*,https://www.crossroads.net/huddle,301!,mas
 /online/getstarted,https://online.crossroads.net/,301!
 /getstarted/thank-you,https://online.crossroads.net/,301!
 /live,https://online.crossroads.net/,301!
-/signin,/https://online-int.crossroads.net,301 Cookie=fromOnline
+/signin,${CRDS_ONLINE_DOMAIN}/sign-in,301 Cookie=fromOnline
 /*,/404.html,404
 

--- a/redirects.csv
+++ b/redirects.csv
@@ -197,3 +197,5 @@ https://discipleship.crossroads.net/*,https://www.crossroads.net/huddle,301!,mas
 /getstarted/thank-you,https://online.crossroads.net/,301!
 /live,https://online.crossroads.net/,301!
 /*,/404.html,404
+/signin,/https://online-int.crossroads.net,301 Cookie=fromOnline
+


### PR DESCRIPTION
## Problem
online registrants are being redirected to crds-net and not church online after account activation.

## Solution
redirect based on cookie presence  will allow for said users to be properly redirected.

### Corresponding Branch
/auth-redirect branch see also [this pr](https://github.com/crdschurch/crds-online/pull/342) and t[his pr](https://github.com/crdschurch/crds-components/pull/1450)

## Testing
Testing will require a user to register on Church Online, activate their email and see if redirection is to Church Online Sign in vs. crds-net signin