### PR TITLE
Weekly Teaching Updates

### DIFF
--- a/_layouts/series.html
+++ b/_layouts/series.html
@@ -71,31 +71,16 @@ title: Series
         {% assign tabs_array = "" | split: "|" %}
   
         {% if page.videos.size > 0 %}
-          {% assign tabs_array = tabs_array | push: "Online" %}
+          {% assign tabs_array = tabs_array | push: "Full Service" %}
         {% endif %}
   
         {% if page.live_messages.size > 0 %}
-          {% assign tabs_array = tabs_array | push: "At Sites" %}
+          {% assign tabs_array = tabs_array | push: "Message Only" %}
         {% endif %}
   
         <div>
           <crds-tabs tabs='{{ tabs_array | jsonify }}' navigation-class="align-tabs-left component-header" horizontal-only>
-            <div slot="tab-online">
-              <div class="cards-3x">
-                <div class="row">
-                  {% for msg_obj in page.videos %}
-                    {% assign item = site.videos | where: 'slug', msg_obj.slug | first %}
-                    {% unless item %}
-                      {% assign item = site.messages | where: 'slug', msg_obj.slug | first %}
-                    {% endunless %}
-                    {% if item %}
-                      {% include _message-card.html %}
-                    {% endif %}
-                  {% endfor %}
-                </div>
-              </div>
-            </div>
-            <div slot="tab-at-sites">
+            <div slot="tab-full-service">
               <div class="cards-3x">
                 <div class="row">
                   {% for msg_obj in page.live_messages %}
@@ -110,6 +95,22 @@ title: Series
                 </div>
               </div>
             </div>
+            <div slot="tab-message-only">
+              <div class="cards-3x">
+                <div class="row">
+                  {% for msg_obj in page.videos %}
+                    {% assign item = site.videos | where: 'slug', msg_obj.slug | first %}
+                    {% unless item %}
+                      {% assign item = site.messages | where: 'slug', msg_obj.slug | first %}
+                    {% endunless %}
+                    {% if item %}
+                      {% include _message-card.html %}
+                    {% endif %}
+                  {% endfor %}
+                </div>
+              </div>
+            </div>
+            
           </crds-tabs>
         </div>
         {% endif %}


### PR DESCRIPTION
## Problem
on /media/series/{series-slug}
we want Online to say Full Service & show live messages content below
we want At Sites to say Message Only & show "online" messages
"online" is going to be converted to show shortened live messages in the future
[Task Link](https://app.asana.com/0/1201454420722044/1203365469722789/f)

<img width="1241" alt="Screen Shot 2022-11-21 at 3 05 17 PM" src="https://user-images.githubusercontent.com/19368093/203148383-0198c9e1-b37d-486c-9f4f-0eb15e61e53c.png">


## Solution
did that
<img width="951" alt="Screen Shot 2022-11-21 at 3 07 03 PM" src="https://user-images.githubusercontent.com/19368093/203148717-61a3eb1e-449e-4ad1-a90b-18e6f3b698bb.png">


### Corresponding Branch

## Testing
pull down locally & verify changes are correct & work as described in the problem statement
or 
merge to development & verify changes are correct & work as described in the problem statement