### PR TITLE
Escaping special characters for reccomended collection and timestamps

### DIFF
--- a/_includes/_bitmovin-player.html
+++ b/_includes/_bitmovin-player.html
@@ -6,11 +6,11 @@
   {% assign is_card = false %}
 {% endif %}
 
-{% assign timestamps = video.timestamps | jsonify %}
+{% assign timestamps = video.timestamps | jsonify | escape %}
 
 {% if recommended_collection.size > 0 %}
   {% assign sorted_collection = recommended_collection | sort: 'date' | reverse %}
-  {% assign json_collection = sorted_collection | jsonify_message: page.date %}
+  {% assign json_collection = sorted_collection | jsonify_message: page.date | escape %}
   <crds-bitmovin-player 
     recommended-collection='{{json_collection}}' 
     class="embed-responsive embed-responsive-16by9" 


### PR DESCRIPTION
## Problem
*Single quotations in recommended collection and timestamps for messages would cause the page to not display any video for the bitmovin component*

## Solution
*Escaped special characters in those fields when creating the component*

### Corresponding Branch
*Add link to crdschurch/repo-name-here#issue-number (if applicable). This helps the code reviewer know that corresponding work exists and where to find it.*

## Testing
*Include information on how to test your work here (if applicable).*