### PR TITLE
Remove Role=user from Unified Routes

### DIFF
--- a/redirects.csv
+++ b/redirects.csv
@@ -17,6 +17,7 @@ https://embedint.crossroads.net/*,https://int.crossroads.net/giving/,302!
 https://embeddemo.crossroads.net/*,https://demo.crossroads.net/giving/,302!
 https://embed.crossroads.net/*,https://www.crossroads.net/giving/,302!
 /,${env:CRDS_UNIFIED_DOMAIN},200!
+/home,${env:CRDS_UNIFIED_DOMAIN}home,200!
 /signout,${env:CRDS_UNIFIED_DOMAIN}signout,200!
 /api/*,${env:CRDS_UNIFIED_DOMAIN}api/:splat,200!
 /growth-path,${env:CRDS_UNIFIED_DOMAIN}growth-path,200!

--- a/redirects.csv
+++ b/redirects.csv
@@ -16,24 +16,15 @@ https://forms.crossroads.net/*,https://${env:CRDS_APP_DOMAIN}/forms/:splat,302!
 https://embedint.crossroads.net/*,https://int.crossroads.net/giving/,302!
 https://embeddemo.crossroads.net/*,https://demo.crossroads.net/giving/,302!
 https://embed.crossroads.net/*,https://www.crossroads.net/giving/,302!
-/,${env:CRDS_UNIFIED_DOMAIN}h,200! Role=user
 /,${env:CRDS_UNIFIED_DOMAIN},200!
-/growth-path,${env:CRDS_UNIFIED_DOMAIN}growth-path,200! Role=user
-/growth-path,/signin,301!
-/receive-teaching-weekly,${env:CRDS_UNIFIED_DOMAIN}receive-teaching-weekly,200! Role=user
-/receive-teaching-weekly,/signin,301!
-/connect-with-god-daily,${env:CRDS_UNIFIED_DOMAIN}connect-with-god-daily,200! Role=user
-/connect-with-god-daily,/signin,301!
-/serve-others,${env:CRDS_UNIFIED_DOMAIN}serve-others,200! Role=user
-/serve-others,/signin,301!
-/live-generously,${env:CRDS_UNIFIED_DOMAIN}live-generously,200! Role=user
-/live-generously,/signin,301!
-/join-community,${env:CRDS_UNIFIED_DOMAIN}join-community,200! Role=user
-/join-community,/signin,301!
-/get-baptized,${env:CRDS_UNIFIED_DOMAIN}get-baptized,200! Role=user
-/get-baptized,/signin,301!
-/share-your-story,${env:CRDS_UNIFIED_DOMAIN}share-your-story,200! Role=user
-/share-your-story,/signin,301!
+/growth-path,${env:CRDS_UNIFIED_DOMAIN}growth-path,200!
+/receive-teaching-weekly,${env:CRDS_UNIFIED_DOMAIN}receive-teaching-weekly,200!
+/connect-with-god-daily,${env:CRDS_UNIFIED_DOMAIN}connect-with-god-daily,200!
+/serve-others,${env:CRDS_UNIFIED_DOMAIN}serve-others,200!
+/live-generously,${env:CRDS_UNIFIED_DOMAIN}live-generously,200!
+/join-community,${env:CRDS_UNIFIED_DOMAIN}join-community,200!
+/get-baptized,${env:CRDS_UNIFIED_DOMAIN}get-baptized,200!
+/share-your-story,${env:CRDS_UNIFIED_DOMAIN}share-your-story,200!
 /group-renew groupIds=:groupIds,/group-renew?groupIds=:groupIds,200! Role=user
 /group-renew groupIds=:groupIds,/signin?redirectUrl=/group-renew?groupIds=:groupIds,302!
 *** CMS REDIRECTS WILL BE INSERTED HERE --- DO NOT REMOVE THIS LINE! ***

--- a/redirects.csv
+++ b/redirects.csv
@@ -17,7 +17,6 @@ https://embedint.crossroads.net/*,https://int.crossroads.net/giving/,302!
 https://embeddemo.crossroads.net/*,https://demo.crossroads.net/giving/,302!
 https://embed.crossroads.net/*,https://www.crossroads.net/giving/,302!
 /,${env:CRDS_UNIFIED_DOMAIN},200!
-/home,${env:CRDS_UNIFIED_DOMAIN}home,200!
 /signout,${env:CRDS_UNIFIED_DOMAIN}signout,200!
 /api/*,${env:CRDS_UNIFIED_DOMAIN}api/:splat,200!
 /growth-path,${env:CRDS_UNIFIED_DOMAIN}growth-path,200!


### PR DESCRIPTION
## Problem
We dont want to utilize nf_jwt for tracking authentication on unified, the routes here are currently being proxied to show a user the auth block pages based on nf_jwt.

## Solution
removed role user from unified routes
removed redirects to signin from auth blocked pages because this file has no concept to determine if we are logged in now

### Corresponding Branch


## Testing


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1203331084606721