### PR TITLE
filter out decommissioned locations

### DIFF
--- a/_includes/_locations-grid.html
+++ b/_includes/_locations-grid.html
@@ -1,6 +1,6 @@
 <div class="card-deck carousel locations" data-crds-carousel="mobile-scroll" data-automation-id="locations-carousel">
   <div id="section-locations" class="feature-cards card-deck--expanded-layout">
-    {% assign locations_sorted_names = site.locations | sort: 'name' | group_by: 'name' %}
+    {% assign locations_sorted_names = site.locations | where: 'decommissioned', false | sort: 'name' | group_by: 'name' %}
     {% for name_group in locations_sorted_names %}
       {% assign locations_sorted_slugs = name_group.items | sort: 'slug' %}
       {% for location in locations_sorted_slugs %}

--- a/redirects.csv
+++ b/redirects.csv
@@ -96,6 +96,7 @@ https://embed.crossroads.net/*,${env:CRDS_ROCK_DOMAIN}mygiving/,302!
 /go/*,${env:CRDS_UNIFIED_DOMAIN}go/:splat,200!
 /world-impact-experience,/wie,302!
 /wie,/world-impact-experience,200!
+/georgetown-decommissioned,/georgetown,302!
 /group-renew groupIds=:groupIds,/group-renew?groupIds=:groupIds,301! Cookie=.ROCK_AUTH
 /group-renew groupIds=:groupIds,${env:CRDS_ROCK_DOMAIN}login?redirectUrl=/group-renew?groupIds=:groupIds,302!
 /profile,${env:CRDS_ROCK_DOMAIN}myaccount,301!


### PR DESCRIPTION
## Problem
we need to be able to decommission locations & maintain their happenings but remove them from /locations page

## Solution
added new field to filter by on /locations
updated /georgetown to /georgetown-decommissioned
added a redirect from /georgetown-decommissioned to /georgetown
added helper text in contentful field to try to document issue for content admins


## Testing
given you have a page created to handle the decommissioned location like this one
https://app.contentful.com/spaces/y3a9myzsdjan/environments/demo/entries/4TLuytPG4ht34pCd8syY8v

mark a location as decommissioned & update its slug to include "-decommissioned" at the end of it like so
https://app.contentful.com/spaces/y3a9myzsdjan/environments/demo/entries/5dUYaUyMwgWUC6AyKkckU0

add a redirect in contentuful for your from the location slug to the new page slug https://app.contentful.com/spaces/y3a9myzsdjan/environments/demo/entries/5dUYaUyMwgWUC6AyKkckU0
https://app.contentful.com/spaces/y3a9myzsdjan/environments/demo/entries/4TLuytPG4ht34pCd8syY8v

to reverse this process do the opposite.

you can see this solution worked because george town will no longer be visible in /locations
& when you visit /georgetown you should see the contentful page for that
& when you visit /georgetown-decommissioned you should be redirected to /georgetown

## Preview
[preview](https://deploy-preview-3085--demo-crds-net.netlify.app/locations)


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1205187398924866