### PR TITLE
Adjust bash script to exclude our-memories.html file when processing …

### DIFF
--- a/bin/update-image-urls.sh
+++ b/bin/update-image-urls.sh
@@ -3,13 +3,15 @@
 replace_image_urls() {
   local file="$1"
 
-  if [[ "$file" =~ \.html$ ]]; then
-    if [[ "$OSTYPE" == "darwin"* ]]; then
-      sed -E -i '' -e 's#(https?:)?//images\.ctfassets\.net/[^/]+/([^/]+)/([^/]+)/([^/#?]+(\.png|\.PNG|\.jpe?g|\.JPE?G))#https://crds-media.imgix.net/\2/\3/\4#g' "$file"
-      sed -E -i '' -e 's#(https?://crds-media\.imgix\.net/[^"]+)#\1?auto=compress#g' "$file"
-    else
-      sed -E -i -e 's#(https?:)?//images\.ctfassets\.net/[^/]+/([^/]+)/([^/]+)/([^/#?]+(\.png|\.PNG|\.jpe?g|\.JPE?G))#https://crds-media.imgix.net/\2/\3/\4#g' "$file"
-      sed -E -i -e 's#(https?://crds-media\.imgix\.net/[^"]+)#\1?auto=compress#g' "$file"
+  if [[ "$file" != _site/our-memories/index.html ]]; then
+    if [[ "$file" =~ \.html$ ]]; then
+      if [[ "$OSTYPE" == "darwin"* ]]; then
+        sed -E -i '' -e 's#(https?:)?//images\.ctfassets\.net/[^/]+/([^/]+)/([^/]+)/([^/#?]+(\.png|\.PNG|\.jpe?g|\.JPE?G))#https://crds-media.imgix.net/\2/\3/\4#g' "$file"
+        sed -E -i '' -e 's#(https?://crds-media\.imgix\.net/[^"]+)#\1?auto=compress#g' "$file"
+      else
+        sed -E -i -e 's#(https?:)?//images\.ctfassets\.net/[^/]+/([^/]+)/([^/]+)/([^/#?]+(\.png|\.PNG|\.jpe?g|\.JPE?G))#https://crds-media.imgix.net/\2/\3/\4#g' "$file"
+        sed -E -i -e 's#(https?://crds-media\.imgix\.net/[^"]+)#\1?auto=compress#g' "$file"
+      fi
     fi
   fi
 }


### PR DESCRIPTION
…image tags

## Problem
Images on `/our-memories` are not displaying correctly.

## Solution
`?auto=compress` was getting appended to the end of image src tags that already had `?auto=format,compress` in the source url. `?auto=compress` was being appended in the `update-image-urls.sh` shell script that only runs when a `netlify build` is run, resulting in the problem manifesting in `demo` and `prod` but not locally.

In the `update-image-urls.sh` the existing logic has been wrapped in an additional if statement checking to see if the file is the `our-memories.html` file. If it is, then it gets skipped over. Otherwise, the logic proceeds as it previously did.

## Testing
Navigate to `/our-memories` and see if images are loading and displaying correctly.