### PR TITLE
Replace GTM w/ Segment

### DIFF
--- a/_includes/_gtm-head.html
+++ b/_includes/_gtm-head.html
@@ -1,7 +1,0 @@
-<!-- Google Tag Manager -->
-<script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
-new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
-j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
-'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
-})(window,document,'script','dataLayer','GTM-MFS4MJ');</script>
-<!-- End Google Tag Manager -->

--- a/_includes/_gtm_noscript.html
+++ b/_includes/_gtm_noscript.html
@@ -1,2 +1,0 @@
-<noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-MFS4MJ"
-  height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>

--- a/_includes/_head.html
+++ b/_includes/_head.html
@@ -147,16 +147,12 @@
   </script>
   {% endunless %}
 
-  {% if page.url contains '/watch' or page.url contains '/go/partners/prison-ministry' or page.url contains '/lexington' %}
-    <script>
-    dataLayer.push({'event': 'segment_loaded'});
-    !function(){var analytics=window.analytics=window.analytics||[];if(!analytics.initialize)if(analytics.invoked)window.console&&console.error&&console.error("Segment snippet included twice.");else{analytics.invoked=!0;analytics.methods=["trackSubmit","trackClick","trackLink","trackForm","pageview","identify","reset","group","track","ready","alias","debug","page","once","off","on","addSourceMiddleware","addIntegrationMiddleware","setAnonymousId","addDestinationMiddleware"];analytics.factory=function(e){return function(){var t=Array.prototype.slice.call(arguments);t.unshift(e);analytics.push(t);return analytics}};for(var e=0;e<analytics.methods.length;e++){var key=analytics.methods[e];analytics[key]=analytics.factory(key)}analytics.load=function(key,e){var t=document.createElement("script");t.type="text/javascript";t.async=!0;t.src="https://analytics.segment.crossroads.net/analytics.js/v1/" + key + "/analytics.min.js";var n=document.getElementsByTagName("script")[0];n.parentNode.insertBefore(t,n);analytics._loadOptions=e};analytics._writeKey="nPCU8RuoHt5Ip7tj3UdS4ek0A53a8dGW";;analytics.SNIPPET_VERSION="4.15.3";
-    analytics.load("nPCU8RuoHt5Ip7tj3UdS4ek0A53a8dGW");
-    }}();
-    </script>
-  {% else %}
-    {% include _gtm-head.html %}
-  {% endif %}
+  <script>
+  dataLayer.push({'event': 'segment_loaded'});
+  !function(){var analytics=window.analytics=window.analytics||[];if(!analytics.initialize)if(analytics.invoked)window.console&&console.error&&console.error("Segment snippet included twice.");else{analytics.invoked=!0;analytics.methods=["trackSubmit","trackClick","trackLink","trackForm","pageview","identify","reset","group","track","ready","alias","debug","page","once","off","on","addSourceMiddleware","addIntegrationMiddleware","setAnonymousId","addDestinationMiddleware"];analytics.factory=function(e){return function(){var t=Array.prototype.slice.call(arguments);t.unshift(e);analytics.push(t);return analytics}};for(var e=0;e<analytics.methods.length;e++){var key=analytics.methods[e];analytics[key]=analytics.factory(key)}analytics.load=function(key,e){var t=document.createElement("script");t.type="text/javascript";t.async=!0;t.src="https://analytics.segment.crossroads.net/analytics.js/v1/" + key + "/analytics.min.js";var n=document.getElementsByTagName("script")[0];n.parentNode.insertBefore(t,n);analytics._loadOptions=e};analytics._writeKey="{% if jekyll_env == 'production' %}nPCU8RuoHt5Ip7tj3UdS4ek0A53a8dGW{% else %}6urDjS9ewsjC9YAbSuihDc0TY7Xrv39b{% endif %}";;analytics.SNIPPET_VERSION="4.15.3";
+  analytics.load("{% if jekyll_env == 'production' %}nPCU8RuoHt5Ip7tj3UdS4ek0A53a8dGW{% else %}6urDjS9ewsjC9YAbSuihDc0TY7Xrv39b{% endif %}");
+  }}();
+  </script>
 
   {% include _monetate-head.html %}
   {% include _facebook.html %}

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -2,10 +2,6 @@
 <html dir="ltr" lang="en-US">
   {% include _head.html %}
   <body class="{% if page.path == 'preview.html' %}preview{% endif %} crds-styles relative">
-    {% if page.url contains '/watch' or page.url contains '/go/partners/prison-ministry' or page.url contains '/lexington' %}
-    {% else %}
-      {% include _gtm_noscript.html %}
-    {% endif %}
     {% include _facebook_noscript.html %}
     {% include _monetate-body.html %}
 

--- a/_layouts/default_footer_flush.html
+++ b/_layouts/default_footer_flush.html
@@ -2,7 +2,6 @@
 <html dir="ltr" lang="en-US">
   {% include _head.html %}
   <body class="{% if page.path == 'preview.html' %}preview{% endif %} crds-styles relative">
-    {% include _gtm_noscript.html %}
     {% include _facebook_noscript.html %}
     {% include _monetate-body.html %}
 

--- a/_layouts/no-header-no-footer.html
+++ b/_layouts/no-header-no-footer.html
@@ -2,7 +2,6 @@
 <html dir="ltr" lang="en-US">
   {% include _head.html %}
   <body class="{% if page.path == 'preview.html' %}preview{% endif %} crds-styles relative">
-    {% include _gtm_noscript.html %}
     {% include _facebook_noscript.html %}
     {% include _monetate-body.html %}
 


### PR DESCRIPTION
## Problem

Loading GTM directly via googletagmanager.com is problematic as certain browsers are blocking 3rd party requests. Thus, we want to load GTM via 1st party hostname, so we need to load GTM as a destination of Segment. 

## Solution

Replace GTM snippet with a new Segment source which loads GTM as a destination. This allows GTM to function as it always has but makes it load via CDN proxy analytics.segment.crossroads.net so its not considered a 3rd party request. 

## Related PRs

- https://github.com/crdschurch/crds-unified/pull/369
- https://github.com/crdschurch/crds-net/pull/2763

## Outstanding Tasks

- [ ] Evaluate ENV when loading source

## Testing

...TBD