### PR TITLE
Remove else clause to give access to ul.pagination element in all pagination clauses

### DIFF
--- a/_includes/_pagination.html
+++ b/_includes/_pagination.html
@@ -24,8 +24,9 @@
     <button class="btn btn-blue" id="pagination-submit-button">Go!</button>
     <button class="btn btn-link text-blue" id="pagination-next-button">&gt;</button>
   </div>
+  {% endif %}
 
-  {% else %}
+  {% if include.n_of_total_pagination != "true" %}
   <div class="text-center{% if include.remote == true %} hide{% endif %}">
     <ul class="pagination" data-pagination="{{ include.collection }}">
     {% if paginator.previous_page %}


### PR DESCRIPTION
## Problem
Pagination on Humans of Crossroads was broken. Each time the "Load More" button was clicked, the same set of articles was loading.

## Solution
A portion of code was accidentally bypassed that provided the requisite `ul.pagination` element when a previous pagination feature was merged. This code restores the presence of the `ul.pagination` element when `n_of_total_pagination` is not getting used.

### Corresponding Branch
There are no corresponding branches with this work.

## Testing
Navigate to /media/articles and confirm pagination is working there.
Navigate to /media/humans-of-crossroads and confirm pagination is working there
Navigate to any other locations you are aware of pagination being present and confirm it is working correctly.