### PR TITLE
Fix /anywhere topo bg image

### DIFF
--- a/_layouts/anywhere.html
+++ b/_layouts/anywhere.html
@@ -555,7 +555,7 @@ layout: default
 </section>
 
 <!-- Sign up  -->
-<section class="anywhere-sign-up soft-ends" style="background-image: url('https://crds-media.imgix.net/1ie6HE8PwHcxZw3qSrOw4Y/4f61fa904ff40800a4dc2a99e1f8cefe/anywhere-form-image.jpg?{{ site.imgix_params.placeholder }}')" data-optimize-bg-img>
+<section class="anywhere-sign-up soft-ends" style="background-image: url('https://crds-media.imgix.net/1ie6HE8PwHcxZw3qSrOw4Y/4f61fa904ff40800a4dc2a99e1f8cefe/anywhere-form-image.jpg')" data-optimize-bg-img>
   <div class="container soft-ends">
     <div class="row text-center">
       <div class="col-md-8 col-md-offset-2">

--- a/_layouts/anywhere.html
+++ b/_layouts/anywhere.html
@@ -555,7 +555,7 @@ layout: default
 </section>
 
 <!-- Sign up  -->
-<section class="anywhere-sign-up soft-ends" style="background-image: url('https://crds-media.imgix.net/1ie6HE8PwHcxZw3qSrOw4Y/4f61fa904ff40800a4dc2a99e1f8cefe/anywhere-form-image.jpg')" data-optimize-bg-img>
+<section class="anywhere-sign-up soft-ends" style="background-image: url('https://crds-media.imgix.net/1ie6HE8PwHcxZw3qSrOw4Y/4f61fa904ff40800a4dc2a99e1f8cefe/anywhere-form-image.jpg?{{ site.imgix_params.placeholder }}')" data-optimize-bg-img>
   <div class="container soft-ends">
     <div class="row text-center">
       <div class="col-md-8 col-md-offset-2">

--- a/bin/update-image-urls.sh
+++ b/bin/update-image-urls.sh
@@ -6,10 +6,10 @@ replace_image_urls() {
   if [[ "$file" =~ \.html$ ]]; then
     if [[ "$OSTYPE" == "darwin"* ]]; then
       sed -E -i '' -e 's#(https?:)?//images\.ctfassets\.net/[^/]+/([^/]+)/([^/]+)/([^/#?]+(\.png|\.PNG|\.jpe?g|\.JPE?G))#https://crds-media.imgix.net/\2/\3/\4#g' "$file"
-      sed -E -i '' -e 's#(https?://crds-media\.imgix\.net/[^"]+)#\1?auto=compress#g' "$file"
+      sed -E -i '' -e 's#(https?://crds-media\.imgix\.net/[^"'\''?]+)(['\'')])#\1?auto=compress\2#g' "$file"
     else
       sed -E -i -e 's#(https?:)?//images\.ctfassets\.net/[^/]+/([^/]+)/([^/]+)/([^/#?]+(\.png|\.PNG|\.jpe?g|\.JPE?G))#https://crds-media.imgix.net/\2/\3/\4#g' "$file"
-      sed -E -i -e 's#(https?://crds-media\.imgix\.net/[^"]+)#\1?auto=compress#g' "$file"
+      sed -E -i -e 's#(https?://crds-media\.imgix\.net/[^"'\''?]+)(['\'')])#\1?auto=compress\2#g' "$file"
     fi
   fi
 }


### PR DESCRIPTION
## Problem
The topo image at the bottom of the /anywhere page was not loading due to how imgix query params were being handled for background images.

## Solution
Change the `update-image-urls` script to better handle query params for background images.

### Corresponding Branch
*Add link to crdschurch/repo-name-here#issue-number (if applicable). This helps the code reviewer know that corresponding work exists and where to find it.*

## Testing
https://deploy-preview-3332--demo-crds-jekyll.netlify.app/anywhere
Make sure all existing images are loading correctly in addition to the one that was fixed.

<img width="1000" alt="Screen Shot 2024-04-25 at 10 56 23 AM" src="https://github.com/crdschurch/crds-net/assets/58494322/7c82fb68-0fd4-4bc6-b500-29427cfe415a">
