### PR TITLE
Alter Redirect Status

### DIFF
--- a/redirects.csv
+++ b/redirects.csv
@@ -21,21 +21,21 @@ https://embed.crossroads.net/*,https://www.crossroads.net/giving/,302!
 /signout,${env:CRDS_UNIFIED_DOMAIN}signout,200!
 /api/*,${env:CRDS_UNIFIED_DOMAIN}api/:splat,200!
 /growth-path,${env:CRDS_UNIFIED_DOMAIN}growth-path,200! Role=user
-/growth-path,/signin,301!
+/growth-path,/signin,302!
 /receive-teaching-weekly,${env:CRDS_UNIFIED_DOMAIN}receive-teaching-weekly,200! Role=user
-/receive-teaching-weekly,/signin,301!
+/receive-teaching-weekly,/signin,302!
 /connect-with-god-daily,${env:CRDS_UNIFIED_DOMAIN}connect-with-god-daily,200! Role=user
-/connect-with-god-daily,/signin,301!
+/connect-with-god-daily,/signin,302!
 /serve-others,${env:CRDS_UNIFIED_DOMAIN}serve-others,200! Role=user
-/serve-others,/signin,301!
+/serve-others,/signin,302!
 /live-generously,${env:CRDS_UNIFIED_DOMAIN}live-generously,200! Role=user
-/live-generously,/signin,301!
+/live-generously,/signin,302!
 /join-community,${env:CRDS_UNIFIED_DOMAIN}join-community,200! Role=user
-/join-community,/signin,301!
+/join-community,/signin,302!
 /get-baptized,${env:CRDS_UNIFIED_DOMAIN}get-baptized,200! Role=user
-/get-baptized,/signin,301!
+/get-baptized,/signin,302!
 /share-your-story,${env:CRDS_UNIFIED_DOMAIN}share-your-story,200! Role=user
-/share-your-story,/signin,301!
+/share-your-story,/signin,302!
 /prayer-night,${env:CRDS_UNIFIED_DOMAIN}prayer-night,200!
 /group-renew groupIds=:groupIds,/group-renew?groupIds=:groupIds,200! Role=user
 /group-renew groupIds=:groupIds,/signin?redirectUrl=/group-renew?groupIds=:groupIds,302!


### PR DESCRIPTION
## Problem
redirects are 301 instead of 302s

## Solution
made them 302s

## Testing
merge to development 
while not signed in & view the growth path page or any of the pillar set a goal pages
you should be redirected back to signin

if you are signed in you should not be redirected to signin & should be allowed to stay on those pages

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1203374479811215