### PR TITLE
Add missing env var config

### DIFF
--- a/_plugins/generators/env_generator.rb
+++ b/_plugins/generators/env_generator.rb
@@ -15,6 +15,8 @@ module Jekyll
       @site.config['crds_domain'] = "https://#{env_prefix}.crossroads.net"
       @site.config['search_domain'] = ENV['SEARCH_DOMAIN'] || 'https://www.crossroads.net'
       @site.config['url'] = ENV['SITE_URL'] if ENV['SITE_URL']
+      @site.config['crds_env'] = ENV['CRDS_ENV'] if ENV['CRDS_ENV']
+      @site.config['contentful_env'] = ENV['CONTENTFUL_ENV'] if ENV['CONTENTFUL_ENV']
       @site.config['music_url'] = ENV['CRDS_MUSIC_ENDPOINT'] if ENV['CRDS_MUSIC_ENDPOINT']
     end
 


### PR DESCRIPTION
## Problem
crds-net was not outputting `crds_env` or `contentful_env` variables, which are needed to populate the alerts bar.

## Solution
Add the missing variables to the EnvGenerator.

## Testing
- See the deploy preview or check out the branch & run locally
- Ensure that you have the two variables above defined in your `.envrc`
- Confirm that you can see alerts on .net pages such as /oakley, /media, etc.