### PR TITLE
Hot fix - Redirect /signin from POST to GET endpoint

### DIFF
--- a/redirects.csv
+++ b/redirects.csv
@@ -16,7 +16,7 @@ https://forms.crossroads.net/*,https://${env:CRDS_APP_DOMAIN}/forms/:splat,302!
 https://embedint.crossroads.net/*,https://int.crossroads.net/giving/,302!
 https://embeddemo.crossroads.net/*,https://demo.crossroads.net/giving/,302!
 https://embed.crossroads.net/*,https://www.crossroads.net/giving/,302!
-/signin redirectUrl=:redirectUrl,/signin/?redirectUrl=:redirectUrl,301
+/signin redirectUrl=:redirectUrl,/signin/?redirectUrl=:redirectUrl,200
 /,${env:CRDS_UNIFIED_DOMAIN}h,200! Role=user
 /,${env:CRDS_UNIFIED_DOMAIN},200!
 /growth-path,${env:CRDS_UNIFIED_DOMAIN}growth-path,200! Role=user

--- a/redirects.csv
+++ b/redirects.csv
@@ -16,6 +16,7 @@ https://forms.crossroads.net/*,https://${env:CRDS_APP_DOMAIN}/forms/:splat,302!
 https://embedint.crossroads.net/*,https://int.crossroads.net/giving/,302!
 https://embeddemo.crossroads.net/*,https://demo.crossroads.net/giving/,302!
 https://embed.crossroads.net/*,https://www.crossroads.net/giving/,302!
+/signin redirectUrl=:redirectUrl,/signin/?redirectUrl=:redirectUrl,301
 /,${env:CRDS_UNIFIED_DOMAIN}h,200! Role=user
 /,${env:CRDS_UNIFIED_DOMAIN},200!
 /growth-path,${env:CRDS_UNIFIED_DOMAIN}growth-path,200! Role=user


### PR DESCRIPTION
The Okta integration from Go Method is POSTing back to /signin which is resulting in a 404 error. We're hoping that by manually redirecting traffic in _redirects, we'll be able to transform this POST to a GET and the user will not longer run into a page not found error. 