### PR TITLE
add prop to crds-tabs for series page

### DIFF
--- a/_layouts/series.html
+++ b/_layouts/series.html
@@ -79,7 +79,7 @@ title: Series
           {% endif %}
 
           <div>
-            <crds-tabs tabs='{{ tabs_array | jsonify }}' navigation-class="align-tabs-left component-header" horizontal-only>
+            <crds-tabs tabs='{{ tabs_array | jsonify }}' show-closed-caption navigation-class="align-tabs-left component-header" horizontal-only>
               <div slot="tab-full-service">
                 <div class="cards-3x">
                   <div class="row">


### PR DESCRIPTION
## Problem
we want to add the closed caption icon to the crds tabs component to only show up when we want it to show up

## Solution
Added an additional prop to crds-tabs component to conditionally render closed caption icon

### Corresponding Branch
*Add link to crdschurch/repo-name-here#issue-number (if applicable). This helps the code reviewer know that corresponding work exists and where to find it.*

## Testing
*Include information on how to test your work here (if applicable).*