### PR TITLE
add center to home-jumbo-rel bg image

### DIFF
--- a/_assets/stylesheets/pages/_homepage.scss
+++ b/_assets/stylesheets/pages/_homepage.scss
@@ -1,6 +1,7 @@
 .home-jumbo-rel {
   position: relative;
   background-size: cover;
+  background-position: center;
 }
 
 .home-jumbo-overlay {


### PR DESCRIPTION
## Problem
This background image on the Logged Out Homepage does not properly resize when you change the viewport size
DE8961 https://rally1.rallydev.com/#/66096747656d/custom/24109743995?detail=%2Fdefect%2F639629882907

## Solution
The css class .home-jumbo-rel with the background-size: cover; needed a bg position of:
background-position: center;

### Corresponding Branch

Deploy Preview: 
https://62a09201439cff03f714fc09--int-crds-net.netlify.app/


## Testing
Currently the INT and Prod deploys have different content for the affected backgrounds. The Int deploys show a topographic map image. It now centers on smaller screens. Note that the cover size scales vertically and/or horizontally to cover the entire container background. This update makes it center. 



