### PR TITLE
US21913 Remove logzio from crds-net

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,16 +136,6 @@ collections:
 
 ## Build Logs
 
-Build logs are dependant on two environment variables
-- APPLICATION_NAME
-- LOGZIO_API_KEY
-
-To find an erroneous log use the following search term in the logz.io search bar:
-
-    type:"APPLICATION_NAME"
-
-APPLICATION_NAME is the value set to that environment variable
-
 Build logs output to `buildlogs.txt`
 
 * **Local development:**  

--- a/bin/build-command.sh
+++ b/bin/build-command.sh
@@ -7,4 +7,3 @@
   ./bin/kickOffCypress.sh &&
   ./bin/adjustCrossroadsOnlineCanonicalURL.sh
 } 2>buildlog.txt
-./bin/logzio.sh

--- a/bin/logzio.sh
+++ b/bin/logzio.sh
@@ -1,3 +1,0 @@
-#!/bin/bash
-
-curl -T buildlog.txt http://listener.logz.io:8021/file_upload/${LOGZIO_API_KEY}/${APPLICATION_NAME}


### PR DESCRIPTION
This PR removes Logzio references to prevent continued shipping of logs
to the Logzio service.