### PR TITLE
Update student ministry breadcrumbs

### DIFF
--- a/_layouts/series.html
+++ b/_layouts/series.html
@@ -30,10 +30,11 @@ title: Series
           <div class="col-sm-6 col-sm-offset-1 col-sm-pull-5 text-left">
 
             <ol class="breadcrumb hard-sides hard-top text-white mobile-push-half-top">
-              <li><a href="/media">Media</a></li>
               {% if page.is_student_ministry_series == true %}
+              <li><a href="/student-ministry">student-ministry</a></li>
               <li><a href="/student-ministry/series">Series</a></li>
               {% else %}
+              <li><a href="/media">Media</a></li>
               <li><a href="/media/series">Series</a></li>
               {% endif %}
             </ol>

--- a/_layouts/series.html
+++ b/_layouts/series.html
@@ -31,7 +31,7 @@ title: Series
 
             <ol class="breadcrumb hard-sides hard-top text-white mobile-push-half-top">
               {% if page.is_student_ministry_series == true %}
-              <li><a href="/student-ministry">student-ministry</a></li>
+              <li><a href="/student-ministry">Student Ministry</a></li>
               <li><a href="/student-ministry/series">Series</a></li>
               {% else %}
               <li><a href="/media">Media</a></li>

--- a/_layouts/video.html
+++ b/_layouts/video.html
@@ -26,7 +26,7 @@ layout: default
                 {% if page.is_student_ministry_series_video %}
                   <li><a href="/student-ministry">Student Ministry</a></li>
                   <li><a href="/student-ministry/series">Series</a></li>
-                  <li><a href="/student-ministry/series/{{ page.series.slug }}">{{ page.series.title }}</a></li>
+                  <li><a href="/media/series/{{ page.series.slug }}">{{ page.series.title }}</a></li>
                 {% else %}
                 {% for breadcrumb in url_array %}
                 {% capture first_word %}{{ url_string | truncatewords: 1, "" }}{% endcapture %}

--- a/_layouts/video.html
+++ b/_layouts/video.html
@@ -23,7 +23,11 @@ layout: default
               {% capture url_string %} {{ page.url | replace: '/', " " }}{% endcapture %}
               {% assign url="" %}
               <ol class="breadcrumb text-orange hard-sides">
-
+                {% if page.is_student_ministry_series_video %}
+                  <li><a href="/student-ministry">Student Ministry</a></li>
+                  <li><a href="/student-ministry/series">Series</a></li>
+                  <li><a href="/student-ministry/series/{{ page.series.slug }}">{{ page.series.title }}</a></li>
+                {% else %}
                 {% for breadcrumb in url_array %}
                 {% capture first_word %}{{ url_string | truncatewords: 1, "" }}{% endcapture %}
                 {% capture url %}{{ url }}/{{ first_word }}{% endcapture %}
@@ -32,6 +36,7 @@ layout: default
 
                 {% capture url_string %}{{ url_string | remove_first: first_word }}{% endcapture %}
                 {% endfor %}
+                {% endif %}
               </ol>
               <!-- End breadcrumbs -->
 

--- a/_plugins/generators/student_ministry_series_videos.rb
+++ b/_plugins/generators/student_ministry_series_videos.rb
@@ -1,0 +1,17 @@
+module GetIsStudentMinistrySeriesVideo
+  class Generator < Jekyll::Generator
+    def generate(site)
+      videos = site.collections['videos'].docs
+
+      videos.each do |video|
+        if video.data.dig('series', 'id').present?
+          id = video.data.dig('series', 'id')
+          series = site.collections['series'].docs.detect{ |doc| doc.data.dig('contentful_id') == id}
+          if series.present?
+            video.data['is_student_ministry_series_video'] = (series.data['is_student_ministry_series'])
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Task
[Asana Task](https://app.asana.com/0/1201454665996628/1207432108755913/f)

Shouldn't the "media" stay "student ministry' so the breadcrumb from [this page](https://demo.crossroads.net/student-ministry/series) to [this page](https://demo.crossroads.net/media/series/test-student-ministry-series3) is a build up? so on that second page the breadcrumbs would be "Student Ministry / Series /"

## Solution
[Student Ministry Series](https://deploy-preview-3350--demo-crds-jekyll.netlify.app/media/series/student-test-series-with-videos)

Also updated the breadcrumbs on the video layout if the video is associated to a series that is a flagged with (Is Student Ministry Series)
[Student Ministry Series Video](https://deploy-preview-3350--demo-crds-jekyll.netlify.app/media/videos/when-we-dont-know-how-to-pray)