### PR TITLE
Restore Humans of Crossroads BG image

### DIFF
--- a/_assets/stylesheets/pages/_humans-of-crossroads.scss
+++ b/_assets/stylesheets/pages/_humans-of-crossroads.scss
@@ -1,7 +1,7 @@
 .humans-of-crossroads {
   background-image:
     linear-gradient(to bottom, rgba($cr-gray-darkest, 0), (rgba($cr-gray-darkest, 1))),
-    url('//crds-media.imgix.net/2Fctn8o4bWp33fXihUZi03/3070d528e6fe8c80b0f2fae86ea02a69/pile-of-images.png');
+    url('//crds-media.imgix.net/7MZiucHPMb8Eua1P0HARsj/5d7937ad57bbd7cb907d466f236da9a5/pile-of-images.png');
   background-size: cover;
 
   .hoc-breadcrumb {


### PR DESCRIPTION
## Problem
Broken image on https://www.crossroads.net/media/humans-of-crossroads/ needed restored

## Solution
Replaced URL w/ an intact version of this image from the similar https://www.crossroads.net/media/topics/humans-of-crossroads

## Testing
Given I am a user
When I visit https://www.crossroads.net/media/humans-of-crossroads/
Then the main bg image will match https://www.crossroads.net/media/topics/humans-of-crossroads