### PR TITLE
add wildcard redirect for /live/

### DIFF
--- a/redirects.csv
+++ b/redirects.csv
@@ -151,6 +151,7 @@ https://discipleship.crossroads.net/*,https://www.crossroads.net/huddle,301!,mas
 /mancamp/,https://www.mancamp.us/?utm_source=crsrds-mancamp,301
 /getstarted/thank-you,https://online.crossroads.net/,301!
 /live,https://online.crossroads.net/,301!
+/live/*,https://online.crossroads.net/:splat,301!
 /signin,${env:CRDS_ONLINE_DOMAIN}/sign-in,301! Cookie=from_online
 /the-chaser,/weekendfollowup,302!
 /weekend-prompts,/weekendfollowup,302!


### PR DESCRIPTION
https://rally1.rallydev.com/#/38108142417d/custom/24109743995?detail=%2Fdefect%2F624270329681&fdp=true

Problem:
The current redirect from https://www.crossroads.net/live/stream is improperly delayed, and Crds data team is still seeing user behavior traffic on old pages from that section.

Request:
Instantly redirect all user traffic from www.crossroads.net/live and /live/* to https://online.crossroads.net

Acceptance Criteria:
Given I am a website visitor
When I navigate to https://www.crossroads.net/live or https://www.crossroads.net/live/stream
Then I will immediately see https://online.crossroads.net load

## Problem
A wildcard was not redirecting routes under /live/

## Solution
updated redirects.csv to include a wildcard redirect for /live/*

## Testing
visit /live/stream on testing site