### PR TITLE
Realencounters updates

### DIFF
--- a/_layouts/collection.html
+++ b/_layouts/collection.html
@@ -80,7 +80,7 @@ layout: default
   <div style="background-color: black;">
     <div class="container" style="padding-bottom: 50px;">
       <div class="row" style="margin-top: 100px; margin-bottom: 60px;">
-        <div class="col-md-7 text-left">
+        <div class="col-md-12 text-center">
           <p class="font-size-large text-white font-family-serif">{{ page.description }}</p>
           {% if page.trailer_video %}
           <div class="push-top">
@@ -91,19 +91,6 @@ layout: default
           {% endif %}
         </div>
 
-        <div class="col-md-4 col-md-offset-1">
-          <img
-            src="//crds-media.imgix.net/1CWBN5OH9MyJk3S7omxLog/007f388fb249284c11af0bb4937a2c13/Screenshot_2023-11-01_at_4.59.32_PM.png?auto=compress,format" />
-          {% if page.trailer_video %}
-          <div class="push-top push-bottom">
-            <strong class="text-white">Real Encounters Prayer</strong>
-            <p class="text-white">The Prayer Experience is now running at Crossroads Oakley for a limited time.</p>
-          </div>
-          <div>
-            <a class="trailer-button" href="/prayerexperience">Find out more</a>
-          </div>
-          {% endif %}
-        </div>
       </div>
       <div class="jumbotron" style="padding-top: 0; padding-bottom: 0;">
         <div class="bg-orange text-black soft-top soft-bottom push-top" style="margin-top: 20px;"><span


### PR DESCRIPTION
## Problem
Crossroads would like content block to the right of the text block removed from the real encounters page.

## Solution
Remove the content block, widen the column's the text consumes, and center the text.

## Testing
- Go to the /media/collections/realencounters page and verify that the text blocks appears in accordance with the clients request.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1206200107653384