### PR TITLE
List tag redirects explicitly

### DIFF
--- a/redirects.csv
+++ b/redirects.csv
@@ -36,7 +36,13 @@ https://embed.crossroads.net/*,https://www.crossroads.net/giving/,302!
 /get-baptized,/signin,302!
 /share-your-story,${env:CRDS_UNIFIED_DOMAIN}share-your-story,200! Role=user
 /share-your-story,/signin,302!
-/practices/*,${env:CRDS_UNIFIED_DOMAIN}practices/:splat,200!
+/practices/get-baptized,${env:CRDS_UNIFIED_DOMAIN}practices/get-baptized,200!
+/practices/share-your-story,${env:CRDS_UNIFIED_DOMAIN}practices/share-your-story,200!
+/practices/join-community,${env:CRDS_UNIFIED_DOMAIN}practices/join-community,200!
+/practices/serve-others,${env:CRDS_UNIFIED_DOMAIN}practices/serve-others,200!
+/practices/receive-teaching-weekly,${env:CRDS_UNIFIED_DOMAIN}practices/receive-teaching-weekly,200!
+/practices/connect-with-others,${env:CRDS_UNIFIED_DOMAIN}practices/connect-with-others,200!
+/practices/live-generously,${env:CRDS_UNIFIED_DOMAIN}practices/live-generously,200!
 /prayer-night,${env:CRDS_UNIFIED_DOMAIN}prayer-night,200!
 /cohorts,${env:CRDS_UNIFIED_DOMAIN}cohorts,200!
 /cohorts/*,${env:CRDS_UNIFIED_DOMAIN}cohorts/:splat,200!


### PR DESCRIPTION
## Problem
The catch-all in the /practices/* redirect was conflicting with the /practices landing page causing it to break.

## Solution
List each tag page explicitly

### Corresponding Branch
*Add link to crdschurch/repo-name-here#issue-number (if applicable). This helps the code reviewer know that corresponding work exists and where to find it.*

## Testing
*Include information on how to test your work here (if applicable).*