### PR TITLE
Update /media index featured content

### DIFF
--- a/media/index.html
+++ b/media/index.html
@@ -51,12 +51,13 @@ paginate:
 
     <!-- Media Sometimes Above the fold -->
     <div class="row push-ends">
-      {% assign media_top_feature = site.featured_media | where: 'page_path', 'media-top-featured' | first %}
-      {% assign featured_item = media_top_feature.entries %}
+      {% assign featured_articles = page.recent_media.docs | where: 'content_type', 'article' %}
+
       <div class="col-sm-8 col-md-9">
-        {% for content in featured_item %}
-        {% assign item = content | get_doc %}
-        {% include _overlay-card.html autoplay=true %}
+        {% assign latest_article = featured_articles | slice: 0, 1 %}
+        {% for item in latest_article %}
+          {% assign image = item.image.url %}
+          {% include _overlay-card.html autoplay=true %}
         {% endfor %}
       </div>
 
@@ -65,25 +66,14 @@ paginate:
           <h3 class="font-family-serif font-size-small text-uppercase text-gray-dark flush soft-half-ends">Popular</h3>
         </div>
         <div class="border-bottom-dashed-group">
-          {% assign popular_this_week =  site.featured_media | where: 'page_path', 'media-homepage-popular' | first %}
-          {% assign featured_popular_items = popular_this_week.entries %}
+          {% assign popular_articles = featured_articles | slice: 1, 4 %}
 
-          {% for content in featured_popular_items limit: 3 %}
-            {% assign item = content | get_doc %}
+          {% for item in popular_articles %}
             {% assign image = item.image.url %}
-
-            {% if item.content_type == 'episode' %}
-              {% assign image = item.podcast_img %}
-            {% endif %}
+            {% assign content_type = 'article' %}
 
             {% if item.duration %}
               {% assign format = 'short' %}
-            {% endif %}
-
-            {% if item.content_type == 'message' %}
-              {% assign content_type = 'video' %}
-            {% else %}
-              {% assign content_type = item.content_type %}
             {% endif %}
 
             <div class="push-bottom">
@@ -91,8 +81,8 @@ paginate:
                 url="{{ item | media_url }}"
                 image-src="{{ image | imgix: site.imgix }}?{{ site.imgix_params.placeholder }}?auto=format"
                 type="{{ content_type }}"
-                title="{{ item.title }}"
                 duration="{{ item.duration | duration: format }}"
+                title="{{ item.title }}"
                 data-optimize-img
               ></crds-media-object>
             </div>

--- a/media/index.html
+++ b/media/index.html
@@ -81,8 +81,8 @@ paginate:
                 url="{{ item | media_url }}"
                 image-src="{{ image | imgix: site.imgix }}?{{ site.imgix_params.placeholder }}?auto=format"
                 type="{{ content_type }}"
-                duration="{{ item.duration | duration: format }}"
                 title="{{ item.title }}"
+                duration="{{ item.duration | duration: format }}"
                 data-optimize-img
               ></crds-media-object>
             </div>


### PR DESCRIPTION
## Problem
Content above the fold on /media was previously organized by a featured media tag. Instead, we want to sort by publish date and only include articles in that section.

## Solution
Change the logic to only pull in article content type & sort the articles by publish date.

## Testing
[Deploy Preview](https://deploy-preview-2773--int-crds-net.netlify.app/media/)

To test, check out articles in Contentful sorted by publish date and confirm that the four most recent map to those shown on the /media page.

<img width="1527" alt="Screen Shot 2022-12-13 at 9 32 39 AM" src="https://user-images.githubusercontent.com/58494322/207375804-813d38b8-0253-488d-b6c7-d85cd35682a2.png">
<img width="1201" alt="Screen Shot 2022-12-13 at 9 33 01 AM" src="https://user-images.githubusercontent.com/58494322/207375885-7999744c-9d71-41a8-be71-9dfa254e902c.png">



---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1202990261116546