### PR TITLE
Add modal for Dayton location page

### DIFF
--- a/_includes/locations/_dayton-modal.html
+++ b/_includes/locations/_dayton-modal.html
@@ -1,0 +1,50 @@
+{% if page.name == 'Dayton' %}
+<div aria-labelledby="New Here?" class="location-overlay modal fade" id="daytonModalOverlay" role="dialog">
+  <div class="modal-dialog" role="document">
+    <div class="">
+      <div class="modal-header hard-bottom">
+        <button aria-label="Close" class="close pull-right" style="background-color: transparent;" data-dismiss="modal"
+          type="button">
+          <span style="font-size: 30px" aria-hidden="true">&times;</span>
+        </button>
+      </div>
+      <div class="modal-body location-overlay-content">
+        <div>
+          <img src="//crds-media.imgix.net/2ud1GhmoEf2udWaruq6XC3/57449963f031b6e036ea7506d81b6c6f/crds-logo-mark.svg"
+            width="50" height="50" />
+          <h3 class="component-header text-center text-white push-ends text-uppercase">New Here?</h3>
+          <div class="text-center">
+            <crds-button href="https://www.crossroads.net/dayton-lp" color="blue" text="Yes"></crds-button>
+            <crds-button data-dismiss="modal" color="blue" text="Nope"></crds-button>
+          </div>
+        </div>
+      </div>
+      <div class="modal-footer">&nbsp;</div>
+    </div>
+  </div>
+</div>
+
+<script type="text/javascript">
+  document.addEventListener('DOMContentLoaded', function () {
+    if (!localStorage.getItem('daytonModalShown')) {
+      $('#welcomeLocationOverlay').modal('hide');
+
+      $(window).on('load', function () {
+        $('#daytonModalOverlay').modal('show');
+      });
+
+      var yesBtn = document.querySelector('#daytonModalOverlay a[href="https://www.crossroads.net/dayton-lp"]');
+      if (yesBtn) {
+        yesBtn.addEventListener('click', function () {
+          localStorage.setItem('daytonModalShown', 'true');
+        });
+      }
+
+      $('#daytonModalOverlay').on('hidden.bs.modal', function () {
+        localStorage.setItem('daytonModalShown', 'true');
+        $('#welcomeLocationOverlay').modal('show');
+      });
+    }
+  });
+</script>
+{% endif %}

--- a/_layouts/frontier.html
+++ b/_layouts/frontier.html
@@ -16,6 +16,7 @@ layout: default
 {% include _livestream.html %}
 
 {% include locations/_welcome-modal.html %}
+{% include locations/_dayton-modal.html %}
 
 {% assign sorted_messages = site.messages | sort: 'published_at' %}
 {% assign current_message = sorted_messages | last %}
@@ -94,16 +95,18 @@ layout: default
             <p></p>
             <crds-button class="push-half-right" data-toggle="modal" href="https://www.crossroads.net/daytonlaunch"
               color="white" text="Learn More"></crds-button>
-            <crds-button class="push-half-right" data-toggle="modal" href="https://my.crossroads.net/Registration/daytonlaunchteam"
-              color="orange" text="Sign Up for the Launch Team"></crds-button>
+            <crds-button class="push-half-right" data-toggle="modal"
+              href="https://my.crossroads.net/Registration/daytonlaunchteam" color="orange"
+              text="Sign Up for the Launch Team"></crds-button>
           </crds-portrait-card>
           {% endif %}
           {% if page.name == 'Columbus' %}
           <crds-portrait-card theme="condensed" lead="Join us" title="Make an Impact. Sign up to Volunteer."
             image-src="//images.ctfassets.net/y3a9myzsdjan/5gRoYiESU4OO0bTCDlWUfl/f81381d8d91720253651feb767169dea/2400616_Crds_Columbus_DavidSlaughter-12-DeNoiseAI-standard.jpg">
             <p class="push-half-ends">Help create an environment that is welcoming and fun.</p>
-            <crds-button class="push-half-right" href="https://my.crossroads.net/volunteer?crossroads-community=columbus"
-              color="white" text="Sign Up"></crds-button>
+            <crds-button class="push-half-right"
+              href="https://my.crossroads.net/volunteer?crossroads-community=columbus" color="white"
+              text="Sign Up"></crds-button>
           </crds-portrait-card>
           {% endif %}
         </div>


### PR DESCRIPTION
When visiting /dayton, you should see a modal that says "New here?" and has two buttons:
- Yes: Route to the new Dayton landing page. This url might need to be updated)
- Nope: Close the modal and show the landing page, including the existing welcome modal if applicable

This also sets a localStorage token when the user has already interacted with the modal to prevent further prompts.