### PR TITLE
Update conditional logic for component libraries/headers

### DIFF
--- a/_includes/_head.html
+++ b/_includes/_head.html
@@ -94,7 +94,7 @@
   <!-- CRDS Components Loading -->
   {% if site.use_unified_components %}
   <script type="module" onload="componentsLoaded()" src="{{ site.unified_components_endpoint }}"></script>
-  {% else %}
+  {% endif %}
   {% unless content contains 'crds-components.esm.js' %}
   <!-- Preload CRDS Component assets -->
   <link rel="preload" href="{{ site.components_endpoint }}/crds-components/crds-components.esm.js" as="script">
@@ -106,7 +106,6 @@
   <script nomodule="" onload="componentsLoaded()" src="{{ site.components_endpoint }}/crds-components.js"></script>
   <!-- END: Preload CRDS Component assets -->
   {% endunless %}
-  {% endif %}
   <!-- END: CRDS Components Loading -->
 
   <!-- Component Ready Event Handler -->
@@ -191,7 +190,7 @@
   <!-- Facebook Pixel Integration -->
   {% include _facebook.html %}
   <!-- END: Facebook Pixel Integration -->
-  
+
   <!-- JavaScript Variables and Main Application Script -->
   {% if page.js_vars %}{% include _js_vars.html %}{% endif %}
   {% javascript_link_tag application %}

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -22,7 +22,11 @@
       <path class="logo-mark" d="m99.1 28.6-24.7-24.7-22.9 22.9-22.8-22.9-24.7 24.7 22.9 22.9-22.9 22.8 24.7 24.7 22.9-22.9 22.8 22.9 24.7-24.7-22.9-22.9zm-11.4 45.7-13.3 13.3-17.2-17.1 13.3-13.3zm-30.5-41.9 17.2-17.2 13.3 13.3-17.1 17.2zm-19 19-22.8-22.8 13.3-13.3 36.2 36.2-36.2 36.1-13.3-13.3z"/>
     </svg>
   </div>
-  <crds-shared-header env="{{ site.crds_env }}"></crds-shared-header>
+  {% if site.use_unified_components %}
+    <shared-header></shared-header>
+  {% else %}
+    <crds-shared-header env="{{ site.crds_env }}"></crds-shared-header>
+  {% endif %}
 </div>
 {% if page.snail_trail != "disabled" %}
   <div class="snail-trail-skeleton">

--- a/_plugins/hooks/config.rb
+++ b/_plugins/hooks/config.rb
@@ -1,6 +1,6 @@
 Jekyll::Hooks.register :site, :after_init do |site|
   site.config['components_endpoint'] = "https://#{ENV['CRDS_COMPONENTS_ENDPOINT'] || "components.crossroads.net"}/dist"
-  site.config['unified_components_endpoint'] = "https://#{ENV['CRDS_UNIFIED_COMPONENTS_ENDPOINT'] || "unified-components.crossroads.net"}/dist/unified-components.js"
+  site.config['unified_components_endpoint'] = "#{ENV['CRDS_UNIFIED_COMPONENTS_DOMAIN'] || "unified-components.crossroads.net"}/dist/unified-components.js"
   site.config['use_unified_components'] = ENV['USE_UNIFIED_COMPONENTS'] == 'true'
 
   env = case ENV['JEKYLL_ENV']
@@ -12,5 +12,5 @@ Jekyll::Hooks.register :site, :after_init do |site|
   site.config['components_root_url'] = ENV['CRDS_COMPONENTS_ROOT_URL'] unless ENV['CRDS_COMPONENTS_ROOT_URL'].nil?
   site.config['data_host'] = "https://#{ENV['CRDS_DATA_ENDPOINT'] || "crds-data.crossroads.net"}"
   site.config['data_file'] = "#{env}.json"
-    site.config['site_url'] = ENV['SITE_URL'];
+  site.config['site_url'] = ENV['SITE_URL']
 end


### PR DESCRIPTION
**_head.html:**
Updates the logic so that the legacy component library is always loaded. If `use_unified_components` is true, we also load crds-unified-components.

**header.html:**
Check for `use_unified_components` before determining which header to use.

**config.rb:**
Updates `CRDS_UNIFIED_COMPONENTS_ENDPOINT` (we are not using this variable) to `CRDS_UNIFIED_COMPONENTS_DOMAIN` and fixes the url syntax.