### PR TITLE
[Defect] Series landing page not showing full services

### DIFF
--- a/_layouts/series.html
+++ b/_layouts/series.html
@@ -80,7 +80,7 @@ title: Series
     
           <div>
             <crds-tabs tabs='{{ tabs_array | jsonify }}' navigation-class="align-tabs-left component-header" horizontal-only>
-              <div slot="tab-live-service">
+              <div slot="tab-full-service">
                 <div class="cards-3x">
                   <div class="row">
                     {% for msg_obj in page.live_messages %}


### PR DESCRIPTION
## Problem
The Full Service tab was not showing videos on the series pages.

## Solution
Update the slot name to reflect the existing naming convention so that videos populate that tab.

<img width="373" alt="Screen Shot 2023-01-23 at 10 58 53 AM" src="https://user-images.githubusercontent.com/58494322/214101696-2884cfde-d3f7-4192-9066-d735b656375e.png">
<img width="373" alt="Screen Shot 2023-01-23 at 10 58 49 AM" src="https://user-images.githubusercontent.com/58494322/214101701-45d42b95-5de4-4b03-869c-abac9faed20e.png">


## Testing

https://deploy-preview-2833--int-crds-net.netlify.app/media/series/god-stories

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1203802000082757