### PR TITLE
Feature Spanish Video Player

### DIFF
--- a/_assets/stylesheets/pages/_message.scss
+++ b/_assets/stylesheets/pages/_message.scss
@@ -1,0 +1,5 @@
+.video-language-controls {
+  display: flex;
+  justify-content: flex-end;
+  margin-left: auto;
+}

--- a/_assets/stylesheets/pages/_modules.scss
+++ b/_assets/stylesheets/pages/_modules.scss
@@ -40,3 +40,4 @@
 @import "bitmovin-player";
 @import "all-trips";
 @import "homepage";
+@import "message";

--- a/_layouts/message.html
+++ b/_layouts/message.html
@@ -41,6 +41,24 @@ layout: default
               </div>
             </div>
           {% endif %}
+          <div class="video-language-controls">
+            <div onclick="switchVideoSource()" id="video-language-switch" class="btn btn-white btn-outline">Ver en Español</div>
+          </div>
+          <script>
+            function switchVideoSource() {
+              var currentText = document.getElementById("video-language-switch").innerText
+              var reloadVideoPlayer = new Event('reload-bitmovin-video');
+              if (currentText == "Ver en Español") {
+                document.getElementById("video-language-switch").innerText = "Watch in English";
+                document.getElementsByTagName("crds-bitmovin-player")[0].setAttribute("url", '{{page.source_url_spanish}}');
+              } else {
+                document.getElementById("video-language-switch").innerText = "Ver en Español";
+                document.getElementsByTagName("crds-bitmovin-player")[0].setAttribute("url", '{{page.source_url}}');
+              }
+
+              document.dispatchEvent(reloadVideoPlayer);
+            }
+          </script>
 
           <header>
             {% if page.audio_file.url or page.video_file.url or page.program.url or page.audio_source_url %}
@@ -84,7 +102,6 @@ layout: default
                 {% endfor %}
               </ol>
               <!-- End breadcrumbs -->
-
               <h1 data-media-title="{{ page.title }}" data-media-id="{{ page.id }}" class="font-family-condensed-extra text-uppercase flush-top push-bottom text-white">{{ page.title }}</h1>
             </div>
           </header>

--- a/index.html
+++ b/index.html
@@ -65,7 +65,7 @@ paginate:
   {% assign online = series.videos | sort: 'published_at' | last | get_doc %}
   {% assign online_title = online.title | split: "|" %}
   {% assign split_title = online.title | split: " " %}
-  {% assign current_week = split_title | slice: -1 %} 
+  {% assign current_week = split_title | slice: -1 %}
 {% endif %}
 
 {% if series.live_messages and series.live_messages.size != 0 %}

--- a/index.html
+++ b/index.html
@@ -65,7 +65,7 @@ paginate:
   {% assign online = series.videos | sort: 'published_at' | last | get_doc %}
   {% assign online_title = online.title | split: "|" %}
   {% assign split_title = online.title | split: " " %}
-  {% assign current_week = split_title | slice: -1 %}
+  {% assign current_week = split_title | slice: -1 %} 
 {% endif %}
 
 {% if series.live_messages and series.live_messages.size != 0 %}


### PR DESCRIPTION
## Problem
Message videos don't currently allow for Spanish video source.

## Solution
On a message detail page, if there is a source_url_spanish provided in Contentful, the video jumbotron will now show a button to "Ver en Español".

### Corresponding Branch
https://github.com/crdschurch/crds-components/pull/2085
https://github.com/crdschurch/crds-unified/pull/1382

## Testing
Go to a message in contentful, provide a value in the Source Url Spanish field, navigate to that message, and confirm that the page shows the button, and that the button switches the video source.