### PR TITLE
US22369 Resi Easter Service

### DIFF
--- a/_assets/javascripts/components/resi-player.js
+++ b/_assets/javascripts/components/resi-player.js
@@ -22,20 +22,23 @@ const isDayOfTheWeek = (day) => {
   }
 };
 
+let isSaturday = isDayOfTheWeek(6);
+let isSunday = isDayOfTheWeek(0);
+
+let saturdayServiceTimes = (
+  (getEstTime() >= 1455 && getEstTime() <= 2359)
+);
+
+let sundayServiceTimes = (
+  (getEstTime() >= 0 && getEstTime() <= 1300)
+);
+
 const isNotCtaRenderTime = () => {
-  let isSunday = isDayOfTheWeek(0);
-  let serviceWindow = (getEstTime() >= 825 && getEstTime() <= 1300);
-  return isSunday && serviceWindow;
+  return (isSunday && sundayServiceTimes) || (isSaturday && saturdayServiceTimes);
 };
 
 const isServiceTime = () => {
-  let isSunday = isDayOfTheWeek(0);
-
-  let sundayServiceTimes = (
-    (getEstTime() >= 825 && getEstTime() <= 1300)
-  );
-
-  return isSunday && sundayServiceTimes;
+  return (isSunday && sundayServiceTimes) || (isSaturday && saturdayServiceTimes);
 };
 
 const refreshPageForServiceStart = (hours, minutes, seconds) => {
@@ -66,7 +69,10 @@ if (!isServiceTime() && document.getElementById('resi-player')) {
   document.getElementById('resi-player').remove();
 }
 
-if (isDayOfTheWeek(0)) {
-  refreshPageForServiceStart(8,25,1);
+if (isSaturday) {
+  refreshPageForServiceStart(14,55,1);
+}
+
+if (isSunday) {
   refreshPageForServiceStart(13,1,1);
 }

--- a/index.html
+++ b/index.html
@@ -57,12 +57,12 @@ paginate:
 
 <!-- Assign Logged Out Home Ad -->
 {% assign logged_out_home_ad = site.content_blocks | where: 'slug', 'logged-out-home-ad' | first %}
-
+{% assign easter_service = site.content_blocks | where: 'slug', 'easter-service' | first %}
 <!-- From /Watch -->
 {% for serie in site.series %}
-  {% if serie.videos.size > 0 %}
-    {% assign series = serie %}
-  {% endif %}
+{% if serie.videos.size > 0 or serie.live_messages.size > 0 %}
+{% assign series = serie %}
+{% endif %}
 {% endfor %}
 
 {% assign online = series.videos | last | get_doc %}
@@ -89,6 +89,9 @@ paginate:
 </section>
 
 <!-- Curent Series Section -->
+{% if easter_service %}
+  {{ easter_service.content_block | liquify }}
+{% else %}
 <section class="bg-blue watch-section" style="margin-top:-24px;"> 
   <div class="home-jumbo-rel" style="background-image: url('{{ series.background_image.url | imgix: site.imgix }}?{{ site.imgix_params.placeholder }}');" data-optimize-bg-img>
     <div class="home-jumbo-overlay soft-ends">
@@ -183,6 +186,7 @@ paginate:
     </div>
   </div>
 </section>
+{% endif %}
 
 <section class="soft-top bg-blue soft-bottom bg-topo best-content-pos">
   <div class="container">


### PR DESCRIPTION
## Task
Update Resi Player for Easter services
Needs to go up on Saturday at 2:55 and go away on Sunday at 1

Also a space for a content block that will take over the current series section. This content block will be scheduled by AG to go live at 8am on Sunday

## Solution 
Test the [deploy preview](https://deploy-preview-2594--crds-net.netlify.app/oakley) by changing your date and time on your machine to the service times 