### PR TITLE
Remove "| Crossroads Church" from title on /media/articles page

### DIFF
--- a/_includes/_head.html
+++ b/_includes/_head.html
@@ -23,7 +23,12 @@
   <meta property="og:site_name" content="{{ site.title | escape }}">
   <meta name="apple-itunes-app" content="app-id=1029478803">
   <meta name="google-play-app" content="app-id=net.crossroads.crossroads">
+  <!-- Long titles were effecting article SEO. Removing "| Crossroads Church from the title on the Articles page." -->
+  {% if page.title != "Articles" %}
   <title>{{ page | meta_title }}</title>
+  {% else %}
+  <title>{{ page.title }}</title>
+  {% endif %}
   <meta http-equiv="content-type" content="text/html; charset=utf-8" />
   <meta name="author" content="Crossroads" />
   <meta name="msapplication-TileColor" content="#ffffff">


### PR DESCRIPTION
## Problem
The title on the `/media/articles` page was too long and was causing SEO ranking issues for articles. Removed `| Crossroads Church` from the formatted title for Articles only

## Solution
Add a condition to check if the formatted page title in `head.html` will include `Articles`. If it does, don't add `| Crossroads Church`

### Corresponding Branch
*Add link to crdschurch/repo-name-here#issue-number (if applicable). This helps the code reviewer know that corresponding work exists and where to find it.*

## Testing
*Include information on how to test your work here (if applicable).*