### PR TITLE
Feature/podcast episode season numbers

### DIFF
--- a/_layouts/podcast.html
+++ b/_layouts/podcast.html
@@ -113,7 +113,7 @@ title: Podcast
       <div class="col-sm-8 col-sm-offset-2">
         <h2 class="component-header">Episodes</h2>
         
-        {% if page.use_season_numbers %}
+        {% if page.use_season_numbers == true %}
           <!-- Tabs -->
           <div>
             <ul class="nav nav-tabs" role="tablist">
@@ -140,7 +140,7 @@ title: Podcast
                   <div class="push-top">
                     <a href="{{ episode.url }}">
                       <h3 class="list-title text-capitalize push-quarter-bottom">
-                        {% if page.use_episode_numbers %}Episode {{ episode.episode_number }}: {% endif %}{{ episode.title }}
+                        {% if page.use_episode_numbers == true %}Episode {{ episode.episode_number }}: {% endif %}{{ episode.title }}
                       </h3>
                     </a>
 
@@ -169,7 +169,7 @@ title: Podcast
             <div class="push-top">
               <a href="{{ episode.url }}">
                 <h3 class="list-title text-capitalize push-quarter-bottom">
-                  {% if page.use_episode_numbers %}Episode {{ episode.episode_number }}: {% endif %}{{ episode.title }}
+                  {% if page.use_episode_numbers == true %}Episode {{ episode.episode_number }}: {% endif %}{{ episode.title }}
                 </h3>
               </a>
 


### PR DESCRIPTION
## Problem
Currently, the podcast layout displays season tabs and episode numbers for all podcasts, regardless of whether they use seasonal organization or episode numbering. This creates unnecessary UI elements for podcasts that don't use these features.

## Solution
Added conditional rendering based on two new fields:
- `use_season_numbers`: Only shows season tabs when true
- `use_episode_numbers`: Only shows episode numbers when true

When these fields are false or not set, the layout defaults to a simple chronological list of episodes without numbers.

### Corresponding Branch
N/A

## Testing
1. View a podcast with both `use_season_numbers: true` and `use_episode_numbers: true`
   - Should see season tabs and episode numbers (e.g., "The Aggressive Life")
2. View a podcast with both fields set to false or not set
   - Should see a single chronological list without season tabs or episode numbers
3. Test mixed configurations:
   - `use_season_numbers: true` but `use_episode_numbers: false`
   - `use_season_numbers: false` but `use_episode_numbers: true`

## Deploy Previews

- [aggressive life (with season numbers and episode numbers)](https://deploy-preview-3429--demo-crds-jekyll.netlify.app/media/podcasts/the-aggressive-life-with-brian-tome)
- [messages (without season numbers and episode numbers)](https://deploy-preview-3429--demo-crds-jekyll.netlify.app/media/podcasts/messages)

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1209266549381264