### PR TITLE
Feature/audio article updates

### DIFF
--- a/_assets/stylesheets/pages/_articles.scss
+++ b/_assets/stylesheets/pages/_articles.scss
@@ -1,3 +1,20 @@
+#article-card {
+  .card-stamp {
+    position: absolute;
+    bottom: 2em;
+    right: 1em;
+    height: 1.75em;
+    width: 4.3em;
+
+    @media screen and (max-width: $screen-sm) {
+      bottom: 0
+    }
+  }
+
+  .with-episode {
+    width: 8.5em;
+  }
+}
 .article-tpl {
   @media screen and (min-width: $screen-md) {
     margin-top: 30px;
@@ -158,4 +175,8 @@
   @media screen and (min-width: $screen-md) {
     font-size: 5rem;
   }
+}
+
+.podcast-listen-now-link {
+  color: white;
 }

--- a/_assets/stylesheets/pages/_podcast.scss
+++ b/_assets/stylesheets/pages/_podcast.scss
@@ -251,3 +251,7 @@ img.btn-logo {
   width: 32px;
   height: 35px;
 }
+
+.subscribe-buttons {
+  margin-top: 2.3em;
+}

--- a/_includes/_article_index.html
+++ b/_includes/_article_index.html
@@ -1,8 +1,9 @@
 <div data-page="articles">
   <div class="row" data-page-number="{{ page.articles.page }}">
     {% for item in page.articles.docs %}
-    <div class="col-sm-6">
+    <div id="article-card" class="col-sm-6">
       {% include _overlay-card.html collection="articles" title="h3" %}
+      {% include _media-label.html source = item %}
     </div>
     {% endfor %}
   </div>

--- a/_includes/_media-label.html
+++ b/_includes/_media-label.html
@@ -1,9 +1,21 @@
+{% if include.source.podcast_episode != null %}
+<div class="card-stamp with-episode text-white">
+{% else %}
 <div class="card-stamp text-white">
+{% endif %}
   {% if include.source.collection %} {% assign content_type =
   include.source.collection | singularize %} {% else %} {% assign content_type =
   include.source.content_type | singularize %} {% endif %} {% if
   include.source.duration %} {% if content_type == 'article' %} {% assign format
   = 'short' %} {% else %} {% assign format = 'long' %} {% endif %}
+  {% if include.source.podcast_episode != null %}
+    <span class="font-size-smallest soft-quarter-right">
+      <a class="podcast-listen-now-link" href="{{include.source.podcast_slug}}">Listen Now</a>
+    </span>
+    <svg class="icon" viewBox="0 0 256 256">
+      <use xlink:href="/assets/svgs/icons.svg#media-podcast"></use>
+    </svg>
+  {% endif %}
   <span class="font-size-smallest soft-quarter-right">{{
     include.source.duration | duration: format
   }}</span>

--- a/_includes/_overlay-card.html
+++ b/_includes/_overlay-card.html
@@ -48,7 +48,6 @@
     <p class="overlay-card-category">{{ item.category.title }}</p>
     <h2 class="overlay-card-title {% if include.title == 'h2' %}font-size-h2{% endif %}">{{ item.title | truncate: 60 }}</h2>
     <p class="overlay-card-author">{{ item.author.full_name }}</p>
-    {% include _media-label.html source=item %}
   </div>
 </a>
 

--- a/_includes/_subscribe-buttons.html
+++ b/_includes/_subscribe-buttons.html
@@ -43,6 +43,19 @@
           </a>
         </li>
         {% endif %}
+        {% if include.content_type.spotify_url.size > 1 %}
+        <li>
+          <a href="{{ include.content_type.spotify_url }}"role="button" class="btn btn-cyan btn-subscribe soft-quarter-ends d-flex justify-content-between" onclick="dataLayer.push({'event': 'ContentEngaged', 'event_action': 'subscribed'})">
+            <div class="d-flex flex-column push-quarter-right align-items-start btn-text">
+              <span class="font-size-small push-quarter-bottom">Spotify</span>
+              <span class="font-size-smallest white-faded text-uppercase">Subscribe</span>
+            </div>
+            <svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 496 512">
+              <path d="M248 8C111.1 8 0 119.1 0 256s111.1 248 248 248 248-111.1 248-248S384.9 8 248 8zm100.7 364.9c-4.2 0-6.8-1.3-10.7-3.6-62.4-37.6-135-39.2-206.7-24.5-3.9 1-9 2.6-11.9 2.6-9.7 0-15.8-7.7-15.8-15.8 0-10.3 6.1-15.2 13.6-16.8 81.9-18.1 165.6-16.5 237 26.2 6.1 3.9 9.7 7.4 9.7 16.5s-7.1 15.4-15.2 15.4zm26.9-65.6c-5.2 0-8.7-2.3-12.3-4.2-62.5-37-155.7-51.9-238.6-29.4-4.8 1.3-7.4 2.6-11.9 2.6-10.7 0-19.4-8.7-19.4-19.4s5.2-17.8 15.5-20.7c27.8-7.8 56.2-13.6 97.8-13.6 64.9 0 127.6 16.1 177 45.5 8.1 4.8 11.3 11 11.3 19.7-.1 10.8-8.5 19.5-19.4 19.5zm31-76.2c-5.2 0-8.4-1.3-12.9-3.9-71.2-42.5-198.5-52.7-280.9-29.7-3.6 1-8.1 2.6-12.9 2.6-13.2 0-23.3-10.3-23.3-23.6 0-13.6 8.4-21.3 17.4-23.9 35.2-10.3 74.6-15.2 117.5-15.2 73 0 149.5 15.2 205.4 47.8 7.8 4.5 12.9 10.7 12.9 22.6 0 13.6-11 23.3-23.2 23.3z"/>
+            </svg>
+          </a>
+        </li>
+        {% endif %}
         {% if include.content_type.google_play_url.size > 1 %}
         <li>
           <a href="{{ include.content_type.google_play_url }}" role="button" class="btn btn-cyan btn-subscribe soft-quarter-ends d-flex justify-content-between" onclick="dataLayer.push({'event': 'ContentEngaged', 'event_action': 'subscribed'})">
@@ -102,7 +115,6 @@
         </li>
         {% endif %}
       </ul>
-
   {% if include.row != false %}
     </div>
   </div>

--- a/_layouts/article.html
+++ b/_layouts/article.html
@@ -24,6 +24,14 @@ title: Articles
             <h1 data-media-title="{{page.title}}" data-media-id="{{page.id}}" class="overlay-card-title overlay-card-heading">{{ page.title | truncate: 70 }}</h1>
             <p class="overlay-card-author text-gray-light">{{ page.author.full_name }}</p>
             <div class="card-stamp text-white">
+              {% if page.podcast_episode != null %}
+                <span class="font-size-smallest soft-quarter-right">
+                  <a class="podcast-listen-now-link" href="{{page.podcast_slug}}">Listen Now</a>
+                </span>
+                <svg class="icon" viewBox="0 0 256 256">
+                  <use xlink:href="/assets/svgs/icons.svg#media-podcast"></use>
+                </svg>
+              {% endif %}
               {% if page.duration %}
                 {% assign format = 'short' %}
               {% endif %}

--- a/_layouts/episode.html
+++ b/_layouts/episode.html
@@ -34,15 +34,16 @@ layout: default
       <div class="col-sm-8 col-sm-offset-2">
         <div class="embedded-audio-player">
           {{ page.audio_embed_code }}
+          <div class="subscribe-buttons">
+            {% include _subscribe-buttons.html content_type=podcast row=false %}
+          </div>
+          <h2 class="component-header mobile-push-half-top">This episode</h2>
+
+          {% assign tabs = 'description show_notes' | split: ' ' %}
+          {% if page.show_notes or page.description %}
+            {% include _tabs.html tabs=tabs %}
+          {% endif %}
         </div>
-
-        <h2 class="component-header mobile-push-half-top">This episode</h2>
-
-        {% assign tabs = 'description show_notes' | split: ' ' %}
-        {% if page.show_notes or page.description %}
-          {% include _tabs.html tabs=tabs %}
-        {% endif %}
-
       </div>
     </div>
 
@@ -71,8 +72,6 @@ layout: default
         {% include _tags_list.html tags=page.tags %}
       </div>
     </div>
-
-    {% include _subscribe-buttons.html content_type=podcast %}
 
     {% if site.podcasts.size > 1 %}
       <div class="row push-top soft-half-top">

--- a/_layouts/podcast.html
+++ b/_layouts/podcast.html
@@ -42,26 +42,48 @@ title: Podcast
             <hr class="hero">
             <p class="subtitle white-faded">{{ page.subtitle }}</p>
 
-            {% if page.apple_podcasts_url.size > 1 %}
-            <p class="push-top">
-              <div class="hard-sides">
-                <a href="{{ page.apple_podcasts_url }}" role="button" class="btn btn-white btn-subscribe soft-quarter-ends d-flex justify-content-between" onclick="dataLayer.push({'event': 'ContentEngaged', 'event_action': 'subscribed'})">
-                  <div class="d-flex flex-column push-quarter-right align-items-start btn-text">
-                    <span class="text-blue font-size-small push-quarter-bottom">Apple Podcasts</span>
-                    <span class="text-blue font-size-smallest text-uppercase">Subscribe</span>
-                  </div>
-                  <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="32" height="32" viewBox="0 0 32 34">
-                    <defs>
-                      <path id="a" d="M0 0h32v32H0z"/>
-                    </defs>
-                    <g fill="none" fill-rule="evenodd" transform="translate(-3 -2)">
-                      <path fill="#253746" fill-rule="nonzero" d="M18.984 29.673C18.69 30.749 17.58 31 16.5 31s-2.19-.25-2.484-1.327c-.438-1.61-1.177-5.646-1.177-7.523 0-1.991 1.781-2.478 3.661-2.478 1.88 0 3.661.487 3.661 2.478 0 1.866-.736 5.9-1.177 7.523zm-8.89-14.532c0-3.466 2.8-6.28 6.285-6.343 3.544-.065 6.523 2.824 6.528 6.334a6.262 6.262 0 0 1-1.606 4.21.337.337 0 0 0-.028.42c.303.427.514.916.626 1.455a.345.345 0 0 0 .572.182 8.545 8.545 0 0 0 2.724-6.295c-.02-4.765-3.998-8.634-8.81-8.572-4.75.061-8.58 3.892-8.58 8.609a8.545 8.545 0 0 0 2.724 6.257c.196.184.518.08.573-.181a3.84 3.84 0 0 1 .625-1.455.337.337 0 0 0-.027-.42 6.261 6.261 0 0 1-1.607-4.201zM16.528 2C9.087 1.985 3.069 7.873 3 15.241c-.052 5.556 3.32 10.338 8.154 12.404a.342.342 0 0 0 .472-.374 55.317 55.317 0 0 1-.315-1.9.34.34 0 0 0-.177-.25c-3.41-1.845-5.847-5.458-5.847-9.754 0-6.135 5.015-11.101 11.212-11.101 6.196 0 11.212 4.965 11.212 11.101 0 4.227-2.376 7.876-5.847 9.753a.34.34 0 0 0-.177.25c-.094.635-.2 1.27-.315 1.9a.342.342 0 0 0 .472.375C26.642 25.595 30 20.87 30 15.367 30 7.994 23.971 2.015 16.529 2zm-.029 9.062c-2.022 0-3.661 1.623-3.661 3.625 0 2.003 1.64 3.625 3.661 3.625 2.022 0 3.661-1.622 3.661-3.625 0-2.002-1.64-3.625-3.661-3.625z" mask="url(#b)"/>
-                    </g>
-                  </svg>
-                </a>
-              </div>
-            </p>
-            {% endif %}
+            <div class="row">
+              {% if page.apple_podcasts_url.size > 1 %}
+              <p class="push-top">
+                <div class="hard-sides col-md-4">
+                  <a href="{{ page.apple_podcasts_url }}" role="button" class="btn btn-white btn-subscribe soft-quarter-ends d-flex justify-content-between" onclick="dataLayer.push({'event': 'ContentEngaged', 'event_action': 'subscribed'})">
+                    <div class="d-flex flex-column push-quarter-right align-items-start btn-text">
+                      <span class="text-blue font-size-small push-quarter-bottom">Apple Podcasts</span>
+                      <span class="text-blue font-size-smallest text-uppercase">Subscribe</span>
+                    </div>
+                    <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="32" height="32" viewBox="0 0 32 34">
+                      <defs>
+                        <path id="a" d="M0 0h32v32H0z"/>
+                      </defs>
+                      <g fill="none" fill-rule="evenodd" transform="translate(-3 -2)">
+                        <path fill="#253746" fill-rule="nonzero" d="M18.984 29.673C18.69 30.749 17.58 31 16.5 31s-2.19-.25-2.484-1.327c-.438-1.61-1.177-5.646-1.177-7.523 0-1.991 1.781-2.478 3.661-2.478 1.88 0 3.661.487 3.661 2.478 0 1.866-.736 5.9-1.177 7.523zm-8.89-14.532c0-3.466 2.8-6.28 6.285-6.343 3.544-.065 6.523 2.824 6.528 6.334a6.262 6.262 0 0 1-1.606 4.21.337.337 0 0 0-.028.42c.303.427.514.916.626 1.455a.345.345 0 0 0 .572.182 8.545 8.545 0 0 0 2.724-6.295c-.02-4.765-3.998-8.634-8.81-8.572-4.75.061-8.58 3.892-8.58 8.609a8.545 8.545 0 0 0 2.724 6.257c.196.184.518.08.573-.181a3.84 3.84 0 0 1 .625-1.455.337.337 0 0 0-.027-.42 6.261 6.261 0 0 1-1.607-4.201zM16.528 2C9.087 1.985 3.069 7.873 3 15.241c-.052 5.556 3.32 10.338 8.154 12.404a.342.342 0 0 0 .472-.374 55.317 55.317 0 0 1-.315-1.9.34.34 0 0 0-.177-.25c-3.41-1.845-5.847-5.458-5.847-9.754 0-6.135 5.015-11.101 11.212-11.101 6.196 0 11.212 4.965 11.212 11.101 0 4.227-2.376 7.876-5.847 9.753a.34.34 0 0 0-.177.25c-.094.635-.2 1.27-.315 1.9a.342.342 0 0 0 .472.375C26.642 25.595 30 20.87 30 15.367 30 7.994 23.971 2.015 16.529 2zm-.029 9.062c-2.022 0-3.661 1.623-3.661 3.625 0 2.003 1.64 3.625 3.661 3.625 2.022 0 3.661-1.622 3.661-3.625 0-2.002-1.64-3.625-3.661-3.625z" mask="url(#b)"/>
+                      </g>
+                    </svg>
+                  </a>
+                </div>
+              </p>
+              {% endif %}
+              {% if page.spotify_url.size > 1 %}
+              <p class="push-top">
+                <div class="hard-sides col-md-4">
+                  <a href="{{ page.apple_podcasts_url }}" role="button" class="btn btn-white btn-subscribe soft-quarter-ends d-flex justify-content-between" onclick="dataLayer.push({'event': 'ContentEngaged', 'event_action': 'subscribed'})">
+                    <div class="d-flex flex-column push-quarter-right align-items-start btn-text">
+                      <span class="text-blue font-size-small push-quarter-bottom">Spotify</span>
+                      <span class="text-blue font-size-smallest text-uppercase">Subscribe</span>
+                    </div>
+                    <svg xmlns="http://www.w3.org/2000/svg" xmlnd:xlink="http://www.w3.org/1999/xlink" width="32" height="32" viewBox="0 0 496 512">
+                      <defs>
+                        <path id="a" d="M0 0h32v32H0z"/>
+                      </defs>
+                      <g fill="none" fill-rule="evenodd" transform="translate(-3 -2)">
+                        <path fill="#253746" fill-rule="nonzero" d="M248 8C111.1 8 0 119.1 0 256s111.1 248 248 248 248-111.1 248-248S384.9 8 248 8zm100.7 364.9c-4.2 0-6.8-1.3-10.7-3.6-62.4-37.6-135-39.2-206.7-24.5-3.9 1-9 2.6-11.9 2.6-9.7 0-15.8-7.7-15.8-15.8 0-10.3 6.1-15.2 13.6-16.8 81.9-18.1 165.6-16.5 237 26.2 6.1 3.9 9.7 7.4 9.7 16.5s-7.1 15.4-15.2 15.4zm26.9-65.6c-5.2 0-8.7-2.3-12.3-4.2-62.5-37-155.7-51.9-238.6-29.4-4.8 1.3-7.4 2.6-11.9 2.6-10.7 0-19.4-8.7-19.4-19.4s5.2-17.8 15.5-20.7c27.8-7.8 56.2-13.6 97.8-13.6 64.9 0 127.6 16.1 177 45.5 8.1 4.8 11.3 11 11.3 19.7-.1 10.8-8.5 19.5-19.4 19.5zm31-76.2c-5.2 0-8.4-1.3-12.9-3.9-71.2-42.5-198.5-52.7-280.9-29.7-3.6 1-8.1 2.6-12.9 2.6-13.2 0-23.3-10.3-23.3-23.6 0-13.6 8.4-21.3 17.4-23.9 35.2-10.3 74.6-15.2 117.5-15.2 73 0 149.5 15.2 205.4 47.8 7.8 4.5 12.9 10.7 12.9 22.6 0 13.6-11 23.3-23.2 23.3z"/>
+                      </g>
+                    </svg>
+                  </a>
+                </div>
+              </p>
+              {% endif %}
+            </div>
           </div>
         </div>
       </div>

--- a/_plugins/generators/audio_article_links_generator.rb
+++ b/_plugins/generators/audio_article_links_generator.rb
@@ -1,0 +1,22 @@
+module Jekyll
+  class AudioArticleLinksGenerator < Jekyll::Generator
+    def generate(site)
+      episodes = site.collections['episodes'].docs
+      episode_id_slug_hashes = episodes.map{ |episode| { id: episode["id"], slug: episode["slug"] }}
+      articles = site.collections['articles'].docs
+      articles.each do | article |
+        if article["podcast_episode"] != nil
+          episode_data = episode_id_slug_hashes.select{ |item| item[:id] == article["podcast_episode"]["id"] }.first
+          slug = episode_data[:slug]
+          if slug.present?
+            audio_article_url = "https://www.crossroads.net/media/podcasts/audio-articles"
+            if ENV["JEKYLL_ENV"] == "demo" || ENV["JEKYLL_ENV"] == "int"
+              audio_article_url = "https://demo.crossroads.net/media/podcasts/audio-articles"
+            end
+            article.data['podcast_slug'] = "#{audio_article_url}/#{slug}"
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Feature
A request was made to link articles that have been recorded to the Audio Articles podcast to the episode in that podcast. 

## Solution
In Contentful, the Article content model has been updated to have a link to a podcast episode, allowing content admins to connect the article to the podcast episode. When an article has a podcast episode associated with it, a "Listen Now" link appears on the article card at `/media/articles` and also on the banner image of the individual article view.

### Corresponding Branch
There is no corresponding branch, but the work done in the demo environment of Contentful will need to be replicated into the master environment of Contentful.

## Testing
Associate a podcast episode to an article, navigate to `/media/articles` and confirm that the article you edited has the link "Listen Now" on it. Click on the article card and confirm that the article's banner image also has the link "Listen Now" on it. Confirm that both links navigate to the associated podcast episode.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1206445409795399