### PR TITLE
Fix for Extraneous Events in Segment

### DIFF
--- a/_includes/_subscribe-buttons.html
+++ b/_includes/_subscribe-buttons.html
@@ -11,7 +11,7 @@
 
         {% if include.youtube %}
         <li>
-          <a href="//www.youtube.com/user/crdschurch" role="button" class="btn btn-cyan btn-subscribe soft-quarter-ends d-flex justify-content-between" onclick="dataLayer.push({'event': 'ContentEngaged', 'event_action': 'subscribed'})">
+          <a href="//www.youtube.com/user/crdschurch" role="button" class="btn btn-cyan btn-subscribe soft-quarter-ends d-flex justify-content-between">
             <div class="d-flex flex-column push-quarter-right align-items-start btn-text">
               <span class="font-size-small push-quarter-bottom">YouTube</span>
               <span class="font-size-smallest white-faded text-uppercase">Subscribe</span>
@@ -24,7 +24,7 @@
         {% endif %}
         {% if include.content_type.apple_podcasts_url.size > 1 %}
         <li>
-          <a href="{{ include.content_type.apple_podcasts_url }}"role="button" class="btn btn-cyan btn-subscribe soft-quarter-ends d-flex justify-content-between" onclick="dataLayer.push({'event': 'ContentEngaged', 'event_action': 'subscribed'})">
+          <a href="{{ include.content_type.apple_podcasts_url }}"role="button" class="btn btn-cyan btn-subscribe soft-quarter-ends d-flex justify-content-between">
             <div class="d-flex flex-column push-quarter-right align-items-start btn-text">
               <span class="font-size-small push-quarter-bottom">Apple Podcasts</span>
               <span class="font-size-smallest white-faded text-uppercase">Subscribe</span>
@@ -45,7 +45,7 @@
         {% endif %}
         {% if include.content_type.spotify_url.size > 1 %}
         <li>
-          <a href="{{ include.content_type.spotify_url }}"role="button" class="btn btn-cyan btn-subscribe soft-quarter-ends d-flex justify-content-between" onclick="dataLayer.push({'event': 'ContentEngaged', 'event_action': 'subscribed'})">
+          <a href="{{ include.content_type.spotify_url }}"role="button" class="btn btn-cyan btn-subscribe soft-quarter-ends d-flex justify-content-between">
             <div class="d-flex flex-column push-quarter-right align-items-start btn-text">
               <span class="font-size-small push-quarter-bottom">Spotify</span>
               <span class="font-size-smallest white-faded text-uppercase">Subscribe</span>
@@ -58,7 +58,7 @@
         {% endif %}
         {% if include.content_type.google_play_url.size > 1 %}
         <li>
-          <a href="{{ include.content_type.google_play_url }}" role="button" class="btn btn-cyan btn-subscribe soft-quarter-ends d-flex justify-content-between" onclick="dataLayer.push({'event': 'ContentEngaged', 'event_action': 'subscribed'})">
+          <a href="{{ include.content_type.google_play_url }}" role="button" class="btn btn-cyan btn-subscribe soft-quarter-ends d-flex justify-content-between">
             <div class="d-flex flex-column push-quarter-right align-items-start  btn-text">
               <span class="font-size-small push-quarter-bottom">Google Play</span>
               <span class="font-size-smallest white-faded text-uppercase">Subscribe</span>
@@ -73,7 +73,7 @@
         {% endif %}
         {% if include.content_type.stitcher_url.size > 1 %}
         <li>
-          <a href="{{ include.content_type.stitcher_url }}" role="button" class="btn btn-cyan btn-subscribe soft-quarter-ends d-flex justify-content-between" onclick="dataLayer.push({'event': 'ContentEngaged', 'event_action': 'subscribed'})">
+          <a href="{{ include.content_type.stitcher_url }}" role="button" class="btn btn-cyan btn-subscribe soft-quarter-ends d-flex justify-content-between">
             <div class="d-flex flex-column push-quarter-right align-items-start btn-text">
               <span class="font-size-small push-quarter-bottom">Stitcher</span>
               <span class="font-size-smallest text-uppercase">Subscribe</span>

--- a/_layouts/podcast.html
+++ b/_layouts/podcast.html
@@ -46,7 +46,7 @@ title: Podcast
               {% if page.apple_podcasts_url.size > 1 %}
               <p class="push-top">
                 <div class="hard-sides col-md-4">
-                  <a href="{{ page.apple_podcasts_url }}" role="button" class="btn btn-white btn-subscribe soft-quarter-ends d-flex justify-content-between" onclick="dataLayer.push({'event': 'ContentEngaged', 'event_action': 'subscribed'})">
+                  <a href="{{ page.apple_podcasts_url }}" role="button" class="btn btn-white btn-subscribe soft-quarter-ends d-flex justify-content-between">
                     <div class="d-flex flex-column push-quarter-right align-items-start btn-text">
                       <span class="text-blue font-size-small push-quarter-bottom">Apple Podcasts</span>
                       <span class="text-blue font-size-smallest text-uppercase">Subscribe</span>
@@ -66,7 +66,7 @@ title: Podcast
               {% if page.spotify_url.size > 1 %}
               <p class="push-top">
                 <div class="hard-sides col-md-4">
-                  <a href="{{ page.spotify_url }}" role="button" class="btn btn-white btn-subscribe soft-quarter-ends d-flex justify-content-between" onclick="dataLayer.push({'event': 'ContentEngaged', 'event_action': 'subscribed'})">
+                  <a href="{{ page.spotify_url }}" role="button" class="btn btn-white btn-subscribe soft-quarter-ends d-flex justify-content-between">
                     <div class="d-flex flex-column push-quarter-right align-items-start btn-text">
                       <span class="text-blue font-size-small push-quarter-bottom">Spotify</span>
                       <span class="text-blue font-size-smallest text-uppercase">Subscribe</span>

--- a/_layouts/series.html
+++ b/_layouts/series.html
@@ -49,8 +49,7 @@ title: Series
             <ul class="list-inline soft-half-top">
               <li class="middle">
                 <a href="//www.youtube.com/user/crdschurch" role="button"
-                  class="btn btn-white btn-subscribe soft-quarter-ends flush d-flex justify-content-between btn-block-mobile {{ include.css }}"
-                  onclick="dataLayer.push({'event': 'ContentEngaged', 'event_action': 'subscribed'})">
+                  class="btn btn-white btn-subscribe soft-quarter-ends flush d-flex justify-content-between btn-block-mobile {{ include.css }}">
                   <div class="d-flex flex-column push-quarter-right align-items-start btn-text">
                     <span class="font-size-small text-blue push-quarter-bottom">YouTube</span>
                     <span class="font-size-smallest text-blue text-uppercase">Subscribe</span>


### PR DESCRIPTION
## Problem
Extraneous events found in Segment seem to be caused by elements having an onClick event in addition to an upstream GTM event on the same trigger. Most of these events were related to outbound links on Jekyll pages, which have an onclick `ContentEngaged` event in the code but a `LinkClicked` event in GTM. 

## Solution
Removing the `ContentEngaged` gets rid of the extraneous event in Segment. `LinkClicked` still fires as it did previously.

## Testing
These primarily came from social share buttons on media pages. Test those and confirm that you don't see any extraneous events appear in Segment. Example pages:

https://deploy-preview-3313--demo-crds-jekyll.netlify.app/media/podcasts/messages
https://deploy-preview-3313--demo-crds-jekyll.netlify.app/media/series/test-student-ministry-series3/test-future-message-josh

<img width="980" alt="Screen Shot 2024-04-01 at 12 22 34 PM" src="https://github.com/crdschurch/crds-net/assets/58494322/fd21bc65-77a1-4901-bfb4-96a95aaf4a67">

<img width="684" alt="Screen Shot 2024-04-01 at 12 22 55 PM" src="https://github.com/crdschurch/crds-net/assets/58494322/3d5d0781-906b-4e29-b6b8-e7aefe7467e9">

