### PR TITLE
remove the .sys from the video-id reference.

### DIFF
--- a/_includes/_bitmovin-player.html
+++ b/_includes/_bitmovin-player.html
@@ -14,7 +14,7 @@
   <crds-bitmovin-player 
     recommended-collection='{{json_collection}}' 
     class="embed-responsive embed-responsive-16by9" 
-    video-id="{{video_id}}" 
+    entry-id="{{video.id}}" 
     title="{{video.title}}" 
     is-card="{{is_card}}" 
     url="{{video.bitmovin_url}}"
@@ -28,7 +28,7 @@
 {% else %}
   <crds-bitmovin-player 
     class="embed-responsive embed-responsive-16by9"
-    video-id="{{video_id}}" 
+    entry-id="{{video.id}}" 
     title="{{video.title}}" 
     is-card="{{is_card}}" 
     url={{video.bitmovin_url}}


### PR DESCRIPTION
## Problem
There is currently no video identification passing to the bitmovin player on crds-net that would be captured in analytics. 

## Solution
update the variable that we use and method to use the contentful id.