### PR TITLE
Remove ` from Frontier templates

### DIFF
--- a/_layouts/frontier.html
+++ b/_layouts/frontier.html
@@ -16,7 +16,7 @@ layout: default
 {% include _livestream.html %}
 
 {% include locations/_welcome-modal.html %}
-`
+
 {% assign sorted_messages = site.messages | sort: 'published_at' %}
 {% assign current_message = sorted_messages | last %}
 


### PR DESCRIPTION
## Problem
A backtick was erroneously added to Frontier page templates

## Solution
Remove the backtick

### Corresponding Branch
*Add link to crdschurch/repo-name-here#issue-number (if applicable). This helps the code reviewer know that corresponding work exists and where to find it.*

## Testing
*Include information on how to test your work here (if applicable).*