### PR TITLE
Full service label

### DIFF
--- a/_layouts/series.html
+++ b/_layouts/series.html
@@ -71,7 +71,7 @@ title: Series
           {% assign tabs_array = "" | split: "|" %}
     
           {% if page.live_messages.size > 0 %}
-            {% assign tabs_array = tabs_array | push: "Live Service" %}
+            {% assign tabs_array = tabs_array | push: "Full Service" %}
           {% endif %}
 
           {% if page.videos.size > 0 %}


### PR DESCRIPTION
## Problem
[Asana Card](https://app.asana.com/0/1201454665996628/1203674525880237/f)

## Solution
- Change tab label on Services template from "Live Service" to "Full Service"

## Testing
[Deploy Preview](https://deploy-preview-2829--int-crds-net.netlify.app/media/series/god-stories)
This change should apply to all `/series` pages.