### PR TITLE
Add cookie redirect for /online guests

### DIFF
--- a/redirects.csv
+++ b/redirects.csv
@@ -15,6 +15,7 @@ https://forms-demo.crossroads.net/*,https://${env:CRDS_APP_DOMAIN}/forms/:splat,
 https://forms.crossroads.net/*,https://${env:CRDS_APP_DOMAIN}/forms/:splat,302!
 /,/h,200! Role=user
 /online/*,${env:CRDS_ONLINE_DOMAIN}/online/:splat,200! Role=user
+/online/*,${env:CRDS_ONLINE_DOMAIN}/online/:splat,200! Cookie=online_guest
 /online/*,/online-church-test,200!
 /group-renew groupIds=:groupIds,/group-renew?groupIds=:groupIds,200! Role=user
 /group-renew groupIds=:groupIds,/signin?redirectUrl=/group-renew?groupIds=:groupIds,302!


### PR DESCRIPTION
## Problem
The current `Continue as guest` button on the logged-out homepage will not redirect properly based on the new landing page auth system.

## Solution
Add a cookie-based redirect for `/online`

## Testing
*Include information on how to test your work here (if applicable).*