### PR TITLE
DE8778 Article Social Icons

### DIFF
--- a/_assets/stylesheets/pages/_articles.scss
+++ b/_assets/stylesheets/pages/_articles.scss
@@ -55,6 +55,27 @@
     padding: 16px 0;
     margin-bottom: 0;
   }
+
+  .social-container {
+    display: flex;
+    position: relative;
+    top: unset;
+    right: unset;
+
+    .social-btn {
+      .icon-color {
+        fill: $cr-orange-dark !important;
+      }
+  
+      &:focus,
+      &:hover {
+        .icon-color {
+          fill: $cr-orange !important;
+        }
+      }
+    }
+  }
+
   .article-tpl-author-section {
     display: flex;
     flex-direction: column;


### PR DESCRIPTION
## Problem
[DE8778](https://rally1.rallydev.com/#/?detail=/defect/618250903277&fdp=true): Social icons are overlaying the hero image

## Solution
[Deploy Preview](https://61a918e3210814717c044c61--int-crds-net.netlify.app/media/articles/two-soldiers-down)
![Screen Shot 2021-11-30 at 2 43 00 PM](https://user-images.githubusercontent.com/32345656/144116458-74e9e57c-8160-46aa-afaf-d7b13aa1ffa3.png)