### PR TITLE
Add Flex Page Proxies dynamically within crds-net

### DIFF
--- a/lib/crds/redirects.rb
+++ b/lib/crds/redirects.rb
@@ -30,7 +30,8 @@ class Redirects
 
   def flex_page_redirects
     if ENV['CRDS_ENV'] == 'prod'
-      data = JSON.parse(get_data(@flex_page_options)).dig('items')
+      # data = JSON.parse(get_data(@flex_page_options)).dig('items')
+      data = nil
     else
       data = JSON.parse(get_preview_data(@flex_page_options)).dig('items')
     end

--- a/lib/crds/redirects.rb
+++ b/lib/crds/redirects.rb
@@ -19,7 +19,7 @@ class Redirects
       query: {
         access_token: ENV['CRDS_ENV'] == 'prod' ? ENV['CONTENTFUL_ACCESS_TOKEN'] : ENV['CONTENTFUL_PREVIEW_TOKEN'],
         content_type: 'flexPage',
-        limit: 2000
+        limit: 1000
       }
     }
   end

--- a/lib/crds/redirects.rb
+++ b/lib/crds/redirects.rb
@@ -62,7 +62,7 @@ class Redirects
     rows.insert(n + flex_page_redirects_data.length, *redirects)
 
     all_rows = rows.map(&:to_csv).join.gsub('"', '')
-    
+
     File.write(path, all_rows)
     if debug
       puts "\nWrote #{redirects.size} redirects and #{flex_page_redirects.size} flex page redirects to #{path}"
@@ -70,20 +70,19 @@ class Redirects
   end
 
   private
+    def item_attrs(item)
+      [
+        item.dig('fields', 'from'),
+        item.dig('fields', 'to'),
+        "#{item.dig('fields', 'status_code') || 302}#{'!' if item.dig('fields', 'is_forced')}"
+      ]
+    end
 
-  def item_attrs(item)
-    [
-      item.dig('fields', 'from'),
-      item.dig('fields', 'to'),
-      "#{item.dig('fields', 'status_code') || 302}#{'!' if item.dig('fields', 'is_forced')}"
-    ]
-  end
+    def flex_item_attrs(item)
+      item.dig('fields', 'slug')
+    end
 
-  def flex_item_attrs(item)
-    item.dig('fields', 'slug')
-  end
-
-  def get_data(options)
-    self.class.get("/spaces/#{ENV['CONTENTFUL_SPACE_ID']}/environments/#{ENV['CONTENTFUL_ENV']}/entries", options)
-  end
+    def get_data(options)
+      self.class.get("/spaces/#{ENV['CONTENTFUL_SPACE_ID']}/environments/#{ENV['CONTENTFUL_ENV']}/entries", options)
+    end
 end

--- a/lib/crds/redirects.rb
+++ b/lib/crds/redirects.rb
@@ -19,7 +19,7 @@ class Redirects
       query: {
         access_token: ENV['CRDS_ENV'] == 'prod' ? ENV['CONTENTFUL_ACCESS_TOKEN'] : ENV['CONTENTFUL_PREVIEW_TOKEN'],
         content_type: 'flexPage',
-        limit: 1000
+        limit: 2000
       }
     }
   end


### PR DESCRIPTION
## Problem
We need the ability to create a proxy for flex pages in Contentful as they get created.

## Solution
Update `redirects.rb` to fetch all flex page entry slugs, then insert them into `redirects.csv` in addition to the existing redirect entries.

## Testing
- View any Contentful flex page in demo and note the slug field for that entry.
- You should be able to visit that url (aka not get a 404 page) by adding the slug to the deploy preview url. This means the redirect was created successfully.
- For example, the slug `/test-flex-page` is viewable at https://deploy-preview-3172--demo-crds-net.netlify.app/test-flex-page

To test the redirects file directly:
- Pull down this branch locally and fetch the latest `demo` entries from Contentful
- Run this command to build `redirects.csv`:
```
ruby bin/contentful-redirects ./redirects.csv
```
- View `redirects.csv` and you should see the flex page redirects added, including drafted pages
- The same should apply if you pull down `prod` entries (but published entries will be added to the redirects file)

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1205605533387381