### PR TITLE
Remove redirect for Crds-Unified

### DIFF
--- a/redirects.csv
+++ b/redirects.csv
@@ -20,7 +20,6 @@ https://embed.crossroads.net/*,https://www.crossroads.net/giving/,302!
 /group-renew groupIds=:groupIds,/group-renew?groupIds=:groupIds,200! Role=user
 /group-renew groupIds=:groupIds,/signin?redirectUrl=/group-renew?groupIds=:groupIds,302!
 *** CMS REDIRECTS WILL BE INSERTED HERE --- DO NOT REMOVE THIS LINE! ***
-/unified/*,${env:CRDS_UNIFIED_DOMAIN}/unified/:splat,200!
 /online/my-profile,/profile,301!
 /online/*,${env:CRDS_ONLINE_DOMAIN}/online/:splat,200!
 /signin,/online,200!,Cookie=online_registrant


### PR DESCRIPTION
## Problem
Redirect not working for the desired urls

## Solution
Remove it because it's not needed in this capacity

### Corresponding Branch
N/a

## Testing
Make sure site doesn't explode when the redirect is removed. It wasn't working anyway, so no functionality for removal needs to be tested.