### PR TITLE
Add check for keys that should be blocked for pagination input

### DIFF
--- a/_assets/javascripts/components/pagination.js
+++ b/_assets/javascripts/components/pagination.js
@@ -156,8 +156,25 @@ $(document).ready(function() {
     navigateToPageByInput();
   }, false);
 
-  document.getElementById("pagination-current-page").addEventListener("keyup", function(e) {
-    if (e.key == 'Enter' && canNavigate) {
+  document.getElementById("pagination-current-page").addEventListener("keydown", function(e) {
+    const dashKeyCode = 189;
+    const numPadNumber0KeyCode = 96;
+    const numPadMultiplyKeyCode = 106;
+    const number0KeyCode = 48;
+    const colonKeyCode = 58;
+    const backspaceKeyCode = 8;
+    const enterKeyCode = 13;
+
+    if (e.keyCode == dashKeyCode || e.key == "-") {
+      e.preventDefault();
+      return false;
+    } else if (!((e.keyCode > numPadNumber0KeyCode && e.keyCode < numPadMultiplyKeyCode)
+      || (e.keyCode > number0KeyCode && e.keyCode < colonKeyCode)
+      || e.keyCode == backspaceKeyCode
+      || e.keyCode == enterKeyCode)) {
+      e.preventDefault();
+      return false;
+    } else if (e.key == 'Enter' && canNavigate) {
       navigateToPageByInput();
     }
   }, false);

--- a/_includes/_pagination.html
+++ b/_includes/_pagination.html
@@ -17,7 +17,7 @@
   {% elsif include.n_of_total_pagination == "true" %}
   <div class="input-pagination">
     <button class="btn btn-link text-blue" id="pagination-previous-button">&lt;</button>
-    <input class="form-control form-control-custom-small" type="number"
+    <input class="form-control form-control-custom-small" require type="number" min="1"
     max="{{paginator.total_pages}}" id="pagination-current-page" placeholder="{{paginator.page}}">
     <span>of</span>
     <span id="total_pages">{{paginator.total_pages}}</span>


### PR DESCRIPTION
## Problem
Pagination input field allowed negative values on /media/articles

## Solution
Add an event listener and checks on keystrokes to prevent the input of anything other than positive numbers in the pagination input field.

### Corresponding Branch
No corresponding branch

## Testing
Navigate to https://6148bc3e9fd22934197af791--crds-net.netlify.app/media/articles/ to see a deploy preview. Try typing letters and characters that aren't numbers in the input field to confirm that they do not appear. Click the up and down arrows in the input field to confirm that you can't navigate to negative numbers.