### PR TITLE
remove geolocation from locations page load

### DIFF
--- a/_assets/javascripts/lib/distance-sorter.js
+++ b/_assets/javascripts/lib/distance-sorter.js
@@ -20,7 +20,6 @@ CRDS.DistanceSorter = class DistanceSorter {
     this.locationsCarousel = DistanceSorter.getLocationsCarousel();
     this.cards = this.locationsCarousel.cards;
     this.locationFinder = new CRDS.LocationFinder();
-    this.isGeoAllowed();
   }
 
   static getLocationsCarousel() {


### PR DESCRIPTION
## Problem
Remove geolocation browser prompt from /locations page load

## Solution
remove call to function in init

### Corresponding Branch
remove-locations-geolocation

## Testing
https://629fc3e1a21d4d0067bf602d--int-crds-net.netlify.app/locations

When testing be sure to watch the url if clicking through site, as you'll often end up off this branch build. This PR refers to the /locations page. 