### PR TITLE
update service times to use 'reference' prefix.

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -146,7 +146,7 @@ collections:
   videos:
     output: true
     permalink: /media/:collection/:title
-  serviceTimes:
+  referenceServiceTimes:
     output: false
 
 contentful:
@@ -202,7 +202,7 @@ contentful:
   video:
     map:
       date: published_at
-  serviceTimes:
+  referenceServiceTimes:
 
 defaults:
   - scope:

--- a/_includes/_columbus-top-section.html
+++ b/_includes/_columbus-top-section.html
@@ -29,27 +29,27 @@
               <p class="flush font-size-small">
                 {% assign current_date = "now" | date: "%s" %}
               
-                {% if page.service_times %}
-                  {% assign service_times_count = page.service_times | size %}
-                  {% for time in page.service_times %}
+                {% if page.reference_service_times %}
+                  {% assign reference_service_times_count = page.reference_service_times | size %}
+                  {% for time in page.reference_service_times %}
                     {% if time.is_special_service_time == true %}
                       {% assign start_date = time.special_service_start_date | date: "%s" %}
                       {% assign end_date = time.special_service_end_date | date: "%s" %}
                       {% if current_date >= start_date and current_date <= end_date %}
                         <span class="font-family-base-bold">{{ time.service_time_label }}</span><br>
-                        {% for service_time in time.service_times %}
+                        {% for service_time in time.reference_service_times %}
                           {{ service_time }}
-                          {% if forloop.index != time.service_times.size %}<br>{% endif %}
+                          {% if forloop.index != time.reference_service_times.size %}<br>{% endif %}
                         {% endfor %}
                       {% endif %}
                     {% else %}
                       <span class="font-family-base-bold">{{ time.service_time_label }}</span><br>
-                      {% for service_time in time.service_times %}
+                      {% for service_time in time.reference_service_times %}
                         {{ service_time }}
-                        {% if forloop.index != time.service_times.size %}<br>{% endif %}
+                        {% if forloop.index != time.reference_service_times.size %}<br>{% endif %}
                       {% endfor %}
                     {% endif %}
-                    {% if forloop.first and service_times_count == 2 %}
+                    {% if forloop.first and reference_service_times_count == 2 %}
                       <!-- Insert double break only after the first item if both service times are present -->
                       <br><br>
                     {% endif %}

--- a/_includes/_location-card.html
+++ b/_includes/_location-card.html
@@ -34,29 +34,29 @@
           <p class="flush font-size-small">
             {% assign current_date = "now" | date: "%s" %}
             
-            {% if location.service_times %}
-            {% assign service_times_count = location.service_times | size %}
-            {% for time in location.service_times %}
+            {% if location.reference_service_times %}
+            {% assign reference_service_times_count = location.reference_service_times | size %}
+            {% for time in location.reference_service_times %}
               {% if time.is_special_service_time == true %}
                 {% assign start_date = time.special_service_start_date | date: "%s" %}
                 {% assign end_date = time.special_service_end_date | date: "%s" %}
                 {% if current_date >= start_date and current_date <= end_date %}
                   <span class="font-family-base-bold">{{ time.service_time_label }}</span><br>
-                  {% for service_time in time.service_times %}
+                  {% for service_time in time.reference_service_times %}
                     {{ service_time }}
-                    {% if forloop.index != time.service_times.size %}<br>{% endif %}
+                    {% if forloop.index != time.reference_service_times.size %}<br>{% endif %}
                   {% endfor %}
                 {% endif %}
               {% else %}
                 {% if location.slug != 'anywhere' %}
                 <span class="font-family-base-bold">{{ time.service_time_label }}</span><br>
                 {% endif %}
-                {% for service_time in time.service_times %}
+                {% for service_time in time.reference_service_times %}
                   {{ service_time }}
-                  {% if forloop.index != time.service_times.size %}<br>{% endif %}
+                  {% if forloop.index != time.reference_service_times.size %}<br>{% endif %}
                 {% endfor %}
               {% endif %}
-              {% if forloop.first and service_times_count == 2 %}
+              {% if forloop.first and reference_service_times_count == 2 %}
                 <!-- Insert double break only after the first item if both service times are present -->
                 <br><br>
               {% endif %}

--- a/_includes/_location-info.html
+++ b/_includes/_location-info.html
@@ -5,24 +5,24 @@
       <p class="flush font-size-small">
         {% assign current_date = "now" | date: "%s" %}
       
-        {% if page.service_times %}
-          {% assign service_times_count = page.service_times | size %}
-          {% for time in page.service_times %}
+        {% if page.reference_service_times %}
+          {% assign service_times_count = page.reference_service_times | size %}
+          {% for time in page.reference_service_times %}
             {% if time.is_special_service_time == true %}
               {% assign start_date = time.special_service_start_date | date: "%s" %}
               {% assign end_date = time.special_service_end_date | date: "%s" %}
               {% if current_date >= start_date and current_date <= end_date %}
                 <span class="font-family-base-bold">{{ time.service_time_label }}</span><br>
-                {% for service_time in time.service_times %}
+                {% for service_time in time.reference_service_times %}
                   {{ service_time }}
-                  {% if forloop.index != time.service_times.size %}<br>{% endif %}
+                  {% if forloop.index != time.reference_service_times.size %}<br>{% endif %}
                 {% endfor %}
               {% endif %}
             {% else %}
               <span class="font-family-base-bold">{{ time.service_time_label }}</span><br>
-              {% for service_time in time.service_times %}
+              {% for service_time in time.reference_service_times %}
                 {{ service_time }}
-                {% if forloop.index != time.service_times.size %}<br>{% endif %}
+                {% if forloop.index != time.reference_service_times.size %}<br>{% endif %}
               {% endfor %}
             {% endif %}
             {% if forloop.first and service_times_count == 2 %}

--- a/_layouts/location.html
+++ b/_layouts/location.html
@@ -70,8 +70,8 @@ layout: default
             <p>
               <strong class="text-orange">Service Times</strong>
               <br />
-              {% if site.data.service_times.size != 0 %}
-              {% assign service_times_str = site.data.service_times[page.name] %}
+              {% if site.data.reference_service_times.size != 0 %}
+              {% assign service_times_str = site.data.reference_service_times[page.name] %}
               {% assign service_times_array = service_times_str | split: '|' %}
               {% for time in service_times_array %}
                 {% assign parts = time | split: '^' %}
@@ -82,8 +82,8 @@ layout: default
                 {% endif %}
               {% endfor %}
             {% endif %}
-            {% if page.service_times %}
-              {{ page.service_times | markdownify | remove: '<p>' | remove: '</p>' }}
+            {% if page.reference_service_times %}
+              {{ page.reference_service_times | markdownify | remove: '<p>' | remove: '</p>' }}
             {% endif %}
             <div class="col-sm-6">
               <p>

--- a/_plugins/generators/location_service_times.rb
+++ b/_plugins/generators/location_service_times.rb
@@ -3,20 +3,20 @@ module LocationServiceTimes
     def generate(site)
       locations = site.collections['locations'].docs
       locations.each do |location|
-        next if location.data['service_times'].nil? || !location.data['service_times'].is_a?(Array)
+        next if location.data['reference_service_times'].nil? || !location.data['reference_service_times'].is_a?(Array)
         
-        full_service_times = []
+        full_reference_service_times = []
         
-        location.data['service_times'].each do |service_time_entry|
+        location.data['reference_service_times'].each do |service_time_entry|
           service_time_id = service_time_entry['id']
           service_time_doc = site.collections['serviceTimes'].docs.detect do |doc|
             doc.data.dig('contentful_id') == service_time_id
           end
           
-          full_service_times << service_time_doc.data if service_time_doc
+          full_reference_service_times << service_time_doc.data if service_time_doc
         end
         
-        location.data['service_times'] = full_service_times unless full_service_times.empty?
+        location.data['reference_service_times'] = full_reference_service_times unless full_reference_service_times.empty?
         # binding.pry
       end
     end


### PR DESCRIPTION
## Problem
service time variable name got normalized and conflicted with the app service time names causing them to not show up on the locations pages. 

## Solution
Update the name to be unique from the app service time names

### Corresponding Branch
[crds-unified]()