### PR TITLE
Update fields for static Jekyll page indexing

### DIFF
--- a/_plugins/hooks/index_static_pages.rb
+++ b/_plugins/hooks/index_static_pages.rb
@@ -112,7 +112,6 @@ Jekyll::Hooks.register :site, :post_write do |site|
     }
 
     records << record
-    puts records
   end
 
   algolia_app_id     = ENV['ALGOLIA_APP_ID']

--- a/_plugins/hooks/index_static_pages.rb
+++ b/_plugins/hooks/index_static_pages.rb
@@ -3,6 +3,7 @@ require 'digest'
 require 'json'
 require 'securerandom'
 require 'algolia'
+require 'time'
 
 module ObjectIDGenerator
   CHARS = '0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz'.chars.freeze
@@ -65,6 +66,7 @@ Jekyll::Hooks.register :site, :post_write do |site|
   html_files = Dir.glob(File.join(directory_path, '**', '*.html'))
 
   records = []
+  current_date = Time.now.strftime("%B %d, %Y")
 
   html_files.each do |file_path|
     doc = Nokogiri::HTML(File.read(file_path))
@@ -98,13 +100,19 @@ Jekyll::Hooks.register :site, :post_write do |site|
     record = {
       objectID: objectID,
       title: title,
-      description: description,
+      summarizedDescription: description,
       image: image,
       url: url,
-      contentType: "page"
+      contentType: "Page",
+      searchExcluded: false,
+      date: current_date,
+      distribution_channels: [
+        { site: "www.crossroads.net", canonical: true }
+      ],
     }
 
     records << record
+    puts records
   end
 
   algolia_app_id     = ENV['ALGOLIA_APP_ID']

--- a/about.html
+++ b/about.html
@@ -1,6 +1,7 @@
 ---
 layout: container-fluid
 title: About Us
+description: Learn more about Crossroads Church.
 permalink: /about
 snail_trail: disabled
 static: true

--- a/digital-tool-belt.html
+++ b/digital-tool-belt.html
@@ -2,6 +2,7 @@
 layout: default
 meta:
   title: Digital Tool Belt | Crossroads
+  description: Learn more about Crossroads’ mission to connect seekers to a community of growing Christ followers who change the world.
 static: true
 ---
 

--- a/our-memories.html
+++ b/our-memories.html
@@ -2,6 +2,7 @@
 layout: default
 meta:
   title: Our Memories
+  description: God has done some amazing things in and through our community in the past 25 years.
 static: true
 ---
 

--- a/spiritual-outfitters.html
+++ b/spiritual-outfitters.html
@@ -2,7 +2,7 @@
 layout: default
 meta:
   title: Spiritual Outfitters | Crossroads
-  description: Crossroads has a brand new look
+  description: Crossroads has a brand new look.
 image:
   url: "//crds-media.imgix.net/7EFusaW9y0WFSxO9KCdumH/2edc127ce50430b3894692f7075122fb/spiritual-outfitters.jpg"
 snail_trail: disabled

--- a/timeline.html
+++ b/timeline.html
@@ -4,6 +4,7 @@ snail_trail: disabled
 static: true
 meta:
   title: Timeline
+  description: Time flies when you're having fun. Check out what God has done through Crossroads over the years.
 ---
 
 <section class="bg-blue bg-contain soft-ends" style="background-image: url('//crds-media.imgix.net/7imk2yfqm1FFMNL8lZaXOn/fa7c7bafb058b48c3486407c46f423a3/Background_Texture-1_2x-min.jpg');" data-optimize-bg-img>


### PR DESCRIPTION
- Adds required fields that were missing from the output
- Updates static page descriptions

You can check the updated fields in the static index here: https://dashboard.algolia.com/apps/8Y3N3H5PNJ/explorer/browse/demo_crds_net_static?searchMode=search