### PR TITLE
fix typo and remove logic for decommissioned pages.

### DIFF
--- a/_layouts/established.html
+++ b/_layouts/established.html
@@ -49,11 +49,7 @@ layout: default
   <div class="container">
     <div class="row soft-half soft-top push-top mobile-flush-top">
       {% if page.community_pastor_name %}
-        {% if page.slug == "uptown" or page.slug == "uptown-decommissioned" %}
-          <crds-tabs tabs='["events & updates", "community pastor", "about", "groups"]' mobile-dropdown>
-        {% else %}
-          <crds-tabs tabs='["events & updates", "community pastor", "about", "kids & strudents", "groups"]' mobile-dropdown>
-        {% endif %}
+        <crds-tabs tabs='["events & updates", "community pastor", "about", "kids & students", "groups"]' mobile-dropdown>
       {% else %}
       <crds-tabs tabs='["events & updates", "about", "kids & students", "groups"]' mobile-dropdown>
       {% endif %}


### PR DESCRIPTION
## Problem
There is a typo in the kids and students tab

## Solution
Fix the typo, but also remove the logic that ultimately got ported to the Contentful page for Uptown and Georgetown
