### PR TITLE
Bump version of jekyll-contentful and adjust queries to reduce number of requests

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -52,7 +52,7 @@ group :jekyll_plugins do
   # gem 'jekyll-asset-pipeline', path: File.expand_path('../jekyll-asset-pipeline', __dir__)
   gem 'jekyll-asset-pipeline', git: 'https://github.com/crdschurch/jekyll-asset-pipeline', tag: '1.0.0'
   # gem 'jekyll-contentful', path: File.expand_path('../jekyll-contentful', __dir__)
-  gem "jekyll-contentful", git: 'https://github.com/crdschurch/jekyll-contentful.git', tag: '3.2.2'
+  gem "jekyll-contentful", git: 'https://github.com/crdschurch/jekyll-contentful.git', tag: '3.3.0'
   # gem 'jekyll-crds', path: File.expand_path('../jekyll-crds', __dir__)
   gem "jekyll-crds", git: 'https://github.com/crdschurch/jekyll-crds.git', tag: '2.3.3'
   # gem 'jekyll-placeholders', path: File.expand_path('../jekyll-placeholders', __dir__)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -27,10 +27,10 @@ GIT
 
 GIT
   remote: https://github.com/crdschurch/jekyll-contentful.git
-  revision: 78224544ceae6c1eb69c90e1b0a97ad5f0e52ce0
-  tag: 3.2.2
+  revision: 65f54b0c8d56d9d90fc407557705d56fa92bbd77
+  tag: 3.3.0
   specs:
-    jekyll-contentful (3.2.2)
+    jekyll-contentful (3.3.0)
       activesupport
       contentful (>= 2.6.0)
       contentful-management (~> 2.6)

--- a/_config.yml
+++ b/_config.yml
@@ -57,6 +57,7 @@ collections:
   articles:
     output: true
     permalink: /media/articles/:title
+    limit: 500
     filename: "{{ published_at | date: '%Y-%m-%d' }}-{{ slug }}"
   humans_of_crossroads:
     output: true
@@ -116,6 +117,7 @@ collections:
     filename: "{{ published_at | date: '%Y-%m-%d' }}-{{ slug }}"
     output: true
     permalink: /media/:collection/:title
+    limit: 250
     has_many:
       - videos
       - live_messages

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "lib": "lib"
   },
   "scripts": {
-    "build": "gulp",
+    "build": "gulp -L",
     "integration_test": "npx cypress run --config-file ./cypress/config/int_crossroads.json"
   },
   "repository": {


### PR DESCRIPTION
## Problem

**1. Max length issues**
The depth of some of our content models is causing Contentful to throw max-length errors for articles & series content. We can work around this issue with minimal risk by reducing the number of entries returned per page (from 1000 to 250). This is a good quick fix but results in a much larger number of queries.  

**2. Verbosity**
Sometimes Netlify truncates the build logs which can make troubleshooting challenging. So we need to reduce the verbosity of our build output to the smallest possible amount.  

## Solution

This PR bumps `crdschurch/jekyll-contentful` to version 3.3.0 which provides new options to specify items per page on a per content-type level and reduces verbosity. 

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1201985975628432