### PR TITLE
Modify user landing page based on auth

### DIFF
--- a/redirects.csv
+++ b/redirects.csv
@@ -15,7 +15,7 @@ https://forms-demo.crossroads.net/*,https://${env:CRDS_APP_DOMAIN}/forms/:splat,
 https://forms.crossroads.net/*,https://${env:CRDS_APP_DOMAIN}/forms/:splat,302!
 /,/h,200! Role=user
 /online/*,${env:CRDS_ONLINE_DOMAIN}/online/:splat,200! Role=user
-/online/*,${env:CRDS_APP_DOMAIN}/online/getstarted,200
+/online/*,${env:CRDS_ONLINE_DOMAIN}/online/getstarted,200
 /group-renew groupIds=:groupIds,/group-renew?groupIds=:groupIds,200! Role=user
 /group-renew groupIds=:groupIds,/signin?redirectUrl=/group-renew?groupIds=:groupIds,302!
 /spouse-invite-landing inviteId=:inviteId response=decline,/spouse-invite-landing/?inviteId=:inviteId&response=decline,200!

--- a/redirects.csv
+++ b/redirects.csv
@@ -14,8 +14,7 @@ http://forms-int.crossroads.net/*,https://${env:CRDS_APP_DOMAIN}/forms/:splat,30
 https://forms-demo.crossroads.net/*,https://${env:CRDS_APP_DOMAIN}/forms/:splat,302!
 https://forms.crossroads.net/*,https://${env:CRDS_APP_DOMAIN}/forms/:splat,302!
 /,/h,200! Role=user
-/online/*,${env:CRDS_ONLINE_DOMAIN}/online/:splat,200! Role=user
-/online/*,${env:CRDS_ONLINE_DOMAIN}/online/getstarted,200
+/online/*,${env:CRDS_APP_DOMAIN}/online/getstarted,200
 /group-renew groupIds=:groupIds,/group-renew?groupIds=:groupIds,200! Role=user
 /group-renew groupIds=:groupIds,/signin?redirectUrl=/group-renew?groupIds=:groupIds,302!
 /spouse-invite-landing inviteId=:inviteId response=decline,/spouse-invite-landing/?inviteId=:inviteId&response=decline,200!

--- a/redirects.csv
+++ b/redirects.csv
@@ -15,7 +15,7 @@ https://forms-demo.crossroads.net/*,https://${env:CRDS_APP_DOMAIN}/forms/:splat,
 https://forms.crossroads.net/*,https://${env:CRDS_APP_DOMAIN}/forms/:splat,302!
 /,/h,200! Role=user
 /online/*,${env:CRDS_ONLINE_DOMAIN}/online/:splat,200! Role=user
-/online/*,${env:CRDS_APP_DOMAIN}/online/getstarted,200!
+/online/*,/online-church-test,200!
 /group-renew groupIds=:groupIds,/group-renew?groupIds=:groupIds,200! Role=user
 /group-renew groupIds=:groupIds,/signin?redirectUrl=/group-renew?groupIds=:groupIds,302!
 /spouse-invite-landing inviteId=:inviteId response=decline,/spouse-invite-landing/?inviteId=:inviteId&response=decline,200!

--- a/redirects.csv
+++ b/redirects.csv
@@ -13,8 +13,9 @@ https://forms-int.crossroads.net/*,https://${env:CRDS_APP_DOMAIN}/forms/:splat,3
 http://forms-int.crossroads.net/*,https://${env:CRDS_APP_DOMAIN}/forms/:splat,302!
 https://forms-demo.crossroads.net/*,https://${env:CRDS_APP_DOMAIN}/forms/:splat,302!
 https://forms.crossroads.net/*,https://${env:CRDS_APP_DOMAIN}/forms/:splat,302!
+/online/*,${env:CRDS_ONLINE_DOMAIN}/online/:splat,200! Role=user
+/online/*,${env:CRDS_ONLINE_DOMAIN}/online/getstarted,200
 /,/h,200! Role=user
-/online/*,${env:CRDS_APP_DOMAIN}/online/getstarted,200
 /group-renew groupIds=:groupIds,/group-renew?groupIds=:groupIds,200! Role=user
 /group-renew groupIds=:groupIds,/signin?redirectUrl=/group-renew?groupIds=:groupIds,302!
 /spouse-invite-landing inviteId=:inviteId response=decline,/spouse-invite-landing/?inviteId=:inviteId&response=decline,200!

--- a/redirects.csv
+++ b/redirects.csv
@@ -14,6 +14,7 @@ http://forms-int.crossroads.net/*,https://${env:CRDS_APP_DOMAIN}/forms/:splat,30
 https://forms-demo.crossroads.net/*,https://${env:CRDS_APP_DOMAIN}/forms/:splat,302!
 https://forms.crossroads.net/*,https://${env:CRDS_APP_DOMAIN}/forms/:splat,302!
 /,/h,200! Role=user
+/online/*,${env:CRDS_ONLINE_DOMAIN}/online/:splat,200!
 /group-renew groupIds=:groupIds,/group-renew?groupIds=:groupIds,200! Role=user
 /group-renew groupIds=:groupIds,/signin?redirectUrl=/group-renew?groupIds=:groupIds,302!
 /spouse-invite-landing inviteId=:inviteId response=decline,/spouse-invite-landing/?inviteId=:inviteId&response=decline,200!

--- a/redirects.csv
+++ b/redirects.csv
@@ -13,9 +13,9 @@ https://forms-int.crossroads.net/*,https://${env:CRDS_APP_DOMAIN}/forms/:splat,3
 http://forms-int.crossroads.net/*,https://${env:CRDS_APP_DOMAIN}/forms/:splat,302!
 https://forms-demo.crossroads.net/*,https://${env:CRDS_APP_DOMAIN}/forms/:splat,302!
 https://forms.crossroads.net/*,https://${env:CRDS_APP_DOMAIN}/forms/:splat,302!
-/online/*,${env:CRDS_ONLINE_DOMAIN}/online/:splat,200! Role=user
-/online/*,${env:CRDS_ONLINE_DOMAIN}/online/getstarted,200
 /,/h,200! Role=user
+/online/*,${env:CRDS_ONLINE_DOMAIN}/online/:splat,200! Role=user
+/online/*,${env:CRDS_ONLINE_DOMAIN}/online/getstarted,200!
 /group-renew groupIds=:groupIds,/group-renew?groupIds=:groupIds,200! Role=user
 /group-renew groupIds=:groupIds,/signin?redirectUrl=/group-renew?groupIds=:groupIds,302!
 /spouse-invite-landing inviteId=:inviteId response=decline,/spouse-invite-landing/?inviteId=:inviteId&response=decline,200!

--- a/redirects.csv
+++ b/redirects.csv
@@ -14,7 +14,8 @@ http://forms-int.crossroads.net/*,https://${env:CRDS_APP_DOMAIN}/forms/:splat,30
 https://forms-demo.crossroads.net/*,https://${env:CRDS_APP_DOMAIN}/forms/:splat,302!
 https://forms.crossroads.net/*,https://${env:CRDS_APP_DOMAIN}/forms/:splat,302!
 /,/h,200! Role=user
-/online/*,${env:CRDS_ONLINE_DOMAIN}/online/:splat,200!
+/online/*,${env:CRDS_ONLINE_DOMAIN}/online/:splat,200! Role=user
+/online/*,${env:CRDS_ONLINE_DOMAIN}/online/getstarted,200!
 /group-renew groupIds=:groupIds,/group-renew?groupIds=:groupIds,200! Role=user
 /group-renew groupIds=:groupIds,/signin?redirectUrl=/group-renew?groupIds=:groupIds,302!
 /spouse-invite-landing inviteId=:inviteId response=decline,/spouse-invite-landing/?inviteId=:inviteId&response=decline,200!

--- a/redirects.csv
+++ b/redirects.csv
@@ -13,9 +13,8 @@ https://forms-int.crossroads.net/*,https://${env:CRDS_APP_DOMAIN}/forms/:splat,3
 http://forms-int.crossroads.net/*,https://${env:CRDS_APP_DOMAIN}/forms/:splat,302!
 https://forms-demo.crossroads.net/*,https://${env:CRDS_APP_DOMAIN}/forms/:splat,302!
 https://forms.crossroads.net/*,https://${env:CRDS_APP_DOMAIN}/forms/:splat,302!
-/,/h,200! Role=user
 /online/*,${env:CRDS_ONLINE_DOMAIN}/online/:splat,200! Role=user
-/online/*,${env:CRDS_ONLINE_DOMAIN}/online/getstarted,200!
+/online/*,${env:CRDS_ONLINE_DOMAIN}/online/getstarted,301!
 /group-renew groupIds=:groupIds,/group-renew?groupIds=:groupIds,200! Role=user
 /group-renew groupIds=:groupIds,/signin?redirectUrl=/group-renew?groupIds=:groupIds,302!
 /spouse-invite-landing inviteId=:inviteId response=decline,/spouse-invite-landing/?inviteId=:inviteId&response=decline,200!

--- a/redirects.csv
+++ b/redirects.csv
@@ -13,8 +13,9 @@ https://forms-int.crossroads.net/*,https://${env:CRDS_APP_DOMAIN}/forms/:splat,3
 http://forms-int.crossroads.net/*,https://${env:CRDS_APP_DOMAIN}/forms/:splat,302!
 https://forms-demo.crossroads.net/*,https://${env:CRDS_APP_DOMAIN}/forms/:splat,302!
 https://forms.crossroads.net/*,https://${env:CRDS_APP_DOMAIN}/forms/:splat,302!
+/,/h,200! Role=user
 /online/*,${env:CRDS_ONLINE_DOMAIN}/online/:splat,200! Role=user
-/online/*,${env:CRDS_ONLINE_DOMAIN}/online/getstarted,301!
+/online/*,${env:CRDS_APP_DOMAIN}/online/getstarted,200
 /group-renew groupIds=:groupIds,/group-renew?groupIds=:groupIds,200! Role=user
 /group-renew groupIds=:groupIds,/signin?redirectUrl=/group-renew?groupIds=:groupIds,302!
 /spouse-invite-landing inviteId=:inviteId response=decline,/spouse-invite-landing/?inviteId=:inviteId&response=decline,200!

--- a/redirects.csv
+++ b/redirects.csv
@@ -15,7 +15,7 @@ https://forms-demo.crossroads.net/*,https://${env:CRDS_APP_DOMAIN}/forms/:splat,
 https://forms.crossroads.net/*,https://${env:CRDS_APP_DOMAIN}/forms/:splat,302!
 /,/h,200! Role=user
 /online/*,${env:CRDS_ONLINE_DOMAIN}/online/:splat,200! Role=user
-/online/*,${env:CRDS_ONLINE_DOMAIN}/online/getstarted,200!
+/online/*,${env:CRDS_APP_DOMAIN}/online/getstarted,200!
 /group-renew groupIds=:groupIds,/group-renew?groupIds=:groupIds,200! Role=user
 /group-renew groupIds=:groupIds,/signin?redirectUrl=/group-renew?groupIds=:groupIds,302!
 /spouse-invite-landing inviteId=:inviteId response=decline,/spouse-invite-landing/?inviteId=:inviteId&response=decline,200!


### PR DESCRIPTION
## Problem
Redirects need to be handled when coming from `crds-online` for the unified platform.

## Solution

- Added a redirect rule for `CRDS_ONLINE_DOMAIN` which currently uses the `crds-online` deploy preview
- Logged-in users will be redirected to `/online`
- Logged-out users will be redirected to `/online/getstarted` (functionality may not work until after merge)

## Testing
[Deploy Preview](https://deploy-preview-2551--int-crds-net.netlify.app/online)

Online PR: [https://github.com/crdschurch/crds-online/pull/552](https://github.com/crdschurch/crds-online/pull/552)