### PR TITLE
Fix for topic aside cards not being clickable

### DIFF
--- a/_assets/stylesheets/pages/_topics.scss
+++ b/_assets/stylesheets/pages/_topics.scss
@@ -245,6 +245,15 @@
         .list-card:first-of-type {
           margin-top: 0;
         }
+
+        .card-link-overlay {
+          position: absolute;
+          top: 0;
+          right: 0;
+          bottom: 0;
+          left: 0;
+          z-index: 1;
+        }
       }
     }
   }


### PR DESCRIPTION
## Problem
Styles for the link overlay were not scoped to the `aside` section

## Solution
Copy the link overlay styles into the `aside` styles so that the cards are clickable



## Testing
Ensure that all cards on this page template are clickable
https://deploy-preview-3475--demo-crds-jekyll.netlify.app/media/topics/culture