### PR TITLE
Fix social share links on articles

### DIFF
--- a/_includes/_article-social-share.html
+++ b/_includes/_article-social-share.html
@@ -5,7 +5,8 @@
   <div class="row soft-bottom">
     <div class="flex-start flex-align-center">
       <div class="article-detail-social">
-        <crds-heart-button theme="button" contentful-id="{{ item.contentful_id }}" contentful-slug= "{{ item.slug }}" contentful-type="{{ item.content_type | upcase }}"></crds-heart-button>
+        <crds-heart-button theme="button" contentful-id="{{ item.contentful_id }}" contentful-slug="{{ item.slug }}"
+          contentful-type="{{ item.content_type | upcase }}"></crds-heart-button>
       </div>
       <div class="social-share sidebar">
         <a data-engaged="shared" href="javascript:shareFacebook()">
@@ -30,7 +31,7 @@
   </div>
 
   {% if include.media_metric != false %}
-    <crds-media-metrics-share slug="{{ item.slug }}" type="{{ item.content_type | upcase }}" />  
+  <crds-media-metrics-share slug="{{ item.slug }}" type="{{ item.content_type | upcase }}" />
   {% endif %}
 </section>
 
@@ -38,16 +39,16 @@
   function shareFacebook() {
     const mediaMetricShare = new Event('mediaMetricInteractionShare');
     document.dispatchEvent(mediaMetricShare);
-    
-    let link = `https://www.facebook.com/sharer/sharer.php?u=https://www.crossroads.net/media{{ page.url }}`;
+
+    let link = `https://www.facebook.com/sharer/sharer.php?u={{ site.url }}{{ page.url }}`;
     window.open(link, '_blank');
   }
 
   function shareTwitter() {
     const mediaMetricShare = new Event('mediaMetricInteractionShare');
     document.dispatchEvent(mediaMetricShare);
-    
-    let link = `https://twitter.com/home?status={{ page.title | escape | titleize }}%20{{ site.url }}{{ page.url }}`;
+
+    let link = `https://twitter.com/intent/tweet?text={{ page.title | uri_escape }}%20{{ site.url }}{{ page.url }}`;
     window.open(link, '_blank');
   }
 


### PR DESCRIPTION
## [Asana Task](https://app.asana.com/1/37330734394864/project/1201454665996628/task/1211150813246660?focus=true)

## Problem
On article templates, the Twitter and Facebook share buttons were not working.

## Solution
### Facebook share URL
**Old:** `https://www.facebook.com/sharer/sharer.php?u=https://www.crossroads.net/media{{ page.url }}`
**New:** `https://www.facebook.com/sharer/sharer.php?u={{ site.url }}{{ page.url }}`
**Why:** Removes the hard-coded domain and /media prefix. It now uses the site’s configured base URL for any environment and any section, reducing bad/duplicated paths.

### Twitter share endpoint + encoding
**Old:** `https://twitter.com/home?status={{ page.title | escape | titleize }}%20{{ site.url }}{{ page.url }}`
**New:** `https://twitter.com/intent/tweet?text={{ page.title | uri_escape }}%20{{ site.url }}{{ page.url }}`
**Why:**
- Switches from `home?status=` to the modern intent/tweet endpoint (more reliable behavior and officially documented).
- Uses `uri_escape` instead of `escape | titleize`, so the title is properly URL-encoded and no longer forced to Title Case (preserves original casing).

## Testing
(Must be logged into Facebook and Twitter to verify)
Click the social share links on an article page. A new tab should open with a pre-populated post.

<img src="https://github.com/user-attachments/assets/90dfa93e-9be5-4ed6-a3cd-deba988b7765" alt="Screenshot 1" width="400">
<img src="https://github.com/user-attachments/assets/0af1089e-def7-4ada-a922-2c046fc052b4" alt="Screenshot 2" width="400">

## Deploy preview
https://deploy-preview-3491--demo-crds-jekyll.netlify.app/media/articles/jesus-was-not-good-looking

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1211150813246660