### PR TITLE
add condition to filter out excluded items

### DIFF
--- a/media/topics.html
+++ b/media/topics.html
@@ -15,29 +15,30 @@ title: Topics
 
   <div class="topic-card-deck">
     {% for topic in site.categories %}
-    {% if topic.title != "Student Ministry" and topic.title != "Kids' Club" %}
-      <div class="topic-card col-md-4" style="background-image:url('{% if topic.image.url %}{{ topic.image.url | imgix: site.imgix }}{% else %}{{ site.default_image | imgix: site.imgix }}{% endif %}');">
-        <div class="bg-overlay"></div>
-        <div class="topic-card-content">
-          <a class="topic-card-link link-icon font-family-base-mid" href="{{ topic.url }}">
-            <span class="link-icon-text">Best of this topic</span>
-            <svg class="icon icon-1" viewBox="0 0 256 256">
-              <use xlink:href="/assets/svgs/icons.svg#chevron-right"></use>
-            </svg>
-          </a>
-          <h2 class="section-header topic-card-title">
-            <a href="{{ topic.url }}">{{ topic.title }}</a>
-          </h2>
-          <ul class="list-unstyled">
-            {% for tag in topic.featured_tags %}
-              <li>
-                <a href="/media/tags/{{ tag.slug }}/" class="topic-card-link">{{ tag.title | capitalize }}</a>
-              </li>
-            {% endfor %}
-          </ul>
-        </div>
+    {% if topic.title != "Student Ministry" and topic.title != "Kids' Club" and topic.excluded != true %}
+    <div class="topic-card col-md-4"
+      style="background-image:url('{% if topic.image.url %}{{ topic.image.url | imgix: site.imgix }}{% else %}{{ site.default_image | imgix: site.imgix }}{% endif %}');">
+      <div class="bg-overlay"></div>
+      <div class="topic-card-content">
+        <a class="topic-card-link link-icon font-family-base-mid" href="{{ topic.url }}">
+          <span class="link-icon-text">Best of this topic</span>
+          <svg class="icon icon-1" viewBox="0 0 256 256">
+            <use xlink:href="/assets/svgs/icons.svg#chevron-right"></use>
+          </svg>
+        </a>
+        <h2 class="section-header topic-card-title">
+          <a href="{{ topic.url }}">{{ topic.title }}</a>
+        </h2>
+        <ul class="list-unstyled">
+          {% for tag in topic.featured_tags %}
+          <li>
+            <a href="/media/tags/{{ tag.slug }}/" class="topic-card-link">{{ tag.title | capitalize }}</a>
+          </li>
+          {% endfor %}
+        </ul>
       </div>
-      {% endif %}
+    </div>
+    {% endif %}
     {% endfor %}
   </div>
 </div>


### PR DESCRIPTION
## Problem
With category content type being used for topics and video shorts now, we needed to implement a way to filter out excluded categories.

[Task](https://app.asana.com/0/1201454420722044/1205173108415310/f)

## Solution
Add a condition to the existing if statement to filter out any category that has excluded set to `true`.

## Testing Notes
There are currently 4 excluded categories. (excluded set to true). 

- [Crossroads Music](https://app.contentful.com/spaces/y3a9myzsdjan/environments/demo/entries/51MVLD7HZ3AtThu70TmmWI)
- [Crossroads](https://app.contentful.com/spaces/y3a9myzsdjan/environments/demo/entries/4KIciGti4VXjUesihtnGEJ)
- [Student Ministry](https://app.contentful.com/spaces/y3a9myzsdjan/environments/demo/entries/45GgGf0SqOhhhmBvaVXazl)
- [Kids'Club](https://app.contentful.com/spaces/y3a9myzsdjan/environments/demo/entries/5f0WbEAhgQ9HX5xrnd5HWc)

## Deploy Preview
[Preview](https://deploy-preview-3084--demo-crds-net.netlify.app/media/topics/)
