### PR TITLE
Add canonical link tags to non-distro channel pages

### DIFF
--- a/_includes/_head.html
+++ b/_includes/_head.html
@@ -47,6 +47,8 @@
     {% else %}
       <link rel="canonical" href="{{ page | get_canonical_host }}">
     {% endif %}
+  {% else %}
+    <link rel="canonical" href="{{ page.url | absolute_url | chomp: 'index.html' }}">
   {% endif %}
 
   {% if page.content_type == "article" %}

--- a/_plugins/filters/chomp.rb
+++ b/_plugins/filters/chomp.rb
@@ -1,0 +1,9 @@
+module Jekyll
+  module ChompFilter
+    def chomp(str, chomp_str)
+      str.chomp(chomp_str)
+    end
+  end
+end
+
+Liquid::Template.register_filter(Jekyll::ChompFilter)


### PR DESCRIPTION
## Problem

The SEO nerds want canonical link tags on every page. Today, we're only rendering these tags when there is [more than one distribution channel](https://github.com/crdschurch/crds-net/blob/master/_includes/_head.html#L43-L49).

## Solution

This PR adds canonicals to all non-distro channel pages.

## Testing

You're looking for the following convention in the page's source... 

<img width="1064" alt="Screen Shot 2022-12-02 at 2 10 18 PM" src="https://user-images.githubusercontent.com/50378/205367820-bdfb5fe4-c55f-4274-8e30-8911bb2e0336.png">

Some examples... 

* https://deploy-preview-2756--int-crds-net.netlify.app/media/
* https://deploy-preview-2756--int-crds-net.netlify.app/media/videos/get-to-know-alli
* https://deploy-preview-2756--int-crds-net.netlify.app/media/videos/get-to-know-alli
* https://deploy-preview-2756--int-crds-net.netlify.app/media/podcasts/spirit-stories
* https://deploy-preview-2756--int-crds-net.netlify.app/spiritual-outfitters/
* https://deploy-preview-2756--int-crds-net.netlify.app/oakley

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1202832936097549