### PR TITLE
add redirect for registration

### DIFF
--- a/redirects.csv
+++ b/redirects.csv
@@ -11,6 +11,7 @@ https://embed.crossroads.net/*,${env:CRDS_ROCK_DOMAIN}mygiving/,302!
 /h,/content-unavailable/,"302! Country=IN,NP"
 /h,${env:CRDS_UNIFIED_DOMAIN}h,200! Cookie=.ROCK_AUTH
 /h,/,302!
+/register,/${CRDS_ROCK_DOMAIN}NewAccount,302!
 /qa/set-token,${env:CRDS_UNIFIED_DOMAIN}qa/set-token,200!
 /qa/get-token,${env:CRDS_UNIFIED_DOMAIN}qa/get-token,200!
 /annualreport/2020,https://annual-report.crossroads.net/,301!


### PR DESCRIPTION
## Problem
we have registration link that is not being redirected to new registration page

## Solution
add redirect to handle this situation

## Testing
navigating to /register should navigate you to my.crossroads.net/NewAccount or mydev.crossroads.net/NewAccount depending on the environment you are on