### PR TITLE
[Hotfix] Sort promos by published_at

### DIFF
--- a/_layouts/anywhere.html
+++ b/_layouts/anywhere.html
@@ -3,7 +3,7 @@ layout: default
 ---
 
 <!-- Pull only the promos that exist for the specific location if any -->
-{% assign location_happenings = site.promos | where: "target_audience", page.name | sort: "date" | reverse %}
+{% assign location_happenings = site.promos | where: "target_audience", page.name | sort: "published_at" | reverse %}
 {% for serie in site.series %}
 {% if serie.slug != 'easter-a-love-story' %}
 {% assign series = serie %}

--- a/_layouts/established.html
+++ b/_layouts/established.html
@@ -3,7 +3,7 @@ layout: default
 ---
 
 <!-- Pull only the promos that exist for the specific location if any -->
-{% assign location_happenings = site.promos | where: "target_audience", page.name | sort: "date" | reverse %}
+{% assign location_happenings = site.promos | where: "target_audience", page.name | sort: "published_at" | reverse %}
 {% for serie in site.series %}
 {% if serie.slug != 'easter-a-love-story' %}
 {% assign series = serie %}

--- a/_layouts/frontier.html
+++ b/_layouts/frontier.html
@@ -3,7 +3,7 @@ layout: default
 ---
 
 <!-- Pull only the promos that exist for the specific location if any -->
-{% assign location_happenings = site.promos | where: "target_audience", page.name | sort: "date" | reverse %}
+{% assign location_happenings = site.promos | where: "target_audience", page.name | sort: "published_at" | reverse %}
 {% for serie in site.series %}
 {% if serie.slug != 'easter-a-love-story' %}
 {% assign series = serie %}


### PR DESCRIPTION
## Problem
Promos on location pages are currently sorted by `date` field

## Solution
Sort the promos by `published_at` instead

## Testing
Check the location pages and confirm that the promos under `events & updates` are sorted according to the `published_at` field.

Example from the Eastside page:

<img width="1260" alt="Screen Shot 2022-11-02 at 3 55 55 PM" src="https://user-images.githubusercontent.com/58494322/199601022-b5ad802b-39c2-4c9e-b5c2-21690c5492d7.png">
<img width="1439" alt="Screen Shot 2022-11-02 at 3 56 31 PM" src="https://user-images.githubusercontent.com/58494322/199601028-a55b47e4-ff2f-4646-8b1e-61618010ffe1.png">
