### PR TITLE
Add missing content types to tag landing pages

### DIFF
--- a/_assets/stylesheets/_fonts.scss
+++ b/_assets/stylesheets/_fonts.scss
@@ -35,103 +35,103 @@
 @font-face {
 font-family:"lexia";
 src:url("https://use.typekit.net/af/042bd3/000000000000000077359d7f/30/l?primer=7cdcb44be4a7db8877ffa5c0007b8dd865b3bbc383831fe2ea177f62257a9191&fvd=n4&v=3") format("woff2"),url("https://use.typekit.net/af/042bd3/000000000000000077359d7f/30/d?primer=7cdcb44be4a7db8877ffa5c0007b8dd865b3bbc383831fe2ea177f62257a9191&fvd=n4&v=3") format("woff"),url("https://use.typekit.net/af/042bd3/000000000000000077359d7f/30/a?primer=7cdcb44be4a7db8877ffa5c0007b8dd865b3bbc383831fe2ea177f62257a9191&fvd=n4&v=3") format("opentype");
-font-display:swap;font-style:normal;font-weight:400;
+font-display:swap;font-style:normal;font-weight:400;font-stretch:normal;
 }
 
 @font-face {
 font-family:"lexia";
 src:url("https://use.typekit.net/af/1c4cee/000000000000000077359d84/30/l?primer=7cdcb44be4a7db8877ffa5c0007b8dd865b3bbc383831fe2ea177f62257a9191&fvd=i4&v=3") format("woff2"),url("https://use.typekit.net/af/1c4cee/000000000000000077359d84/30/d?primer=7cdcb44be4a7db8877ffa5c0007b8dd865b3bbc383831fe2ea177f62257a9191&fvd=i4&v=3") format("woff"),url("https://use.typekit.net/af/1c4cee/000000000000000077359d84/30/a?primer=7cdcb44be4a7db8877ffa5c0007b8dd865b3bbc383831fe2ea177f62257a9191&fvd=i4&v=3") format("opentype");
-font-display:swap;font-style:italic;font-weight:400;
+font-display:swap;font-style:italic;font-weight:400;font-stretch:normal;
 }
 
 @font-face {
 font-family:"acumin-pro";
 src:url("https://use.typekit.net/af/ac1071/00000000000000003b9acafe/27/l?primer=7cdcb44be4a7db8877ffa5c0007b8dd865b3bbc383831fe2ea177f62257a9191&fvd=n8&v=3") format("woff2"),url("https://use.typekit.net/af/ac1071/00000000000000003b9acafe/27/d?primer=7cdcb44be4a7db8877ffa5c0007b8dd865b3bbc383831fe2ea177f62257a9191&fvd=n8&v=3") format("woff"),url("https://use.typekit.net/af/ac1071/00000000000000003b9acafe/27/a?primer=7cdcb44be4a7db8877ffa5c0007b8dd865b3bbc383831fe2ea177f62257a9191&fvd=n8&v=3") format("opentype");
-font-display:swap;font-style:normal;font-weight:800;
+font-display:swap;font-style:normal;font-weight:800;font-stretch:normal;
 }
 
 @font-face {
 font-family:"acumin-pro";
 src:url("https://use.typekit.net/af/6d4bb2/00000000000000003b9acafc/27/l?primer=7cdcb44be4a7db8877ffa5c0007b8dd865b3bbc383831fe2ea177f62257a9191&fvd=n7&v=3") format("woff2"),url("https://use.typekit.net/af/6d4bb2/00000000000000003b9acafc/27/d?primer=7cdcb44be4a7db8877ffa5c0007b8dd865b3bbc383831fe2ea177f62257a9191&fvd=n7&v=3") format("woff"),url("https://use.typekit.net/af/6d4bb2/00000000000000003b9acafc/27/a?primer=7cdcb44be4a7db8877ffa5c0007b8dd865b3bbc383831fe2ea177f62257a9191&fvd=n7&v=3") format("opentype");
-font-display:swap;font-style:normal;font-weight:700;
+font-display:swap;font-style:normal;font-weight:700;font-stretch:normal;
 }
 
 @font-face {
 font-family:"acumin-pro";
 src:url("https://use.typekit.net/af/aa5b59/00000000000000003b9acaf7/27/l?primer=7cdcb44be4a7db8877ffa5c0007b8dd865b3bbc383831fe2ea177f62257a9191&fvd=i4&v=3") format("woff2"),url("https://use.typekit.net/af/aa5b59/00000000000000003b9acaf7/27/d?primer=7cdcb44be4a7db8877ffa5c0007b8dd865b3bbc383831fe2ea177f62257a9191&fvd=i4&v=3") format("woff"),url("https://use.typekit.net/af/aa5b59/00000000000000003b9acaf7/27/a?primer=7cdcb44be4a7db8877ffa5c0007b8dd865b3bbc383831fe2ea177f62257a9191&fvd=i4&v=3") format("opentype");
-font-display:swap;font-style:italic;font-weight:400;
+font-display:swap;font-style:italic;font-weight:400;font-stretch:normal;
 }
 
 @font-face {
 font-family:"acumin-pro";
 src:url("https://use.typekit.net/af/a2c82e/00000000000000003b9acaf4/27/l?primer=7cdcb44be4a7db8877ffa5c0007b8dd865b3bbc383831fe2ea177f62257a9191&fvd=n3&v=3") format("woff2"),url("https://use.typekit.net/af/a2c82e/00000000000000003b9acaf4/27/d?primer=7cdcb44be4a7db8877ffa5c0007b8dd865b3bbc383831fe2ea177f62257a9191&fvd=n3&v=3") format("woff"),url("https://use.typekit.net/af/a2c82e/00000000000000003b9acaf4/27/a?primer=7cdcb44be4a7db8877ffa5c0007b8dd865b3bbc383831fe2ea177f62257a9191&fvd=n3&v=3") format("opentype");
-font-display:swap;font-style:normal;font-weight:300;
+font-display:swap;font-style:normal;font-weight:300;font-stretch:normal;
 }
 
 @font-face {
 font-family:"acumin-pro";
 src:url("https://use.typekit.net/af/51b548/00000000000000003b9acaf5/27/l?primer=7cdcb44be4a7db8877ffa5c0007b8dd865b3bbc383831fe2ea177f62257a9191&fvd=i3&v=3") format("woff2"),url("https://use.typekit.net/af/51b548/00000000000000003b9acaf5/27/d?primer=7cdcb44be4a7db8877ffa5c0007b8dd865b3bbc383831fe2ea177f62257a9191&fvd=i3&v=3") format("woff"),url("https://use.typekit.net/af/51b548/00000000000000003b9acaf5/27/a?primer=7cdcb44be4a7db8877ffa5c0007b8dd865b3bbc383831fe2ea177f62257a9191&fvd=i3&v=3") format("opentype");
-font-display:swap;font-style:italic;font-weight:300;
+font-display:swap;font-style:italic;font-weight:300;font-stretch:normal;
 }
 
 @font-face {
 font-family:"acumin-pro";
 src:url("https://use.typekit.net/af/46da36/00000000000000003b9acaf6/27/l?primer=7cdcb44be4a7db8877ffa5c0007b8dd865b3bbc383831fe2ea177f62257a9191&fvd=n4&v=3") format("woff2"),url("https://use.typekit.net/af/46da36/00000000000000003b9acaf6/27/d?primer=7cdcb44be4a7db8877ffa5c0007b8dd865b3bbc383831fe2ea177f62257a9191&fvd=n4&v=3") format("woff"),url("https://use.typekit.net/af/46da36/00000000000000003b9acaf6/27/a?primer=7cdcb44be4a7db8877ffa5c0007b8dd865b3bbc383831fe2ea177f62257a9191&fvd=n4&v=3") format("opentype");
-font-display:swap;font-style:normal;font-weight:400;
+font-display:swap;font-style:normal;font-weight:400;font-stretch:normal;
 }
 
 @font-face {
 font-family:"acumin-pro";
 src:url("https://use.typekit.net/af/027dd4/00000000000000003b9acafa/27/l?primer=7cdcb44be4a7db8877ffa5c0007b8dd865b3bbc383831fe2ea177f62257a9191&fvd=n6&v=3") format("woff2"),url("https://use.typekit.net/af/027dd4/00000000000000003b9acafa/27/d?primer=7cdcb44be4a7db8877ffa5c0007b8dd865b3bbc383831fe2ea177f62257a9191&fvd=n6&v=3") format("woff"),url("https://use.typekit.net/af/027dd4/00000000000000003b9acafa/27/a?primer=7cdcb44be4a7db8877ffa5c0007b8dd865b3bbc383831fe2ea177f62257a9191&fvd=n6&v=3") format("opentype");
-font-display:swap;font-style:normal;font-weight:600;
+font-display:swap;font-style:normal;font-weight:600;font-stretch:normal;
 }
 
 @font-face {
 font-family:"acumin-pro";
 src:url("https://use.typekit.net/af/b27b16/00000000000000003b9acaf0/27/l?primer=7cdcb44be4a7db8877ffa5c0007b8dd865b3bbc383831fe2ea177f62257a9191&fvd=n1&v=3") format("woff2"),url("https://use.typekit.net/af/b27b16/00000000000000003b9acaf0/27/d?primer=7cdcb44be4a7db8877ffa5c0007b8dd865b3bbc383831fe2ea177f62257a9191&fvd=n1&v=3") format("woff"),url("https://use.typekit.net/af/b27b16/00000000000000003b9acaf0/27/a?primer=7cdcb44be4a7db8877ffa5c0007b8dd865b3bbc383831fe2ea177f62257a9191&fvd=n1&v=3") format("opentype");
-font-display:swap;font-style:normal;font-weight:100;
+font-display:swap;font-style:normal;font-weight:100;font-stretch:normal;
 }
 
 @font-face {
 font-family:"acumin-pro";
 src:url("https://use.typekit.net/af/3a3f7a/00000000000000003b9acaf1/27/l?primer=7cdcb44be4a7db8877ffa5c0007b8dd865b3bbc383831fe2ea177f62257a9191&fvd=i1&v=3") format("woff2"),url("https://use.typekit.net/af/3a3f7a/00000000000000003b9acaf1/27/d?primer=7cdcb44be4a7db8877ffa5c0007b8dd865b3bbc383831fe2ea177f62257a9191&fvd=i1&v=3") format("woff"),url("https://use.typekit.net/af/3a3f7a/00000000000000003b9acaf1/27/a?primer=7cdcb44be4a7db8877ffa5c0007b8dd865b3bbc383831fe2ea177f62257a9191&fvd=i1&v=3") format("opentype");
-font-display:swap;font-style:italic;font-weight:100;
+font-display:swap;font-style:italic;font-weight:100;font-stretch:normal;
 }
 
 @font-face {
 font-family:"acumin-pro-extra-condensed";
 src:url("https://use.typekit.net/af/c4767b/00000000000000003b9acb20/27/l?primer=7cdcb44be4a7db8877ffa5c0007b8dd865b3bbc383831fe2ea177f62257a9191&fvd=n7&v=3") format("woff2"),url("https://use.typekit.net/af/c4767b/00000000000000003b9acb20/27/d?primer=7cdcb44be4a7db8877ffa5c0007b8dd865b3bbc383831fe2ea177f62257a9191&fvd=n7&v=3") format("woff"),url("https://use.typekit.net/af/c4767b/00000000000000003b9acb20/27/a?primer=7cdcb44be4a7db8877ffa5c0007b8dd865b3bbc383831fe2ea177f62257a9191&fvd=n7&v=3") format("opentype");
-font-display:swap;font-style:normal;font-weight:700;
+font-display:swap;font-style:normal;font-weight:700;font-stretch:normal;
 }
 
 @font-face {
 font-family:"acumin-pro-extra-condensed";
 src:url("https://use.typekit.net/af/f2b2eb/00000000000000003b9acb1a/27/l?primer=7cdcb44be4a7db8877ffa5c0007b8dd865b3bbc383831fe2ea177f62257a9191&fvd=n4&v=3") format("woff2"),url("https://use.typekit.net/af/f2b2eb/00000000000000003b9acb1a/27/d?primer=7cdcb44be4a7db8877ffa5c0007b8dd865b3bbc383831fe2ea177f62257a9191&fvd=n4&v=3") format("woff"),url("https://use.typekit.net/af/f2b2eb/00000000000000003b9acb1a/27/a?primer=7cdcb44be4a7db8877ffa5c0007b8dd865b3bbc383831fe2ea177f62257a9191&fvd=n4&v=3") format("opentype");
-font-display:swap;font-style:normal;font-weight:400;
+font-display:swap;font-style:normal;font-weight:400;font-stretch:normal;
 }
 
 @font-face {
 font-family:"acumin-pro-extra-condensed";
 src:url("https://use.typekit.net/af/b8e425/00000000000000003b9acb1c/27/l?primer=7cdcb44be4a7db8877ffa5c0007b8dd865b3bbc383831fe2ea177f62257a9191&fvd=n5&v=3") format("woff2"),url("https://use.typekit.net/af/b8e425/00000000000000003b9acb1c/27/d?primer=7cdcb44be4a7db8877ffa5c0007b8dd865b3bbc383831fe2ea177f62257a9191&fvd=n5&v=3") format("woff"),url("https://use.typekit.net/af/b8e425/00000000000000003b9acb1c/27/a?primer=7cdcb44be4a7db8877ffa5c0007b8dd865b3bbc383831fe2ea177f62257a9191&fvd=n5&v=3") format("opentype");
-font-display:swap;font-style:normal;font-weight:500;
+font-display:swap;font-style:normal;font-weight:500;font-stretch:normal;
 }
 
 @font-face {
 font-family:"acumin-pro-extra-condensed";
 src:url("https://use.typekit.net/af/ca6558/00000000000000003b9acb18/27/l?primer=7cdcb44be4a7db8877ffa5c0007b8dd865b3bbc383831fe2ea177f62257a9191&fvd=n3&v=3") format("woff2"),url("https://use.typekit.net/af/ca6558/00000000000000003b9acb18/27/d?primer=7cdcb44be4a7db8877ffa5c0007b8dd865b3bbc383831fe2ea177f62257a9191&fvd=n3&v=3") format("woff"),url("https://use.typekit.net/af/ca6558/00000000000000003b9acb18/27/a?primer=7cdcb44be4a7db8877ffa5c0007b8dd865b3bbc383831fe2ea177f62257a9191&fvd=n3&v=3") format("opentype");
-font-display:swap;font-style:normal;font-weight:300;
+font-display:swap;font-style:normal;font-weight:300;font-stretch:normal;
 }
 
 @font-face {
 font-family:"acumin-pro-semi-condensed";
 src:url("https://use.typekit.net/af/e60e87/00000000000000003b9acb31/27/l?primer=7cdcb44be4a7db8877ffa5c0007b8dd865b3bbc383831fe2ea177f62257a9191&fvd=n6&v=3") format("woff2"),url("https://use.typekit.net/af/e60e87/00000000000000003b9acb31/27/d?primer=7cdcb44be4a7db8877ffa5c0007b8dd865b3bbc383831fe2ea177f62257a9191&fvd=n6&v=3") format("woff"),url("https://use.typekit.net/af/e60e87/00000000000000003b9acb31/27/a?primer=7cdcb44be4a7db8877ffa5c0007b8dd865b3bbc383831fe2ea177f62257a9191&fvd=n6&v=3") format("opentype");
-font-display:swap;font-style:normal;font-weight:600;
+font-display:swap;font-style:normal;font-weight:600;font-stretch:normal;
 }
 
 @font-face {
 font-family:"acumin-pro-semi-condensed";
 src:url("https://use.typekit.net/af/8bab0c/00000000000000003b9acb32/27/l?primer=7cdcb44be4a7db8877ffa5c0007b8dd865b3bbc383831fe2ea177f62257a9191&fvd=i6&v=3") format("woff2"),url("https://use.typekit.net/af/8bab0c/00000000000000003b9acb32/27/d?primer=7cdcb44be4a7db8877ffa5c0007b8dd865b3bbc383831fe2ea177f62257a9191&fvd=i6&v=3") format("woff"),url("https://use.typekit.net/af/8bab0c/00000000000000003b9acb32/27/a?primer=7cdcb44be4a7db8877ffa5c0007b8dd865b3bbc383831fe2ea177f62257a9191&fvd=i6&v=3") format("opentype");
-font-display:swap;font-style:italic;font-weight:600;
+font-display:swap;font-style:italic;font-weight:600;font-stretch:normal;
 }
 
 .tk-lexia { font-family: "lexia",serif; }

--- a/_assets/stylesheets/_fonts.scss
+++ b/_assets/stylesheets/_fonts.scss
@@ -35,103 +35,103 @@
 @font-face {
 font-family:"lexia";
 src:url("https://use.typekit.net/af/042bd3/000000000000000077359d7f/30/l?primer=7cdcb44be4a7db8877ffa5c0007b8dd865b3bbc383831fe2ea177f62257a9191&fvd=n4&v=3") format("woff2"),url("https://use.typekit.net/af/042bd3/000000000000000077359d7f/30/d?primer=7cdcb44be4a7db8877ffa5c0007b8dd865b3bbc383831fe2ea177f62257a9191&fvd=n4&v=3") format("woff"),url("https://use.typekit.net/af/042bd3/000000000000000077359d7f/30/a?primer=7cdcb44be4a7db8877ffa5c0007b8dd865b3bbc383831fe2ea177f62257a9191&fvd=n4&v=3") format("opentype");
-font-display:swap;font-style:normal;font-weight:400;font-stretch:normal;
+font-display:swap;font-style:normal;font-weight:400;
 }
 
 @font-face {
 font-family:"lexia";
 src:url("https://use.typekit.net/af/1c4cee/000000000000000077359d84/30/l?primer=7cdcb44be4a7db8877ffa5c0007b8dd865b3bbc383831fe2ea177f62257a9191&fvd=i4&v=3") format("woff2"),url("https://use.typekit.net/af/1c4cee/000000000000000077359d84/30/d?primer=7cdcb44be4a7db8877ffa5c0007b8dd865b3bbc383831fe2ea177f62257a9191&fvd=i4&v=3") format("woff"),url("https://use.typekit.net/af/1c4cee/000000000000000077359d84/30/a?primer=7cdcb44be4a7db8877ffa5c0007b8dd865b3bbc383831fe2ea177f62257a9191&fvd=i4&v=3") format("opentype");
-font-display:swap;font-style:italic;font-weight:400;font-stretch:normal;
+font-display:swap;font-style:italic;font-weight:400;
 }
 
 @font-face {
 font-family:"acumin-pro";
 src:url("https://use.typekit.net/af/ac1071/00000000000000003b9acafe/27/l?primer=7cdcb44be4a7db8877ffa5c0007b8dd865b3bbc383831fe2ea177f62257a9191&fvd=n8&v=3") format("woff2"),url("https://use.typekit.net/af/ac1071/00000000000000003b9acafe/27/d?primer=7cdcb44be4a7db8877ffa5c0007b8dd865b3bbc383831fe2ea177f62257a9191&fvd=n8&v=3") format("woff"),url("https://use.typekit.net/af/ac1071/00000000000000003b9acafe/27/a?primer=7cdcb44be4a7db8877ffa5c0007b8dd865b3bbc383831fe2ea177f62257a9191&fvd=n8&v=3") format("opentype");
-font-display:swap;font-style:normal;font-weight:800;font-stretch:normal;
+font-display:swap;font-style:normal;font-weight:800;
 }
 
 @font-face {
 font-family:"acumin-pro";
 src:url("https://use.typekit.net/af/6d4bb2/00000000000000003b9acafc/27/l?primer=7cdcb44be4a7db8877ffa5c0007b8dd865b3bbc383831fe2ea177f62257a9191&fvd=n7&v=3") format("woff2"),url("https://use.typekit.net/af/6d4bb2/00000000000000003b9acafc/27/d?primer=7cdcb44be4a7db8877ffa5c0007b8dd865b3bbc383831fe2ea177f62257a9191&fvd=n7&v=3") format("woff"),url("https://use.typekit.net/af/6d4bb2/00000000000000003b9acafc/27/a?primer=7cdcb44be4a7db8877ffa5c0007b8dd865b3bbc383831fe2ea177f62257a9191&fvd=n7&v=3") format("opentype");
-font-display:swap;font-style:normal;font-weight:700;font-stretch:normal;
+font-display:swap;font-style:normal;font-weight:700;
 }
 
 @font-face {
 font-family:"acumin-pro";
 src:url("https://use.typekit.net/af/aa5b59/00000000000000003b9acaf7/27/l?primer=7cdcb44be4a7db8877ffa5c0007b8dd865b3bbc383831fe2ea177f62257a9191&fvd=i4&v=3") format("woff2"),url("https://use.typekit.net/af/aa5b59/00000000000000003b9acaf7/27/d?primer=7cdcb44be4a7db8877ffa5c0007b8dd865b3bbc383831fe2ea177f62257a9191&fvd=i4&v=3") format("woff"),url("https://use.typekit.net/af/aa5b59/00000000000000003b9acaf7/27/a?primer=7cdcb44be4a7db8877ffa5c0007b8dd865b3bbc383831fe2ea177f62257a9191&fvd=i4&v=3") format("opentype");
-font-display:swap;font-style:italic;font-weight:400;font-stretch:normal;
+font-display:swap;font-style:italic;font-weight:400;
 }
 
 @font-face {
 font-family:"acumin-pro";
 src:url("https://use.typekit.net/af/a2c82e/00000000000000003b9acaf4/27/l?primer=7cdcb44be4a7db8877ffa5c0007b8dd865b3bbc383831fe2ea177f62257a9191&fvd=n3&v=3") format("woff2"),url("https://use.typekit.net/af/a2c82e/00000000000000003b9acaf4/27/d?primer=7cdcb44be4a7db8877ffa5c0007b8dd865b3bbc383831fe2ea177f62257a9191&fvd=n3&v=3") format("woff"),url("https://use.typekit.net/af/a2c82e/00000000000000003b9acaf4/27/a?primer=7cdcb44be4a7db8877ffa5c0007b8dd865b3bbc383831fe2ea177f62257a9191&fvd=n3&v=3") format("opentype");
-font-display:swap;font-style:normal;font-weight:300;font-stretch:normal;
+font-display:swap;font-style:normal;font-weight:300;
 }
 
 @font-face {
 font-family:"acumin-pro";
 src:url("https://use.typekit.net/af/51b548/00000000000000003b9acaf5/27/l?primer=7cdcb44be4a7db8877ffa5c0007b8dd865b3bbc383831fe2ea177f62257a9191&fvd=i3&v=3") format("woff2"),url("https://use.typekit.net/af/51b548/00000000000000003b9acaf5/27/d?primer=7cdcb44be4a7db8877ffa5c0007b8dd865b3bbc383831fe2ea177f62257a9191&fvd=i3&v=3") format("woff"),url("https://use.typekit.net/af/51b548/00000000000000003b9acaf5/27/a?primer=7cdcb44be4a7db8877ffa5c0007b8dd865b3bbc383831fe2ea177f62257a9191&fvd=i3&v=3") format("opentype");
-font-display:swap;font-style:italic;font-weight:300;font-stretch:normal;
+font-display:swap;font-style:italic;font-weight:300;
 }
 
 @font-face {
 font-family:"acumin-pro";
 src:url("https://use.typekit.net/af/46da36/00000000000000003b9acaf6/27/l?primer=7cdcb44be4a7db8877ffa5c0007b8dd865b3bbc383831fe2ea177f62257a9191&fvd=n4&v=3") format("woff2"),url("https://use.typekit.net/af/46da36/00000000000000003b9acaf6/27/d?primer=7cdcb44be4a7db8877ffa5c0007b8dd865b3bbc383831fe2ea177f62257a9191&fvd=n4&v=3") format("woff"),url("https://use.typekit.net/af/46da36/00000000000000003b9acaf6/27/a?primer=7cdcb44be4a7db8877ffa5c0007b8dd865b3bbc383831fe2ea177f62257a9191&fvd=n4&v=3") format("opentype");
-font-display:swap;font-style:normal;font-weight:400;font-stretch:normal;
+font-display:swap;font-style:normal;font-weight:400;
 }
 
 @font-face {
 font-family:"acumin-pro";
 src:url("https://use.typekit.net/af/027dd4/00000000000000003b9acafa/27/l?primer=7cdcb44be4a7db8877ffa5c0007b8dd865b3bbc383831fe2ea177f62257a9191&fvd=n6&v=3") format("woff2"),url("https://use.typekit.net/af/027dd4/00000000000000003b9acafa/27/d?primer=7cdcb44be4a7db8877ffa5c0007b8dd865b3bbc383831fe2ea177f62257a9191&fvd=n6&v=3") format("woff"),url("https://use.typekit.net/af/027dd4/00000000000000003b9acafa/27/a?primer=7cdcb44be4a7db8877ffa5c0007b8dd865b3bbc383831fe2ea177f62257a9191&fvd=n6&v=3") format("opentype");
-font-display:swap;font-style:normal;font-weight:600;font-stretch:normal;
+font-display:swap;font-style:normal;font-weight:600;
 }
 
 @font-face {
 font-family:"acumin-pro";
 src:url("https://use.typekit.net/af/b27b16/00000000000000003b9acaf0/27/l?primer=7cdcb44be4a7db8877ffa5c0007b8dd865b3bbc383831fe2ea177f62257a9191&fvd=n1&v=3") format("woff2"),url("https://use.typekit.net/af/b27b16/00000000000000003b9acaf0/27/d?primer=7cdcb44be4a7db8877ffa5c0007b8dd865b3bbc383831fe2ea177f62257a9191&fvd=n1&v=3") format("woff"),url("https://use.typekit.net/af/b27b16/00000000000000003b9acaf0/27/a?primer=7cdcb44be4a7db8877ffa5c0007b8dd865b3bbc383831fe2ea177f62257a9191&fvd=n1&v=3") format("opentype");
-font-display:swap;font-style:normal;font-weight:100;font-stretch:normal;
+font-display:swap;font-style:normal;font-weight:100;
 }
 
 @font-face {
 font-family:"acumin-pro";
 src:url("https://use.typekit.net/af/3a3f7a/00000000000000003b9acaf1/27/l?primer=7cdcb44be4a7db8877ffa5c0007b8dd865b3bbc383831fe2ea177f62257a9191&fvd=i1&v=3") format("woff2"),url("https://use.typekit.net/af/3a3f7a/00000000000000003b9acaf1/27/d?primer=7cdcb44be4a7db8877ffa5c0007b8dd865b3bbc383831fe2ea177f62257a9191&fvd=i1&v=3") format("woff"),url("https://use.typekit.net/af/3a3f7a/00000000000000003b9acaf1/27/a?primer=7cdcb44be4a7db8877ffa5c0007b8dd865b3bbc383831fe2ea177f62257a9191&fvd=i1&v=3") format("opentype");
-font-display:swap;font-style:italic;font-weight:100;font-stretch:normal;
+font-display:swap;font-style:italic;font-weight:100;
 }
 
 @font-face {
 font-family:"acumin-pro-extra-condensed";
 src:url("https://use.typekit.net/af/c4767b/00000000000000003b9acb20/27/l?primer=7cdcb44be4a7db8877ffa5c0007b8dd865b3bbc383831fe2ea177f62257a9191&fvd=n7&v=3") format("woff2"),url("https://use.typekit.net/af/c4767b/00000000000000003b9acb20/27/d?primer=7cdcb44be4a7db8877ffa5c0007b8dd865b3bbc383831fe2ea177f62257a9191&fvd=n7&v=3") format("woff"),url("https://use.typekit.net/af/c4767b/00000000000000003b9acb20/27/a?primer=7cdcb44be4a7db8877ffa5c0007b8dd865b3bbc383831fe2ea177f62257a9191&fvd=n7&v=3") format("opentype");
-font-display:swap;font-style:normal;font-weight:700;font-stretch:normal;
+font-display:swap;font-style:normal;font-weight:700;
 }
 
 @font-face {
 font-family:"acumin-pro-extra-condensed";
 src:url("https://use.typekit.net/af/f2b2eb/00000000000000003b9acb1a/27/l?primer=7cdcb44be4a7db8877ffa5c0007b8dd865b3bbc383831fe2ea177f62257a9191&fvd=n4&v=3") format("woff2"),url("https://use.typekit.net/af/f2b2eb/00000000000000003b9acb1a/27/d?primer=7cdcb44be4a7db8877ffa5c0007b8dd865b3bbc383831fe2ea177f62257a9191&fvd=n4&v=3") format("woff"),url("https://use.typekit.net/af/f2b2eb/00000000000000003b9acb1a/27/a?primer=7cdcb44be4a7db8877ffa5c0007b8dd865b3bbc383831fe2ea177f62257a9191&fvd=n4&v=3") format("opentype");
-font-display:swap;font-style:normal;font-weight:400;font-stretch:normal;
+font-display:swap;font-style:normal;font-weight:400;
 }
 
 @font-face {
 font-family:"acumin-pro-extra-condensed";
 src:url("https://use.typekit.net/af/b8e425/00000000000000003b9acb1c/27/l?primer=7cdcb44be4a7db8877ffa5c0007b8dd865b3bbc383831fe2ea177f62257a9191&fvd=n5&v=3") format("woff2"),url("https://use.typekit.net/af/b8e425/00000000000000003b9acb1c/27/d?primer=7cdcb44be4a7db8877ffa5c0007b8dd865b3bbc383831fe2ea177f62257a9191&fvd=n5&v=3") format("woff"),url("https://use.typekit.net/af/b8e425/00000000000000003b9acb1c/27/a?primer=7cdcb44be4a7db8877ffa5c0007b8dd865b3bbc383831fe2ea177f62257a9191&fvd=n5&v=3") format("opentype");
-font-display:swap;font-style:normal;font-weight:500;font-stretch:normal;
+font-display:swap;font-style:normal;font-weight:500;
 }
 
 @font-face {
 font-family:"acumin-pro-extra-condensed";
 src:url("https://use.typekit.net/af/ca6558/00000000000000003b9acb18/27/l?primer=7cdcb44be4a7db8877ffa5c0007b8dd865b3bbc383831fe2ea177f62257a9191&fvd=n3&v=3") format("woff2"),url("https://use.typekit.net/af/ca6558/00000000000000003b9acb18/27/d?primer=7cdcb44be4a7db8877ffa5c0007b8dd865b3bbc383831fe2ea177f62257a9191&fvd=n3&v=3") format("woff"),url("https://use.typekit.net/af/ca6558/00000000000000003b9acb18/27/a?primer=7cdcb44be4a7db8877ffa5c0007b8dd865b3bbc383831fe2ea177f62257a9191&fvd=n3&v=3") format("opentype");
-font-display:swap;font-style:normal;font-weight:300;font-stretch:normal;
+font-display:swap;font-style:normal;font-weight:300;
 }
 
 @font-face {
 font-family:"acumin-pro-semi-condensed";
 src:url("https://use.typekit.net/af/e60e87/00000000000000003b9acb31/27/l?primer=7cdcb44be4a7db8877ffa5c0007b8dd865b3bbc383831fe2ea177f62257a9191&fvd=n6&v=3") format("woff2"),url("https://use.typekit.net/af/e60e87/00000000000000003b9acb31/27/d?primer=7cdcb44be4a7db8877ffa5c0007b8dd865b3bbc383831fe2ea177f62257a9191&fvd=n6&v=3") format("woff"),url("https://use.typekit.net/af/e60e87/00000000000000003b9acb31/27/a?primer=7cdcb44be4a7db8877ffa5c0007b8dd865b3bbc383831fe2ea177f62257a9191&fvd=n6&v=3") format("opentype");
-font-display:swap;font-style:normal;font-weight:600;font-stretch:normal;
+font-display:swap;font-style:normal;font-weight:600;
 }
 
 @font-face {
 font-family:"acumin-pro-semi-condensed";
 src:url("https://use.typekit.net/af/8bab0c/00000000000000003b9acb32/27/l?primer=7cdcb44be4a7db8877ffa5c0007b8dd865b3bbc383831fe2ea177f62257a9191&fvd=i6&v=3") format("woff2"),url("https://use.typekit.net/af/8bab0c/00000000000000003b9acb32/27/d?primer=7cdcb44be4a7db8877ffa5c0007b8dd865b3bbc383831fe2ea177f62257a9191&fvd=i6&v=3") format("woff"),url("https://use.typekit.net/af/8bab0c/00000000000000003b9acb32/27/a?primer=7cdcb44be4a7db8877ffa5c0007b8dd865b3bbc383831fe2ea177f62257a9191&fvd=i6&v=3") format("opentype");
-font-display:swap;font-style:italic;font-weight:600;font-stretch:normal;
+font-display:swap;font-style:italic;font-weight:600;
 }
 
 .tk-lexia { font-family: "lexia",serif; }

--- a/_config.yml
+++ b/_config.yml
@@ -190,6 +190,9 @@ contentful:
       date: published_at
   sign_up_form:
     query: fields.pageType=OnsiteGroupSignupPage
+  song:
+    map:
+      date: published_at
   video:
     map:
       date: published_at

--- a/_includes/_media-card.html
+++ b/_includes/_media-card.html
@@ -1,12 +1,13 @@
 {% assign author = site.authors | where: "name",item.author | first %}
 {% assign item = include.item %}
+{% assign album_url = item.album_url %}
 
 {% if include.carousel == true %}
 <div class="card carousel-cell card-2x">
 {% else %}
 <div class="card">
 {% endif %}
-  <a class="relative" href="{{item | media_url }}">
+  <a class="relative" href="{% if item.content_type == 'song' %}{{ album_url }}{% else %}{{item | media_url }}{% endif %}">
     {% if item.content_type != nil %}
       {% include _media-label.html source= item %}
     {% else %}

--- a/_includes/_media-label.html
+++ b/_includes/_media-label.html
@@ -14,7 +14,7 @@
     <use xlink:href="/assets/svgs/icons.svg#media-article"></use>
     {% elsif content_type == "video" or content_type == "message" %}
     <use xlink:href="/assets/svgs/icons.svg#media-video"></use>
-    {% elsif content_type == "album" %}
+    {% elsif content_type == "album" or content_type == "song" %}
     <use xlink:href="/assets/svgs/icons.svg#media-music"></use>
     {% elsif content_type == "podcast" or content_type == "episode" %}
     <use xlink:href="/assets/svgs/icons.svg#media-podcast"></use>

--- a/_includes/_overlay-card.html
+++ b/_includes/_overlay-card.html
@@ -5,6 +5,8 @@
 {% case handle %}
   {% when 'message' %}
     {% assign image = item.image.url %}
+  {% when 'song' %}
+    {% assign image = item.bg_image.url %}
   {% when 'episode' %}
     {% if item.image != nil %}
       {% assign image = item.image.url %}

--- a/_includes/_overlay-card.html
+++ b/_includes/_overlay-card.html
@@ -20,15 +20,18 @@
 {% endcase %}
 
 {% assign url = item.url %}
+{% assign album_url = item.album_url %}
 
 {% if url %}
   {% assign url = item | media_url %}
+{% elsif album_url %}
+  {% assign url = item.album_url %}
 {% else %}
   {% assign doc = item | get_doc %}
   {% assign url = doc.url %}
 {% endif %}
 
-<a href="{{ item | media_url }}" class="overlay-card{% if include.size == 'xl' %} overlay-card-xl{% endif %}">
+<a href="{% if album_url %}{{ album_url }}{% else %}{{ item | media_url }}{% endif %}" class="overlay-card{% if include.size == 'xl' %} overlay-card-xl{% endif %}">
   {% if item.bitmovin_url == null %}
     <div class="bg-overlay"></div>
   {% endif %}

--- a/_layouts/tag.html
+++ b/_layouts/tag.html
@@ -3,10 +3,15 @@ layout: default
 paginate:
   tagged_media:
     collections:
+      - albums
       - articles
       - episodes
       - messages
       - videos
+      - collections
+      - podcasts
+      - series
+      - songs
     per: 80
     offset: 4
     sort: date desc

--- a/_plugins/generators/song_album_generator.rb
+++ b/_plugins/generators/song_album_generator.rb
@@ -1,0 +1,16 @@
+module GetAlbumSongs
+  class Generator < Jekyll::Generator
+    def generate(site)
+      albums = site.collections['albums'].docs
+      songs = site.collections['songs'].docs
+      song_ids = Hash[albums.collect do |album|
+        [album.data['slug'], album.data['songs'].collect{|song| song['id']}]
+      end]
+      songs.each do |song|
+        slug = song_ids.keys.detect{|id| song_ids[id].include?(song.data['id'])}
+        song.data['album_slug'] = slug
+        song.data['album_url'] = "#{ENV['CRDS_MUSIC_ENDPOINT'].chomp('/')}/music/#{slug}/#{song.data['slug']}"
+      end
+    end
+  end
+end

--- a/_plugins/generators/song_album_generator.rb
+++ b/_plugins/generators/song_album_generator.rb
@@ -1,4 +1,4 @@
-module GetAlbumSongs
+module GetSongAlbum
   class Generator < Jekyll::Generator
     def generate(site)
       albums = site.collections['albums'].docs


### PR DESCRIPTION
## Problem
Tag landing pages associated with the 7 proven practices are not showing certain types of content.

## Solution
Update so all content types can populate the pages.


## Testing
In Contentful, use the tag content model to assign practices to content and confirm that any of these content types are able to populate on the given page (I used Share Your Story for testing):

Album 
Article 
Episode 
Message (live and online)
Podcast 
Series 
Collection (including Show and Next Level)
Song 
Video 

https://deploy-preview-2732--int-crds-net.netlify.app/media/tags/share-your-story/

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1203166629225652