### PR TITLE
Move 'Crossroads Messages' podcast to the front of the list

### DIFF
--- a/_plugins/generators/sorted_podcasts_generator.rb
+++ b/_plugins/generators/sorted_podcasts_generator.rb
@@ -15,6 +15,11 @@ module Jekyll
       podcasts = podcast_ids.map { |id| all_podcasts.detect { |p| p.data['id'] == id } }
       # Append the missing podcasts to the list.
       podcasts += (all_podcasts - podcasts).sort_by { |p| p.data['title'].downcase }
+
+      featured_title = "Crossroads Messages"
+      featured = podcasts.detect{|pod, i|  pod['title'].include?(featured_title) }
+      podcasts = podcasts.filter{|p| !p['title'].include?(featured_title) }.unshift(featured)
+
       # Store the collection on the site config object.
       site.config['ordered_podcasts'] = podcasts
     end


### PR DESCRIPTION
## Problem
Marketing wants the 'Crossroads Messages' podcasts in position number one. 

## Solution
Make 'Crossroads Messages' show up first.

## Testing
[Deploy Preview](https://deploy-preview-2678--int-crds-net.netlify.app/media/podcasts/)

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1202670799550093