### PR TITLE
update student ministry breadcrumb

### DIFF
--- a/_layouts/series.html
+++ b/_layouts/series.html
@@ -31,7 +31,7 @@ title: Series
 
             <ol class="breadcrumb hard-sides hard-top text-white mobile-push-half-top">
               {% if page.is_student_ministry_series == true %}
-              <li><a href="/student-ministry">Student Ministry</a></li>
+              <li><a href="/students">Student Ministry</a></li>
               <li><a href="/student-ministry/series">Series</a></li>
               {% else %}
               <li><a href="/media">Media</a></li>

--- a/_layouts/video.html
+++ b/_layouts/video.html
@@ -24,7 +24,7 @@ layout: default
               {% assign url="" %}
               <ol class="breadcrumb text-orange hard-sides">
                 {% if page.is_student_ministry_series_video %}
-                  <li><a href="/student-ministry">Student Ministry</a></li>
+                  <li><a href="/students">Student Ministry</a></li>
                   <li><a href="/student-ministry/series">Series</a></li>
                   <li><a href="/media/series/{{ page.series.slug }}">{{ page.series.title }}</a></li>
                 {% else %}


### PR DESCRIPTION
## Task
[Asana Task](https://app.asana.com/0/1202525367528099/1207432108755913/f)

when you click "Student Ministry" breadcrumb it goes to a 404. It either needs to go to /students or we need to put a redirect in place from /student-ministry to /students

## Solution
[Deploy Preview](https://deploy-preview-3352--demo-crds-jekyll.netlify.app/media/videos/god-is-bigger-than-feelings-for-older-kids-or-kids-club)

`/students` 404s on the deploy preview but is the correct url