### PR TITLE
Meter modal glitch

### DIFF
--- a/_assets/stylesheets/pages/_video.scss
+++ b/_assets/stylesheets/pages/_video.scss
@@ -1,4 +1,10 @@
 .overlay-container {
+  display: none;
+
+  .hydrated & {
+    display: block;
+  }
+
   @media screen and (max-width: $screen-md) {
     padding-top: 10px;
   }


### PR DESCRIPTION
## Problem
On video pages with the meter modal, the content will display on the page before the page fully loads.

[Asana Task](https://app.asana.com/0/1201454665996628/1201755178268983)

## Solution
Hide the content until the modal is hydrated.

## Testing
[Preview](https://deploy-preview-2550--int-crds-net.netlify.app/media/videos/3-35-stitches)