### PR TITLE
Change location pages to display most recent message instead of current series

### DIFF
--- a/_layouts/anywhere.html
+++ b/_layouts/anywhere.html
@@ -89,16 +89,16 @@ layout: default
               </div>
               {% endif %}
 
-              <!-- Current Series -->
-              <a href="{{ series.url }}" title="{{ series.title }}">
-                <crds-image unified src="{{ series.image.url | imgix: site.imgix }}?auto=format,compress&w=720" no-crop size="card"></crds-image>
+              <!-- Most Recent Message -->
+              {% assign message = site.messages | sort: "published_at" | reverse | first %}
+              <a href="{{ message.url }}" title="{{ message.title }}">
+                <crds-image unified src="{{ message.image.url | imgix: site.imgix }}?auto=format,compress&w=720" no-crop size="card"></crds-image>
               </a>
-              <p class="text-orange text-uppercase flush-bottom push-top"><strong>Current Series</strong></p>
-              <h2 class="font-family-condensed-extra text-uppercase flush font-weight-300">{{ series.title }}</h2>
+              <h2 class="font-family-condensed-extra text-uppercase flush font-weight-300">{{ message.title }}</h2>
               <div class="push-half-top push-bottom font-size-small text-gray-dark">
-                {{ series.description | markdownify }}
+                {{ message.description | markdownify }}
               </div>
-              <crds-button href="{{ series.url }}#online" title="{{ series.title }}" text="Watch current teaching series"
+              <crds-button href="{{ message.url }}#online" title="{{ message.title }}" text="Watch the latest Message"
                 color="orange"></crds-button>
 
             </div>

--- a/_layouts/established.html
+++ b/_layouts/established.html
@@ -69,18 +69,17 @@ layout: default
               </div>
               {% endif %}
 
-              <!-- Current Series -->
-              <a href="{{ series.url }}" title="{{ series.title }}">
-                <crds-image src="{{ series.image.url | imgix: site.imgix }}?auto=format,compress&w=720" no-crop size="card"></crds-image>
+              <!-- Most Recent Message -->
+              {% assign message = site.messages | sort: "published_at" | reverse | first %}
+              <a href="{{ message.url }}" title="{{ message.title }}">
+                <crds-image src="{{ message.image.url | imgix: site.imgix }}?auto=format,compress&w=720" no-crop size="card"></crds-image>
               </a>
-              <p class="text-orange text-uppercase flush-bottom push-top"><strong>Current Series</strong></p>
-              <h2 class="font-family-condensed-extra text-uppercase flush">{{ series.title }}</h2>
+              <h2 class="font-family-condensed-extra text-uppercase flush">{{ message.title }}</h2>
               <div class="push-half-top push-bottom font-size-small text-gray-dark">
-                {{ series.description | markdownify }}
+                {{ message.description | markdownify }}
               </div>
-              <crds-button href="{{ series.url }}#at-sites" title="{{ series.title }}" text="Watch current teaching series"
+              <crds-button href="{{ message.url }}#at-sites" title="{{ message.title }}" text="Watch the latest Message"
                 color="orange"></crds-button>
-
             </div>
             <div class="col-sm-4 push-bottom soft-bottom">
               <crds-site-happenings-locations location="{{ page.name }}" show-limit="5" has-promo="{{ hasPromo }}"></crds-site-happenings-locations>

--- a/_layouts/frontier.html
+++ b/_layouts/frontier.html
@@ -118,15 +118,16 @@ layout: default
               </div>
               {% endif %}
 
-              <a href="{{ series.url }}" title="{{ series.title }}">
-                <crds-image src="{{ series.image.url | imgix: site.imgix }}?auto=format,compress&w=720" no-crop size="card"></crds-image>
+              <!-- Most Recent Message -->
+              {% assign message = site.messages | sort: "published_at" | reverse | first %}
+              <a href="{{ message.url }}" title="{{ message.title }}">
+                <crds-image src="{{ message.image.url | imgix: site.imgix }}?auto=format,compress&w=720" no-crop size="card"></crds-image>
               </a>
-              <p class="text-orange text-uppercase flush-bottom push-top"><strong>Current Series</strong></p>
-              <h2 class="font-family-condensed-extra text-uppercase flush">{{ series.title }}</h2>
+              <h2 class="font-family-condensed-extra text-uppercase flush">{{ message.title }}</h2>
               <div class="push-half-top push-bottom font-size-small text-gray-dark">
-                {{ series.description | markdownify }}
+                {{ message.description | markdownify }}
               </div>
-              <crds-button href="{{ series.url }}#at-sites" title="{{ series.title }}" text="Watch current teaching series"
+              <crds-button href="{{ message.url }}#at-sites" title="{{ message.title }}" text="Watch the latest Message"
                 color="orange"></crds-button>
 
             </div>


### PR DESCRIPTION
## Problem
DPT has asked to change on all location pages from current series displaying to most recent messages.

## Solution
Code in layouts was changes to bring in the most recent message and display it in place of the current series.

### Corresponding Branch
No corresponding branches

## Testing
No requisite testing beyond a spot check of an established location page, frontier location page, and the anywhere location page.