### PR TITLE
Revert "Reset user_ids for Segment migration plan"

### DIFF
--- a/_assets/javascripts/components/analytics.js
+++ b/_assets/javascripts/components/analytics.js
@@ -1,7 +1,3 @@
-/* eslint-disable no-undef */
-/* eslint-disable no-unused-vars */
-/* eslint-disable indent */
-
 function parseCommand(originalCommand) {
   var commandArray = originalCommand.split('.');
   return commandArray[commandArray.length - 1];
@@ -24,14 +20,3 @@ function abstractedAnalytics(originalCommand, event, eventCategory, eventAction)
       this.error('gtag() command not found! Command: ' + command);
   }
 }
-
-(function() {
-  var timer = setInterval(segmentCheck, 200);
-  function segmentCheck() {
-    if(window.analytics) {
-      clearInterval(timer);
-      return;
-    }
-    window.analytics.reset(); // clear out any existing analytics
-  }
-})();

--- a/_assets/javascripts/config.js
+++ b/_assets/javascripts/config.js
@@ -55,7 +55,6 @@ module.exports = [
       'components/toggle-tooltip',
       'components/resi-player',
       'components/load-more',
-      'components/analytics'
     ],
   },
   {


### PR DESCRIPTION
This reverts commit af2af373729b76fc7f4e43831c2d97e966c245a7.

## Problem
Dave had asked us to nullify user_ids prior to the Rock cutover. This commit was designed to reset user IDs but that may be contributing to some odd behavior that Insights has been troubleshooting. 

<img width="719" alt="Screen Shot 2023-03-30 at 9 09 15 AM" src="https://user-images.githubusercontent.com/50378/228846084-18196e55-b3b1-4c3e-ae4a-ed798996456b.png">

## Solution
Now that we're on the Rock officially, I'd like to revert this change to reduce the factors. 