### PR TITLE
DE8872 video on modal close

### DIFF
--- a/_layouts/collection.html
+++ b/_layouts/collection.html
@@ -112,4 +112,10 @@ layout: default
       </div>
     </div>
   </div>
+
+  <script type="text/javascript">
+    $('#trailerModal').on('hidden.bs.modal', function () {
+      $("#trailerModal iframe").attr("src", $("#trailerModal iframe").attr("src"));
+  });
+  </script>
 {% endif %}


### PR DESCRIPTION
## Problem
On shows with trailer - when I X out of the modal, the video sound still plays
[DE8872](https://rally1.rallydev.com/#/?detail=/defect/626546433481&fdp=true): Video sound plays after the modal is closed