### PR TITLE
Add hook to output static pages for indexing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 _site
+_site_static
 _redirects
 .DS*
 .aws

--- a/_assets/stylesheets/_fonts.scss
+++ b/_assets/stylesheets/_fonts.scss
@@ -26,7 +26,7 @@
  *   - http://typekit.com/eulas/000000000000000077359d7f
  *   - http://typekit.com/eulas/000000000000000077359d84
  *
- * © 2009-2024 Adobe Systems Incorporated. All Rights Reserved.
+ * © 2009-2025 Adobe Systems Incorporated. All Rights Reserved.
  */
 /*{"last_published":"2021-07-28 18:02:49 UTC"}*/
 

--- a/_plugins/hooks/static_pages.rb
+++ b/_plugins/hooks/static_pages.rb
@@ -1,0 +1,40 @@
+Jekyll::Hooks.register :site, :post_write do |site|
+  static_output_dir = "_site_static"
+
+  FileUtils.mkdir_p(static_output_dir)
+
+  site.pages.each do |page|
+    if page.data['static'] == true
+      base_path = File.join(site.dest, page.url)
+      candidates = []
+
+      if File.extname(page.url) == ".html"
+        candidates << base_path
+      else
+        unless page.url.end_with?("/")
+          candidates << "#{base_path}.html"
+        end
+      end
+
+      candidates << File.join(base_path, "index.html")
+      candidates.uniq!
+
+      source_path = candidates.find { |candidate| File.file?(candidate) }
+
+      unless source_path
+        puts "Warning: No valid source file found for '#{page.url}' among these candidates:"
+        candidates.each { |c| puts "  - #{c}" }
+        next
+      end
+
+      dest_filename = page.name
+
+      dest_path = File.join(static_output_dir, dest_filename)
+
+      FileUtils.mkdir_p(File.dirname(dest_path))
+
+      FileUtils.cp(source_path, dest_path)
+      puts "Copied: #{source_path} -> #{dest_path}"
+    end
+  end
+end

--- a/about.html
+++ b/about.html
@@ -3,6 +3,7 @@ layout: container-fluid
 title: About Us
 permalink: /about
 snail_trail: disabled
+static: true
 ---
 
 <section class="jumbotron jumbotron-xl jumbotron-home flush" style="background-image: url('//crds-media.imgix.net/1mEInC0vAIoDX6trTFRXNT/246e8f0e2d108b6e9f1f3b10238ed635/crossroads-about-collage2.jpg?{{ site.imgix_params.placeholder_sixteen_nine }}');" data-optimize-bg-img >

--- a/brian-tome.html
+++ b/brian-tome.html
@@ -1,5 +1,6 @@
 ---
 layout: default
+static: true
 ---
 
 <section class="bg-blue">

--- a/digital-tool-belt.html
+++ b/digital-tool-belt.html
@@ -1,5 +1,6 @@
 ---
 layout: default
+static: true
 ---
 
 {% assign digital_toolbelt_your_growth = site.content_blocks | where: 'slug', 'digital-toolbelt-your-growth' | first %}

--- a/history.html
+++ b/history.html
@@ -1,6 +1,7 @@
 ---
 layout: default
 snail_trail: disabled
+static: true
 ---
 
 <div class="preview" id="history-preloader">

--- a/our-history.html
+++ b/our-history.html
@@ -5,6 +5,7 @@ meta:
   description: In 1995, a group of Cincinnatians felt a need. The rest is history.
 image:
   url: "//crds-media.imgix.net/6r0I6UWJuM3rDOzksoPebe/f6323b82d6d7fdf2d5bdbe3ad284fbd3/history.jpg"
+static: true
 ---
 
 <section class="jumbotron our-history-bg img-background soft-ends">

--- a/our-memories.html
+++ b/our-memories.html
@@ -1,5 +1,6 @@
 ---
 layout: default
+static: true
 ---
 
 <section class="align-items-center d-flex flush jumbotron jumbotron-xl" style="background-image: url('//crds-media.imgix.net/315gBqZpkfcgv52mDjYAK5/ae6d6abb77dde2dadb16a769a0ba224f/crds-my25-mosaic__2_.jpg?{{ site.imgix_params.placeholder_sixteen_nine }}');" data-optimize-bg-img>

--- a/seven-hills.html
+++ b/seven-hills.html
@@ -5,6 +5,7 @@ meta:
   description: As a church, we believe that if something is worth living for, it is worth dying for.
 image:
   url: "//crds-media.imgix.net/3u1o8P0WJH07ktyJbUj4pc/9984660755eeee4b608b3ce60e8ab620/seven-hills.jpg"
+static: true
 ---
 
 <section class="jumbotron jumbotron-basics hard-top flush-bottom" data-optimize-bg-img data-hero-image>

--- a/spiritual-outfitters.html
+++ b/spiritual-outfitters.html
@@ -6,6 +6,7 @@ meta:
 image:
   url: "//crds-media.imgix.net/7EFusaW9y0WFSxO9KCdumH/2edc127ce50430b3894692f7075122fb/spiritual-outfitters.jpg"
 snail_trail: disabled
+static: true
 ---
 
 <section class="bg-primary">

--- a/statement-of-faith.html
+++ b/statement-of-faith.html
@@ -5,6 +5,7 @@ meta:
   description: Learn more about our statement of faith.
 image:
   url: "//crds-media.imgix.net/2400yJgIheb1iCSLedBvm/b49f37686517f24841e1688136e35ba7/statement-of-faith.jpg"
+static: true
 ---
 
 <section class="jumbotron statement-of-faith-bg img-background soft-ends">

--- a/timeline.html
+++ b/timeline.html
@@ -1,6 +1,7 @@
 ---
 layout: default
 snail_trail: disabled
+static: true
 ---
 
 <section class="bg-blue bg-contain soft-ends" style="background-image: url('//crds-media.imgix.net/7imk2yfqm1FFMNL8lZaXOn/fa7c7bafb058b48c3486407c46f423a3/Background_Texture-1_2x-min.jpg');" data-optimize-bg-img>

--- a/what-we-believe.html
+++ b/what-we-believe.html
@@ -5,6 +5,7 @@ meta:
   description: Learn more about what we believe as a church.
 image:
   url: "//crds-media.imgix.net/50FBEpFzihpFas4F67NhnS/76b9d09dc500c84ff6cedfb6b71cdfc8/what-we-believe.jpg"
+static: true
 ---
 
 <section class="jumbotron what-we-believe-bg img-background soft-ends">


### PR DESCRIPTION
## Problem
- The existing Jekyll build process generates both static and dynamic content into the _site directory.
- We needed a way to separate static pages Algolia indexing without disrupting the existing build logic.
- Static pages sometimes output as standalone .html files or as directories with index.html, requiring consistent handling.

## Solution
- Added a `post_write` hook to identify and copy static pages (marked with `static: true` in frontmatter) from `_site` to a new `_site_static` directory
  - This directory is considered a built artifact and is being ignored by git, but we should still be able to utilize a rake task or some other script to prepare these pages for indexing without exposing them.
- Ensured that static pages are always output as standalone .html files in `_site_static`, avoiding nested directories to simplify the next steps of the indexing process
- Kept the existing build process intact to avoid conflation

## Testing
*Include information on how to test your work here (if applicable).*