### PR TITLE
Revert  Thanksgiving Redirect

### DIFF
--- a/redirects.csv
+++ b/redirects.csv
@@ -69,7 +69,6 @@ https://embed.crossroads.net/*,${env:CRDS_ROCK_DOMAIN}mygiving/,302!
 /cohorts/*,${env:CRDS_UNIFIED_DOMAIN}cohorts/:splat,200!
 /happenings,${env:CRDS_UNIFIED_DOMAIN}happenings,200!
 /thanksgiving-food-drive,${env:CRDS_UNIFIED_DOMAIN}thanksgiving-food-drive,200!
-/happy-thanksgiving,${env:CRDS_UNIFIED_DOMAIN}happy-thanksgiving,200!
 /go/local,/go/local,200!
 /go/local/christmas-gift-drive,/cgd,302!
 /go/local/thanksgiving-food-drive,/tfd,302!


### PR DESCRIPTION
Revert `/happy-thanksgiving` redirect so that temporary thanksgiving campaign can be live in prod.

This link should go to [Registering Your Box](https://crossroads-3993985.hs-sites.com/thanksgiving-food-drive-box-registration) until Nov 13:
https://deploy-preview-3183--demo-crds-net.netlify.app/happy-thanksgiving
