### PR TITLE
Revert "Remove Role=user from Unified Routes"

### DIFF
--- a/redirects.csv
+++ b/redirects.csv
@@ -16,17 +16,26 @@ https://forms.crossroads.net/*,https://${env:CRDS_APP_DOMAIN}/forms/:splat,302!
 https://embedint.crossroads.net/*,https://int.crossroads.net/giving/,302!
 https://embeddemo.crossroads.net/*,https://demo.crossroads.net/giving/,302!
 https://embed.crossroads.net/*,https://www.crossroads.net/giving/,302!
+/,${env:CRDS_UNIFIED_DOMAIN}h,200! Role=user
 /,${env:CRDS_UNIFIED_DOMAIN},200!
 /signout,${env:CRDS_UNIFIED_DOMAIN}signout,200!
 /api/*,${env:CRDS_UNIFIED_DOMAIN}api/:splat,200!
-/growth-path,${env:CRDS_UNIFIED_DOMAIN}growth-path,200!
-/receive-teaching-weekly,${env:CRDS_UNIFIED_DOMAIN}receive-teaching-weekly,200!
-/connect-with-god-daily,${env:CRDS_UNIFIED_DOMAIN}connect-with-god-daily,200!
-/serve-others,${env:CRDS_UNIFIED_DOMAIN}serve-others,200!
-/live-generously,${env:CRDS_UNIFIED_DOMAIN}live-generously,200!
-/join-community,${env:CRDS_UNIFIED_DOMAIN}join-community,200!
-/get-baptized,${env:CRDS_UNIFIED_DOMAIN}get-baptized,200!
-/share-your-story,${env:CRDS_UNIFIED_DOMAIN}share-your-story,200!
+/growth-path,${env:CRDS_UNIFIED_DOMAIN}growth-path,200! Role=user
+/growth-path,/signin,302!
+/receive-teaching-weekly,${env:CRDS_UNIFIED_DOMAIN}receive-teaching-weekly,200! Role=user
+/receive-teaching-weekly,/signin,302!
+/connect-with-god-daily,${env:CRDS_UNIFIED_DOMAIN}connect-with-god-daily,200! Role=user
+/connect-with-god-daily,/signin,302!
+/serve-others,${env:CRDS_UNIFIED_DOMAIN}serve-others,200! Role=user
+/serve-others,/signin,302!
+/live-generously,${env:CRDS_UNIFIED_DOMAIN}live-generously,200! Role=user
+/live-generously,/signin,302!
+/join-community,${env:CRDS_UNIFIED_DOMAIN}join-community,200! Role=user
+/join-community,/signin,302!
+/get-baptized,${env:CRDS_UNIFIED_DOMAIN}get-baptized,200! Role=user
+/get-baptized,/signin,302!
+/share-your-story,${env:CRDS_UNIFIED_DOMAIN}share-your-story,200! Role=user
+/share-your-story,/signin,302!
 /prayer-night,${env:CRDS_UNIFIED_DOMAIN}prayer-night,200!
 /group-renew groupIds=:groupIds,/group-renew?groupIds=:groupIds,200! Role=user
 /group-renew groupIds=:groupIds,/signin?redirectUrl=/group-renew?groupIds=:groupIds,302!


### PR DESCRIPTION
Reverts crdschurch/crds-net#2741
Temporary revert to have crds-unified in a properly working state while we adjust the authentication modifications on that external repo.