### PR TITLE
Reset user_ids for Segment migration plan

### DIFF
--- a/_assets/javascripts/components/analytics.js
+++ b/_assets/javascripts/components/analytics.js
@@ -1,3 +1,7 @@
+/* eslint-disable no-undef */
+/* eslint-disable no-unused-vars */
+/* eslint-disable indent */
+
 function parseCommand(originalCommand) {
   var commandArray = originalCommand.split('.');
   return commandArray[commandArray.length - 1];
@@ -20,3 +24,14 @@ function abstractedAnalytics(originalCommand, event, eventCategory, eventAction)
       this.error('gtag() command not found! Command: ' + command);
   }
 }
+
+(function() {
+  var timer = setInterval(segmentCheck, 200);
+  function segmentCheck() {
+    if(window.analytics) {
+      clearInterval(timer);
+      return;
+    }
+    window.analytics.reset(); // clear out any existing analytics
+  }
+})();

--- a/_assets/javascripts/config.js
+++ b/_assets/javascripts/config.js
@@ -55,6 +55,7 @@ module.exports = [
       'components/toggle-tooltip',
       'components/resi-player',
       'components/load-more',
+      'components/analytics'
     ],
   },
   {


### PR DESCRIPTION
I am still seeing some users identified via their MP Contact ID in Segment. This PR ensures that any statically generated page will attempt to reset the user ID which should be reflected in subsequent events both on this page and elsewhere. 
