### PR TITLE
Remove health check plugin from `netlify.toml`.

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -17,9 +17,6 @@ package = "@netlify/plugin-sitemap"
     '**/tags/**'
   ]
 
-[[plugins]]
-package = "./_plugins/netlify-plugin-health-check"
-
 [dev]
   BASEURL="/"
   CRDS_COMPONENTS_ENDPOINT="components-demo.crossroads.net"


### PR DESCRIPTION
## Problem
Netlify is forcing all plugins to run on Node 20.

## Solution
They notified us that one of our plugins will be effected,

### Corresponding Branch
*Add link to crdschurch/repo-name-here#issue-number (if applicable). This helps the code reviewer know that corresponding work exists and where to find it.*

## Testing
*Include information on how to test your work here (if applicable).*

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1206408373230426