### PR TITLE
Footer CTA fix for Articles 

### DIFF
--- a/_assets/stylesheets/_fonts.scss
+++ b/_assets/stylesheets/_fonts.scss
@@ -26,7 +26,7 @@
  *   - http://typekit.com/eulas/000000000000000077359d7f
  *   - http://typekit.com/eulas/000000000000000077359d84
  *
- * © 2009-2022 Adobe Systems Incorporated. All Rights Reserved.
+ * © 2009-2023 Adobe Systems Incorporated. All Rights Reserved.
  */
 /*{"last_published":"2021-07-28 18:02:49 UTC"}*/
 

--- a/_assets/stylesheets/pages/_articles.scss
+++ b/_assets/stylesheets/pages/_articles.scss
@@ -151,3 +151,11 @@
   margin-left: 14px;
   margin-top: 4px;
 }
+
+.jumbotron-content .container h4 {
+  font-size: 2.75rem;
+
+  @media screen and (min-width: $screen-md) {
+    font-size: 5rem;
+  }
+}

--- a/_layouts/article.html
+++ b/_layouts/article.html
@@ -21,7 +21,7 @@ title: Articles
           </div>
           <div class="overlay-card-content">
             <p class="overlay-card-category">{{ page.category.title }}</p>
-            <h2 data-media-title="{{page.title}}" data-media-id="{{page.id}}" class="overlay-card-title overlay-card-heading">{{ page.title | truncate: 70 }}</h2>
+            <h1 data-media-title="{{page.title}}" data-media-id="{{page.id}}" class="overlay-card-title overlay-card-heading">{{ page.title | truncate: 70 }}</h1>
             <p class="overlay-card-author text-gray-light">{{ page.author.full_name }}</p>
             <div class="card-stamp text-white">
               {% if page.duration %}
@@ -221,9 +221,9 @@ title: Articles
   <div class="jumbotron jumbotron-xl grid-overlay-light flush-bottom" style="background-image: url('//crds-media.imgix.net/4TdSCGoNEJn0RRuPLuNv3h/86ded15c0c78b2f5d3204c07dbc3b365/bianca-castillo-iAGPCmxKbls-unsplash.jpg?{{ site.imgix_params.placeholder_sixteen_nine}}');" data-optimize-bg-img>
     <div class="jumbotron-content">
       <div class="container text-center">
-        <h1 class="component-header-box text-white">
+        <h4 class="component-header-box text-white">
           Now Keep<br />it coming
-        </h1>
+        </h4>
         <div class="media-homepage-footer-form col-md-6 col-md-offset-3 col-sm-10 col-sm-offset-1">
           <script charset="utf-8" type="text/javascript" src="//js.hsforms.net/forms/v2-legacy.js"></script>
           <script>


### PR DESCRIPTION
## Problem
On article pages, titles were using `h2` tags and the footer CTA text was using `h1` tags which is not ideal SEO.

## Solution
- Change article title elements from `h2` to `h1`
- Change Jumbotron CTA from `h1` to `h4` (`h2` and `h3` are already being used well semantically based on the page context)
- Also add styling to ensure the appearance stays the same regardless of tag name

### Corresponding Branch
*Add link to crdschurch/repo-name-here#issue-number (if applicable). This helps the code reviewer know that corresponding work exists and where to find it.*

## Testing
Check that article titles and the footer CTA text are using the correct tags as described above

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1204179871685798