### PR TITLE
Account for one message video on series detail page

### DIFF
--- a/_layouts/series.html
+++ b/_layouts/series.html
@@ -77,12 +77,16 @@ title: Series
           {% if page.videos.size > 0 %}
             {% assign tabs_array = tabs_array | push: "Message Only" %}
           {% endif %}
-    
+
+          {% if page.live_messages == null or page.videos == null %}
+            {% assign row_align_class = "d-flex justify-content-center" %}
+          {% endif %}
+
           <div>
             <crds-tabs tabs='{{ tabs_array | jsonify }}' navigation-class="align-tabs-left component-header" horizontal-only>
               <div slot="tab-full-service">
                 <div class="cards-3x">
-                  <div class="row">
+                  <div class="row {{ row_align_class }}">
                     {% for msg_obj in page.live_messages %}
                       {% assign item = site.videos | where: 'slug', msg_obj.slug | first %}
                       {% unless item %}
@@ -97,11 +101,11 @@ title: Series
               </div>
               <div slot="tab-message-only">
                 <div class="cards-3x">
-                  <div class="row">
+                  <div class="row {{ row_align_class }}">
                     {% for msg_obj in page.videos %}
                       {% assign item = site.videos | where: 'slug', msg_obj.slug | first %}
                       {% unless item %}
-                        {% assign item = site.messages | where: 'slug', msg_obj.slug | first %}
+                        {% assign item = site.messages | where: 'slug', msg_obj.slug | first %}`
                       {% endunless %}
                       {% if item %}
                         {% include _message-card.html %}


### PR DESCRIPTION
## Problem
If only one message video is present, only that video/tab should be shown on the series detail page.

## Solution
If there is only one video, confirm that only the tab for the existing video shows and center that video card.

## Testing
Option 1 (Contentful): In `int` Contentful, unpublish either the Full Service or Message Only video on the latest series (or whatever series is being shown in that environment).
Option 2 (local): 
Pull down Contentful
Find the latest _series in collections directory and comment out/delete the videos or live_messages
Run crds-net server
See the changes reflected on /watch. You should only see the videos that exist for that series.

https://deploy-preview-2838--int-crds-net.netlify.app/media/series/god-stories