### PR TITLE
Include description field when indexing static pages

### DIFF
--- a/_plugins/hooks/index_static_pages.rb
+++ b/_plugins/hooks/index_static_pages.rb
@@ -85,7 +85,6 @@ Jekyll::Hooks.register :site, :post_write do |site|
     objectID = ObjectIDGenerator.encode(slug_hash)[0...22]
 
     description = doc.at('meta[name="description"]')&.attr('content') || ""
-    image       = doc.at('meta[name="image"]')&.attr('content') || ""
 
     domain_env = ENV['CRDS_ENV']
     domain = domain_env == 'demo' ? 'demo.crossroads.net' : 'www.crossroads.net'
@@ -103,7 +102,6 @@ Jekyll::Hooks.register :site, :post_write do |site|
       title: title,
       summarizedDescription: description,
       description: description,
-      image: image,
       url: url,
       contentType: "Page",
       searchExcluded: false,

--- a/_plugins/hooks/index_static_pages.rb
+++ b/_plugins/hooks/index_static_pages.rb
@@ -101,6 +101,7 @@ Jekyll::Hooks.register :site, :post_write do |site|
       objectID: objectID,
       title: title,
       summarizedDescription: description,
+      description: description,
       image: image,
       url: url,
       contentType: "Page",


### PR DESCRIPTION
[Task](https://app.asana.com/1/37330734394864/project/1201454665996628/task/1209641195645766)

Adds a `description` field to static pages that get indexed. This text will be displayed in each search hit.

To test/verify, I ran the hook locally which updated the entries in the `demo_crds_net_static` index: https://dashboard.algolia.com/apps/8Y3N3H5PNJ/explorer/browse/demo_crds_net_static?page=2&searchMode=search

I also removed the `image` field since they will all return the placeholder image for static pages.