### PR TITLE
Remove bg image references

### DIFF
--- a/_includes/_media-card.html
+++ b/_includes/_media-card.html
@@ -1,4 +1,4 @@
-==/{% assign author = site.authors | where: "name",item.author | first %}
+{% assign author = site.authors | where: "name",item.author | first %}
 {% assign item = include.item %}
 {% assign album_url = item.album_url %}
 

--- a/_includes/_media-card.html
+++ b/_includes/_media-card.html
@@ -1,4 +1,4 @@
-{% assign author = site.authors | where: "name",item.author | first %}
+==/{% assign author = site.authors | where: "name",item.author | first %}
 {% assign item = include.item %}
 {% assign album_url = item.album_url %}
 
@@ -22,11 +22,9 @@
     {% assign image = item.image.url %}
 
     {% if item.content_type == 'episode' %}
-      {% assign image =item.podcast.image.url %}
+      {% assign image = item.podcast.image.url %}
     {% endif %}
-    {% if image == blank %}
-      {% assign image = item.bg_image.url %}
-    {% endif %}
+    
     {% assign recommended_collection=site.messages %}
     {% include _video-player-card.html %}
     {% if image %}

--- a/_includes/_overlay-card.html
+++ b/_includes/_overlay-card.html
@@ -1,6 +1,3 @@
-{% comment %}
-// This assures the messages content type uses the background image instead of the thumbnail image like all other content types.
-{% endcomment %}
 {% assign handle = item.content_type %}
 {% case handle %}
   {% when 'message' %}

--- a/_includes/_overlay-feature-card.html
+++ b/_includes/_overlay-feature-card.html
@@ -1,6 +1,3 @@
-{% comment %}
-// This assures the messages content types use the background image instead of the thumbnail image like all other content types.
-{% endcomment %}
 {% assign image_source = item | card_image %}
 
 <a href="{{ item | media_url }}" class="overlay-feature-card-link">

--- a/_includes/_video-player-card.html
+++ b/_includes/_video-player-card.html
@@ -1,10 +1,7 @@
-{% comment %}
-// This assures the messages content type uses the background image instead of the thumbnail image like all other content types.
-{% endcomment %}
 {% assign handle = item.content_type %}
 {% case handle %}
   {% when 'message' %}
-    {% assign banner_image = item.background_image.url %}
+    {% assign banner_image = item.image.url %}
   {% when 'episode' %}
     {% assign banner_image = item.podcast.image.url %}
   {% else %}

--- a/_plugins/filters/jsonify_message.rb
+++ b/_plugins/filters/jsonify_message.rb
@@ -15,8 +15,6 @@ module Jekyll
             title: m["title"].truncate(55),
             author: m["author"],
             duration: m["duration"],
-            background_image: m["background_image"],
-            bg_image: m["bg_image"],
             image: m["image"],
             podcast: m["podcast"],
             album: m["album"],


### PR DESCRIPTION
## Problem
Remove dependencies for the message background image so that the field can be removed upstream in Contentful.

## Solution
Removed the background image dependency for message content type by:
1. Standardizing the use of the `image` field across all content types
2. Removing special case handling for message content type images in:
   - `_includes/_video-player-card.html`
   - `_includes/_overlay-card.html`
   - `_includes/_overlay-feature-card.html`
   - `_includes/_media-card.html`
3. Removing the `background_image` and `bg_image` fields from the message JSON structure in `_plugins/filters/jsonify_message.rb`
4. Simplifying the image fallback logic to use the standard image field and default image

### Corresponding Branch
N/A


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1210143622147462