### PR TITLE
add userway widget to crdsnet pages

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -23,5 +23,9 @@
     <!-- Start of HubSpot Embed Code -->
     <script type="text/javascript" id="hs-script-loader" async defer src="//js.hs-scripts.com/3993985.js"></script>
     <!-- End of HubSpot Embed Code -->
+
+    {% if site.jekyll_env != "production" %}
+      <script src="https://cdn.userway.org/widget.js" data-account="4XbzePFiPE"></script>
+    {% endif %}
   </body>
 </html>

--- a/_layouts/default_footer_flush.html
+++ b/_layouts/default_footer_flush.html
@@ -20,5 +20,8 @@
     {% if page.preloader %}{% include _preloader.html %}{% endif %}
 
     {% include _footer-script.html %}
+    {% if site.jekyll_env != "production" %}
+      <script src="https://cdn.userway.org/widget.js" data-account="4XbzePFiPE"></script>
+    {% endif %}
   </body>
 </html>

--- a/_layouts/no-header-no-footer.html
+++ b/_layouts/no-header-no-footer.html
@@ -20,5 +20,9 @@
     <!-- Start of HubSpot Embed Code -->
       <script type="text/javascript" id="hs-script-loader" async defer src="//js.hs-scripts.com/3993985.js"></script>
     <!-- End of HubSpot Embed Code -->
+
+    {% if site.jekyll_env != "production" %}
+      <script src="https://cdn.userway.org/widget.js" data-account="4XbzePFiPE"></script>
+    {% endif %}
   </body>
 </html>


### PR DESCRIPTION
## Problem
we have a free widget that we want to deploy on demo but no where else

## Solution
added conditional check for jekyll_env to conditionally render script tag or not



## Testing
locally youll need to have this line defined in your .envrc file
```bash
export JEKYLL_ENV=production
```
direnv allow
run project you should not see any userway widget displayed

```bash
export JEKYLL_ENV=demo
```
direnv allow
run project you should see the userway widget displayed



