### PR TITLE
Add livestream toggle to location pages

### DIFF
--- a/_includes/_livestream.html
+++ b/_includes/_livestream.html
@@ -1,4 +1,3 @@
-<!-- Livestream -->
 <script>
   document.addEventListener('DOMContentLoaded', function () {
     let livestreamData = {{ site.data.livestreams | jsonify | strip_newlines
@@ -15,6 +14,7 @@
 
   let isStream = false;
   let playerUrl = '';
+  let entryId = '';
   let currentPageTitle = "{{ page.name }}";
 
   livestreamData.forEach(function (livestream) {
@@ -27,6 +27,7 @@
 
     if (isPageMatch && isTimeInRange(startTime, endTime)) {
       playerUrl = livestream.url || 'https://resi.media/cr-cinc-oh/Manifest.m3u8';
+      entryId = livestream.id;
       isStream = true;
 
       // Refresh the page one minute after the livestream starts
@@ -56,9 +57,13 @@
         <div class="container">
           <div class="row push-ends">
             <div id="resi-video-player-container" class="col-sm-10 col-sm-offset-1">
-              <crds-bitmovin-player class="embed-responsive embed-responsive-16by9" video-id="crossroadsLiveWeekend"
+              <crds-bitmovin-player
+                class="embed-responsive embed-responsive-16by9"
+                video-id="crossroadsLiveWeekend"
                 is-stream="true"
-                url="${playerUrl}"></crds-bitmovin-player>
+                entry-id=${entryId}
+                url=${playerUrl}>
+              </crds-bitmovin-player>
             </div>
           </div>
         </div>

--- a/_includes/_livestream.html
+++ b/_includes/_livestream.html
@@ -27,7 +27,7 @@
 
     if (isPageMatch && isTimeInRange(startTime, endTime)) {
       playerUrl = livestream.url || 'https://resi.media/cr-cinc-oh/Manifest.m3u8';
-      entryId = livestream.id;
+      entryId = livestream.id || 'VideoManager';
       isStream = true;
 
       // Refresh the page one minute after the livestream starts

--- a/_includes/_livestream.html
+++ b/_includes/_livestream.html
@@ -1,0 +1,74 @@
+<!-- Livestream -->
+<script>
+  document.addEventListener('DOMContentLoaded', function () {
+    let livestreamData = {{ site.data.livestreams | jsonify | strip_newlines
+  }};
+
+  if (!livestreamData || livestreamData.length === 0) {
+    return;
+  }
+
+  function isTimeInRange(startTime, endTime) {
+    let currentTime = Date.now();
+    return currentTime >= startTime && currentTime <= endTime;
+  }
+
+  let isStream = false;
+  let playerUrl = '';
+  let currentPageTitle = "{{ page.name }}";
+
+  livestreamData.forEach(function (livestream) {
+    let startTime = new Date(livestream.startTime).getTime();
+    let endTime = new Date(livestream.endTime).getTime();
+
+    let isPageMatch = livestream.pages.some(function (page) {
+      return page === currentPageTitle || page === 'Churchwide (all location pages)';
+    });
+
+    if (isPageMatch && isTimeInRange(startTime, endTime)) {
+      playerUrl = livestream.url || 'https://resi.media/cr-cinc-oh/Manifest.m3u8';
+      isStream = true;
+
+      // Refresh the page one minute after the livestream starts
+      let refreshStartTime = startTime + 60000;
+      if (refreshStartTime > Date.now()) {
+        setTimeout(function () {
+          location.reload(true);
+        }, refreshStartTime - Date.now());
+      }
+
+      // Refresh the page one minute after the livestream ends
+      let refreshEndTime = endTime + 60000;
+      if (refreshEndTime > Date.now()) {
+        setTimeout(function () {
+          location.reload(true);
+        }, refreshEndTime - Date.now());
+      }
+    }
+  });
+
+  if (isStream) {
+    let resiPlayerSection = document.createElement('section');
+    resiPlayerSection.className = 'bg-blue';
+    resiPlayerSection.id = 'resi-player';
+
+    resiPlayerSection.innerHTML = `
+        <div class="container">
+          <div class="row push-ends">
+            <div id="resi-video-player-container" class="col-sm-10 col-sm-offset-1">
+              <crds-bitmovin-player class="embed-responsive embed-responsive-16by9" video-id="crossroadsLiveWeekend"
+                is-stream="true"
+                url="${playerUrl}"></crds-bitmovin-player>
+            </div>
+          </div>
+        </div>
+      `;
+
+    let jumbotronSection = document.querySelector('.jumbotron');
+
+    if (jumbotronSection && jumbotronSection.parentNode) {
+      jumbotronSection.parentNode.insertBefore(resiPlayerSection, jumbotronSection);
+    }
+  }
+  });
+</script>

--- a/_includes/_resi-player.html
+++ b/_includes/_resi-player.html
@@ -1,16 +1,10 @@
 <section class="bg-blue" id="resi-player">
   <div class="container">
-    <div class="row text-center push-top">
-      <h2 class="flush-top font-family-condensed-extra font-size-h2 text-uppercase text-white">Welcome to Crossroads</h2>
-    </div>
     <div class="row push-ends">
       <div id="resi-video-player-container" class="col-sm-10 col-sm-offset-1">
-        <crds-bitmovin-player class="embed-responsive embed-responsive-16by9" video-id="crossroadsLiveWeekend" is-stream="{{true}}" url="https://resi.media/cr-cinc-oh/Manifest.m3u8"></crds-bitmovin-player>
+        <crds-bitmovin-player class="embed-responsive embed-responsive-16by9" video-id="crossroadsLiveWeekend"
+          is-stream="{{true}}" url="{{ include.url | default: 'https://resi.media/cr-cinc-oh/Manifest.m3u8' }}"></crds-bitmovin-player>
       </div>
-    </div>
-    <div class="row text-center text-white push-bottom soft-bottom">
-      <p class="flush-bottom font-size-small text-uppercase">You're watching the</p>
-      <h3 class="flush-top font-family-condensed-extra font-size-h2 text-uppercase text-white">Crossroads Live Weekend</h3>
     </div>
   </div>
 </section>

--- a/_layouts/anywhere.html
+++ b/_layouts/anywhere.html
@@ -12,6 +12,9 @@ layout: default
   </div>
 {% endif %}
 
+<!-- Livestream player-->
+{% include _livestream.html %}
+
 {% include locations/_welcome-modal.html %}
 
 {% assign sorted_messages = site.messages | sort: 'published_at' %}

--- a/_layouts/established.html
+++ b/_layouts/established.html
@@ -8,6 +8,23 @@ layout: default
 {% assign sorted_messages = site.messages | sort: 'published_at' %}
 {% assign current_message = sorted_messages | last %}
 
+<!-- Resi Player -->
+{% if site.data.livestreams %}
+  {% assign show_resi_player = false %}
+  {% for livestream in site.data.livestreams %}
+    {% if livestream.pages contains page.name %}
+      {% assign show_resi_player = true %}
+      {% assign url = livestream.url %}
+    {% elsif livestream.pages contains 'Churchwide (all location pages)' %}
+      {% assign show_resi_player = true %}
+      {% assign url = livestream.url %}
+    {% endif %}
+  {% endfor %}
+  {% if show_resi_player %}
+    {% include _resi-player.html url=url %}
+  {% endif %}
+{% endif %}
+
 {% include locations/_welcome-modal.html %}
 
 <!-- Featured Section -->
@@ -18,7 +35,7 @@ layout: default
 {% endif %}
 
 <!-- Jumbotron section -->
-<section class="jumbotron locations-jumbotron flush-bottom width-100" style="background-image: url('{{ page.bg_image.url | imgix: site.imgix }}?{{ site.imgix_params.placeholder }}')"
+<section class="jumbotron locations-jumbotron flush-bottom width-100" id="has-resi-player" style="background-image: url('{{ page.bg_image.url | imgix: site.imgix }}?{{ site.imgix_params.placeholder }}')"
   data-optimize-bg-img>
   <div class="bg-overlay"></div>
   <div class="container">
@@ -29,7 +46,7 @@ layout: default
           <span class="font-family-base text-uppercase text-white">
             <strong>welcome to</strong>
           </span>
-          <h1 class="flush-ends font-family-condensed-extra text-uppercase soft-half-top">Crossroads <br />{{ page.name }}</h1>
+          <h1 class="flush-ends font-family-condensed-extra text-uppercase soft-half-top">Crossroads <br />{{ page.name }} ESTABLISHED</h1>
         </div>
       </div>
     </div>

--- a/_layouts/established.html
+++ b/_layouts/established.html
@@ -8,23 +8,6 @@ layout: default
 {% assign sorted_messages = site.messages | sort: 'published_at' %}
 {% assign current_message = sorted_messages | last %}
 
-<!-- Resi Player -->
-{% if site.data.livestreams %}
-  {% assign show_resi_player = false %}
-  {% for livestream in site.data.livestreams %}
-    {% if livestream.pages contains page.name %}
-      {% assign show_resi_player = true %}
-      {% assign url = livestream.url %}
-    {% elsif livestream.pages contains 'Churchwide (all location pages)' %}
-      {% assign show_resi_player = true %}
-      {% assign url = livestream.url %}
-    {% endif %}
-  {% endfor %}
-  {% if show_resi_player %}
-    {% include _resi-player.html url=url %}
-  {% endif %}
-{% endif %}
-
 {% include locations/_welcome-modal.html %}
 
 <!-- Featured Section -->
@@ -33,6 +16,9 @@ layout: default
   {{ page.featured_section }}
 </div>
 {% endif %}
+
+<!-- Livestream player-->
+{% include _livestream.html %}
 
 <!-- Jumbotron section -->
 <section class="jumbotron locations-jumbotron flush-bottom width-100" id="has-resi-player" style="background-image: url('{{ page.bg_image.url | imgix: site.imgix }}?{{ site.imgix_params.placeholder }}')"
@@ -46,7 +32,7 @@ layout: default
           <span class="font-family-base text-uppercase text-white">
             <strong>welcome to</strong>
           </span>
-          <h1 class="flush-ends font-family-condensed-extra text-uppercase soft-half-top">Crossroads <br />{{ page.name }} ESTABLISHED</h1>
+          <h1 class="flush-ends font-family-condensed-extra text-uppercase soft-half-top">Crossroads <br />{{ page.name }}</h1>
         </div>
       </div>
     </div>

--- a/_layouts/frontier.html
+++ b/_layouts/frontier.html
@@ -5,29 +5,15 @@ layout: default
 <!-- Pull only the promos that exist for the specific location if any -->
 {% assign location_happenings = site.promos | where: "target_audience", page.name | sort: "published_at" | reverse %}
 
-<!-- Resi Player -->
-{% if site.data.livestreams %}
-  {% assign show_resi_player = false %}
-  {% for livestream in site.data.livestreams %}
-    {% if livestream.pages contains page.name %}
-      {% assign show_resi_player = true %}
-      {% assign url = livestream.url %}
-    {% elsif livestream.pages contains 'Churchwide (all location pages)' %}
-      {% assign show_resi_player = true %}
-      {% assign url = livestream.url %}
-    {% endif %}
-  {% endfor %}
-  {% if show_resi_player %}
-    {% include _resi-player.html url=url %}
-  {% endif %}
-{% endif %}
-
 <!-- Featured Section -->
 {% if page.featured_section.size > 0 %}
   <div class="overflow-hidden">
     {{ page.featured_section }}
   </div>
 {% endif %}
+
+<!-- Livestream player-->
+{% include _livestream.html %}
 
 {% include locations/_welcome-modal.html %}
 `
@@ -47,7 +33,7 @@ layout: default
           <span class="font-family-base text-uppercase text-white">
             <strong>welcome to</strong>
           </span>
-          <h1 class="flush-ends font-family-condensed-extra text-uppercase soft-half-top">Crossroads <br />{{ page.name }} FRONTIER</h1>
+          <h1 class="flush-ends font-family-condensed-extra text-uppercase soft-half-top">Crossroads <br />{{ page.name }}</h1>
         </div>
         <div>
           <p class="font-family-serif font-size-h6 text-white push-top">A place to know God, make friends, and explore the adventure of faith together.</p>

--- a/_layouts/frontier.html
+++ b/_layouts/frontier.html
@@ -5,6 +5,23 @@ layout: default
 <!-- Pull only the promos that exist for the specific location if any -->
 {% assign location_happenings = site.promos | where: "target_audience", page.name | sort: "published_at" | reverse %}
 
+<!-- Resi Player -->
+{% if site.data.livestreams %}
+  {% assign show_resi_player = false %}
+  {% for livestream in site.data.livestreams %}
+    {% if livestream.pages contains page.name %}
+      {% assign show_resi_player = true %}
+      {% assign url = livestream.url %}
+    {% elsif livestream.pages contains 'Churchwide (all location pages)' %}
+      {% assign show_resi_player = true %}
+      {% assign url = livestream.url %}
+    {% endif %}
+  {% endfor %}
+  {% if show_resi_player %}
+    {% include _resi-player.html url=url %}
+  {% endif %}
+{% endif %}
+
 <!-- Featured Section -->
 {% if page.featured_section.size > 0 %}
   <div class="overflow-hidden">
@@ -13,13 +30,13 @@ layout: default
 {% endif %}
 
 {% include locations/_welcome-modal.html %}
-
+`
 {% assign sorted_messages = site.messages | sort: 'published_at' %}
 {% assign current_message = sorted_messages | last %}
 
 <!-- Jumbotron section -->
 {% if page.site_id != 23 %}
-<section class="jumbotron locations-jumbotron flush-bottom width-100" style="background-image: url('{{ page.bg_image.url | imgix: site.imgix }}?{{ site.imgix_params.placeholder }}')"
+<section class="jumbotron locations-jumbotron flush-bottom width-100" id="has-resi-player" style="background-image: url('{{ page.bg_image.url | imgix: site.imgix }}?{{ site.imgix_params.placeholder }}')"
   data-optimize-bg-img>
   <div class="bg-overlay"></div>
   <div class="container">
@@ -30,7 +47,7 @@ layout: default
           <span class="font-family-base text-uppercase text-white">
             <strong>welcome to</strong>
           </span>
-          <h1 class="flush-ends font-family-condensed-extra text-uppercase soft-half-top">Crossroads <br />{{ page.name }}</h1>
+          <h1 class="flush-ends font-family-condensed-extra text-uppercase soft-half-top">Crossroads <br />{{ page.name }} FRONTIER</h1>
         </div>
         <div>
           <p class="font-family-serif font-size-h6 text-white push-top">A place to know God, make friends, and explore the adventure of faith together.</p>

--- a/_plugins/hooks/livestreams.rb
+++ b/_plugins/hooks/livestreams.rb
@@ -1,0 +1,19 @@
+Jekyll::Hooks.register :site, :pre_render do |site|
+  require 'open-uri'
+  require 'json'
+
+  data_endpoint = "https://#{ENV['CRDS_DATA_ENDPOINT'] || 'crds-data.crossroads.net'}"
+  livestream_url = "#{data_endpoint}/livestreams/#{ENV['CRDS_ENV']}.json"
+
+  begin
+    response = Net::HTTP.get(URI(livestream_url))
+    data = JSON.parse(response)
+
+    site.data['livestreams'] = data['livestreams']
+
+    Jekyll.logger.info "Livestreams data: #{site.data['livestreams']}"
+  rescue => e
+    Jekyll.logger.warn "Error fetching livestreams data: #{e.message}"
+    site.data['livestreams'] = {}
+  end
+end

--- a/_plugins/hooks/livestreams.rb
+++ b/_plugins/hooks/livestreams.rb
@@ -10,8 +10,6 @@ Jekyll::Hooks.register :site, :pre_render do |site|
     data = JSON.parse(response)
 
     site.data['livestreams'] = data['livestreams']
-
-    Jekyll.logger.info "Livestreams data: #{site.data['livestreams']}"
   rescue => e
     Jekyll.logger.warn "Error fetching livestreams data: #{e.message}"
     site.data['livestreams'] = {}


### PR DESCRIPTION
## Problem
The goal is to use the Livestream model in Contentful to manage livestream events

## Solution
- Fetch livestream JSON from `crds-data` and append to `site.data`
- Add a script that determines whether a livestream should show
- Include the script on all location pages

### Corresponding Branch
https://github.com/crdschurch/crds-unified/pull/1129

## Testing
- Create or modify a livestream entry in Contentful
- Based on the datetime and page selections, the livestream should only show during those times/on those location pages

https://deploy-preview-3208--demo-crds-net.netlify.app/