### PR TITLE
[Demo] /contactus alternative chat button functionality

### DIFF
--- a/_assets/javascripts/components/chat.js
+++ b/_assets/javascripts/components/chat.js
@@ -1,12 +1,12 @@
 $(document).ready(function() {
   $('[data-trigger=chat]').click(function(e) {
     console.log('Chat button clicked');
-    if (window.Intercom !== undefined) {
+    if (window.Intercom !== undefined || $('.intercom-launcher').length > 0) {
       console.log('Intercom is defined, attempting to show widget.');
       window.Intercom('show');
     } else {
-      console.warn('Intercom is undefined');
-      window.location.href = '/contactus/';
+      console.log('Intercom is undefined, initializing mailto.');
+      window.location.href = 'mailto:hello@crossroads.net';
     }
 
     e.preventDefault();

--- a/_layouts/anywhere.html
+++ b/_layouts/anywhere.html
@@ -555,7 +555,7 @@ layout: default
 </section>
 
 <!-- Sign up  -->
-<section class="anywhere-sign-up soft-ends" style="background-image: url('https://crds-media.imgix.net/1ie6HE8PwHcxZw3qSrOw4Y/4f61fa904ff40800a4dc2a99e1f8cefe/anywhere-form-image.jpg?{{ site.imgix_params.placeholder }}')" data-optimize-bg-img>
+<section class="anywhere-sign-up soft-ends" style="background-image: url('https://crds-media.imgix.net/1ie6HE8PwHcxZw3qSrOw4Y/4f61fa904ff40800a4dc2a99e1f8cefe/anywhere-form-image.jpg')" data-optimize-bg-img>
   <div class="container soft-ends">
     <div class="row text-center">
       <div class="col-md-8 col-md-offset-2">

--- a/bin/update-image-urls.sh
+++ b/bin/update-image-urls.sh
@@ -6,10 +6,10 @@ replace_image_urls() {
   if [[ "$file" =~ \.html$ ]]; then
     if [[ "$OSTYPE" == "darwin"* ]]; then
       sed -E -i '' -e 's#(https?:)?//images\.ctfassets\.net/[^/]+/([^/]+)/([^/]+)/([^/#?]+(\.png|\.PNG|\.jpe?g|\.JPE?G))#https://crds-media.imgix.net/\2/\3/\4#g' "$file"
-      sed -E -i '' -e 's#(https?://crds-media\.imgix\.net/[^"'\''?]+)(['\'')])#\1?auto=compress\2#g' "$file"
+      sed -E -i '' -e 's#(https?://crds-media\.imgix\.net/[^"]+)#\1?auto=compress#g' "$file"
     else
       sed -E -i -e 's#(https?:)?//images\.ctfassets\.net/[^/]+/([^/]+)/([^/]+)/([^/#?]+(\.png|\.PNG|\.jpe?g|\.JPE?G))#https://crds-media.imgix.net/\2/\3/\4#g' "$file"
-      sed -E -i -e 's#(https?://crds-media\.imgix\.net/[^"'\''?]+)(['\'')])#\1?auto=compress\2#g' "$file"
+      sed -E -i -e 's#(https?://crds-media\.imgix\.net/[^"]+)#\1?auto=compress#g' "$file"
     fi
   fi
 }

--- a/bin/update-image-urls.sh
+++ b/bin/update-image-urls.sh
@@ -6,10 +6,10 @@ replace_image_urls() {
   if [[ "$file" =~ \.html$ ]]; then
     if [[ "$OSTYPE" == "darwin"* ]]; then
       sed -E -i '' -e 's#(https?:)?//images\.ctfassets\.net/[^/]+/([^/]+)/([^/]+)/([^/#?]+(\.png|\.PNG|\.jpe?g|\.JPE?G))#https://crds-media.imgix.net/\2/\3/\4#g' "$file"
-      sed -E -i '' -e 's#(https?://crds-media\.imgix\.net/[^"]+)#\1?auto=compress#g' "$file"
+      sed -E -i '' -e 's#(https?://crds-media\.imgix\.net/[^"'\''?]+)(['\'')])#\1?auto=compress\2#g' "$file"
     else
       sed -E -i -e 's#(https?:)?//images\.ctfassets\.net/[^/]+/([^/]+)/([^/]+)/([^/#?]+(\.png|\.PNG|\.jpe?g|\.JPE?G))#https://crds-media.imgix.net/\2/\3/\4#g' "$file"
-      sed -E -i -e 's#(https?://crds-media\.imgix\.net/[^"]+)#\1?auto=compress#g' "$file"
+      sed -E -i -e 's#(https?://crds-media\.imgix\.net/[^"'\''?]+)(['\'')])#\1?auto=compress\2#g' "$file"
     fi
   fi
 }

--- a/bin/update-image-urls.sh
+++ b/bin/update-image-urls.sh
@@ -5,15 +5,11 @@ replace_image_urls() {
 
   if [[ "$file" =~ \.html$ ]]; then
     if [[ "$OSTYPE" == "darwin"* ]]; then
-      # Replace image domain and update the path format
       sed -E -i '' -e 's#(https?:)?//images\.ctfassets\.net/[^/]+/([^/]+)/([^/]+)/([^/#?]+(\.png|\.PNG|\.jpe?g|\.JPE?G))#https://crds-media.imgix.net/\2/\3/\4#g' "$file"
-      # Correctly append auto=compress based on whether the URL already has query parameters
-      sed -E -i '' -e 's#(https?://crds-media\.imgix\.net/[^"'\'']*)(\?[^"'\'' ]*)?(['\'')])#\1\2\3&auto=compress#g' -e 's#(&auto=compress)(\?[^"'\'' ]*)#?auto=compress\2#g' "$file"
+      sed -E -i '' -e 's#(https?://crds-media\.imgix\.net/[^"'\''?]+)(['\'')])#\1?auto=compress\2#g' "$file"
     else
-      # Replace image domain and update the path format
       sed -E -i -e 's#(https?:)?//images\.ctfassets\.net/[^/]+/([^/]+)/([^/]+)/([^/#?]+(\.png|\.PNG|\.jpe?g|\.JPE?G))#https://crds-media.imgix.net/\2/\3/\4#g' "$file"
-      # Correctly append auto=compress based on whether the URL already has query parameters
-      sed -E -i -e 's#(https?://crds-media\.imgix\.net/[^"'\'']*)(\?[^"'\'' ]*)?(['\'')])#\1\2\3&auto=compress#g' -e 's#(&auto=compress)(\?[^"'\'' ]*)#?auto=compress\2#g' "$file"
+      sed -E -i -e 's#(https?://crds-media\.imgix\.net/[^"'\''?]+)(['\'')])#\1?auto=compress\2#g' "$file"
     fi
   fi
 }

--- a/bin/update-image-urls.sh
+++ b/bin/update-image-urls.sh
@@ -5,11 +5,15 @@ replace_image_urls() {
 
   if [[ "$file" =~ \.html$ ]]; then
     if [[ "$OSTYPE" == "darwin"* ]]; then
+      # Replace image domain and update the path format
       sed -E -i '' -e 's#(https?:)?//images\.ctfassets\.net/[^/]+/([^/]+)/([^/]+)/([^/#?]+(\.png|\.PNG|\.jpe?g|\.JPE?G))#https://crds-media.imgix.net/\2/\3/\4#g' "$file"
-      sed -E -i '' -e 's#(https?://crds-media\.imgix\.net/[^"'\''?]+)(['\'')])#\1?auto=compress\2#g' "$file"
+      # Correctly append auto=compress based on whether the URL already has query parameters
+      sed -E -i '' -e 's#(https?://crds-media\.imgix\.net/[^"'\'']*)(\?[^"'\'' ]*)?(['\'')])#\1\2\3&auto=compress#g' -e 's#(&auto=compress)(\?[^"'\'' ]*)#?auto=compress\2#g' "$file"
     else
+      # Replace image domain and update the path format
       sed -E -i -e 's#(https?:)?//images\.ctfassets\.net/[^/]+/([^/]+)/([^/]+)/([^/#?]+(\.png|\.PNG|\.jpe?g|\.JPE?G))#https://crds-media.imgix.net/\2/\3/\4#g' "$file"
-      sed -E -i -e 's#(https?://crds-media\.imgix\.net/[^"'\''?]+)(['\'')])#\1?auto=compress\2#g' "$file"
+      # Correctly append auto=compress based on whether the URL already has query parameters
+      sed -E -i -e 's#(https?://crds-media\.imgix\.net/[^"'\'']*)(\?[^"'\'' ]*)?(['\'')])#\1\2\3&auto=compress#g' -e 's#(&auto=compress)(\?[^"'\'' ]*)#?auto=compress\2#g' "$file"
     fi
   fi
 }


### PR DESCRIPTION
### Task

[Asana Task](https://app.asana.com/0/1201454420722044/1206558274609681/f)

### Solution

- Adds alternative functionality to the "Chat with us now" button on the /contactus page. The button will result in a mailto action if:
  - `window.Intercom` is undefined (meaning the script did not initialize), or
  - The `.intercom-launcher` class is not present on the page

### Testing

https://deploy-preview-3340--crds-jekyll.netlify.app/contactus/

- Visit the testing link in a private/incognito window
- Click "deny" on the cookie consent banner (may take a few tries to reproduce)
- Assuming the chat widget does not appear on the bottom right, click "Chat with us now" and ensure that an email client opens which is directed to [hello@crossroads.net](mailto:hello@crossroads.net) 
- If the chat widget DOES appear, the expected behavior is that it opens the intercom widget