### PR TITLE
Remove hubspot form from the article page.

### DIFF
--- a/_layouts/article.html
+++ b/_layouts/article.html
@@ -57,8 +57,6 @@ title: Articles
         </div>
         {% endif %}
 
-        <iframe src="https://share.hsforms.com/1-ca6OFYhR3uThec74KwCkQ2dls1" width="100%" height="650px" style="padding-top: 20px;" frameborder="0" scrolling="no"></iframe>
-
         <!-- Author Section -->
         <div class="article-tpl-content article-tpl-author-section row row-no-gutters soft-ends">
           <div>


### PR DESCRIPTION
## Problem
The hubspot form on article pages is no longer needed.

## Solution
Remove link in article.html file that displays that hubspot form

### Corresponding Branch
No corresponding branches

## Testing
Randomly select 4 articles on the article index page and confirm that none of them have the hubspot form on the page anymore.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1206612801710180