### PR TITLE
Include full url when indexing static pages

### DIFF
--- a/_plugins/hooks/index_static_pages.rb
+++ b/_plugins/hooks/index_static_pages.rb
@@ -84,12 +84,23 @@ Jekyll::Hooks.register :site, :post_write do |site|
     description = doc.at('meta[name="description"]')&.attr('content') || ""
     image       = doc.at('meta[name="image"]')&.attr('content') || ""
 
+    domain_env = ENV['CRDS_ENV']
+    domain = domain_env == 'demo' ? 'demo.crossroads.net' : 'www.crossroads.net'
+
+    # Get the permalink if available, otherwise use the slug
+    permalink = doc.at('meta[name="permalink"]')&.attr('content')
+    url = if permalink
+            "https://#{domain}#{permalink}"
+          else
+            "https://#{domain}#{slug}"
+          end
+
     record = {
       objectID: objectID,
       title: title,
       description: description,
       image: image,
-      slug: slug,
+      url: url,
       contentType: "page"
     }
 


### PR DESCRIPTION
## Problem
Static page entries need to include the full url instead of just the page slug.

## Solution
Generate the full url based on `CRDS_ENV` and add it to each Algolia record.

### Corresponding Branch
*Add link to crdschurch/repo-name-here#issue-number (if applicable). This helps the code reviewer know that corresponding work exists and where to find it.*

## Testing
*Include information on how to test your work here (if applicable).*