### PR TITLE
Remove hubspot newsletter signup on media index

### DIFF
--- a/media/index.html
+++ b/media/index.html
@@ -151,11 +151,6 @@ paginate:
             {% include media-homepage/_latest-message.html %}
           </div>
         </div>
-
-        <div>
-          {% include media-homepage/_hubspot-newsletter-form.html %}
-        </div>
-
       </div>
     </div>
   </section>


### PR DESCRIPTION
## Problem
Newsletter sign up not longer wanted on media index page

## Solution
Removed _includes file that placed the signup on the media index page

### Corresponding Branch
No corresponding branches

## Testing
Go to /media and confirm the newsletter signup component is no longer present on the right side of the page.