### PR TITLE
Bump jekyll-contetful to its latest

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -52,7 +52,7 @@ group :jekyll_plugins do
   # gem 'jekyll-asset-pipeline', path: File.expand_path('../jekyll-asset-pipeline', __dir__)
   gem 'jekyll-asset-pipeline', git: 'https://github.com/crdschurch/jekyll-asset-pipeline', tag: '1.0.0'
   # gem 'jekyll-contentful', path: File.expand_path('../jekyll-contentful', __dir__)
-  gem "jekyll-contentful", git: 'https://github.com/crdschurch/jekyll-contentful.git', tag: '3.2.1'
+  gem "jekyll-contentful", git: 'https://github.com/crdschurch/jekyll-contentful.git', tag: '3.2.2'
   # gem 'jekyll-crds', path: File.expand_path('../jekyll-crds', __dir__)
   gem "jekyll-crds", git: 'https://github.com/crdschurch/jekyll-crds.git', tag: '2.3.3'
   # gem 'jekyll-placeholders', path: File.expand_path('../jekyll-placeholders', __dir__)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -27,10 +27,10 @@ GIT
 
 GIT
   remote: https://github.com/crdschurch/jekyll-contentful.git
-  revision: 16092358e89394d9277972cfda9f75d75d7a2c33
-  tag: 3.2.1
+  revision: 78224544ceae6c1eb69c90e1b0a97ad5f0e52ce0
+  tag: 3.2.2
   specs:
-    jekyll-contentful (3.2.1)
+    jekyll-contentful (3.2.2)
       activesupport
       contentful (>= 2.6.0)
       contentful-management (~> 2.6)
@@ -87,7 +87,7 @@ GEM
     colorator (1.1.0)
     colorize (0.8.1)
     concurrent-ruby (1.1.8)
-    contentful (2.16.2)
+    contentful (2.16.3)
       http (> 0.8, < 5.0)
       multi_json (~> 1)
     contentful-management (2.13.1)
@@ -134,7 +134,7 @@ GEM
       http-cookie (~> 1.0)
       http-form_data (~> 2.2)
       http-parser (~> 1.2.0)
-    http-cookie (1.0.4)
+    http-cookie (1.0.5)
       domain_name (~> 0.5)
     http-form_data (2.3.0)
     http-parser (1.2.3)
@@ -173,7 +173,7 @@ GEM
       sassc (> 2.0.1, < 3.0)
     jekyll-watch (2.2.1)
       listen (~> 3.0)
-    json (2.6.1)
+    json (2.6.2)
     kramdown (2.3.1)
       rexml
     kramdown-parser-gfm (1.1.0)
@@ -249,8 +249,8 @@ GEM
       execjs (>= 0.3.0, < 3)
     unf (0.1.4)
       unf_ext
-    unf_ext (0.0.8)
-    unf_ext (0.0.8-x64-mingw32)
+    unf_ext (0.0.8.2)
+    unf_ext (0.0.8.2-x64-mingw32)
     unicode-display_width (1.7.0)
     vcr (6.0.0)
     wdm (0.1.1)


### PR DESCRIPTION
We need to reduce the number of items per page in our Contentful queries. This PR updates the version of `jekyll-contentful` to its latest to reduce the page number from 500 to 250. 