### PR TITLE
Trigger global search sync after static indexing

### DIFF
--- a/_plugins/hooks/index_static_pages.rb
+++ b/_plugins/hooks/index_static_pages.rb
@@ -4,6 +4,8 @@ require 'json'
 require 'securerandom'
 require 'algolia'
 require 'time'
+require 'net/http'
+require 'uri'
 
 module ObjectIDGenerator
   CHARS = '0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz'.chars.freeze
@@ -19,6 +21,36 @@ module ObjectIDGenerator
     end
     encoded
   end
+end
+
+def invoke_global_search_sync(source:, env:)
+  sync_token = ENV['GLOBAL_SEARCH_SYNC_TOKEN']
+  sync_disabled = ENV['GLOBAL_SEARCH_SYNC_DISABLED'].to_s.downcase == 'true'
+  search_domain = ENV['SEARCH_DOMAIN'] || (env == 'demo' ? 'https://demo.crossroads.net' : 'https://www.crossroads.net')
+
+  if sync_disabled
+    puts "[global-search-trigger] skipped because GLOBAL_SEARCH_SYNC_DISABLED=true"
+    return
+  end
+
+  if sync_token.nil? || sync_token.strip.empty?
+    puts "[global-search-trigger] skipped because GLOBAL_SEARCH_SYNC_TOKEN is missing"
+    return
+  end
+
+  sync_url = "#{search_domain.sub(%r{/$}, '')}/.netlify/functions/sync-global-search-background"
+  uri = URI.parse(sync_url)
+  params = URI.decode_www_form(String(uri.query)) << ['env', env] << ['source', source] << ['applySettings', 'true'] << ['dryRun', 'false']
+  uri.query = URI.encode_www_form(params)
+
+  request = Net::HTTP::Post.new(uri)
+  request['x-global-search-sync-token'] = sync_token
+
+  response = Net::HTTP.start(uri.hostname, uri.port, use_ssl: uri.scheme == 'https') do |http|
+    http.request(request)
+  end
+
+  puts "[global-search-trigger] source=#{source} env=#{env} status=#{response.code}"
 end
 
 # Copy static pages to the _site_static directory
@@ -137,6 +169,7 @@ Jekyll::Hooks.register :site, :post_write do |site|
     index.save_objects(records)
 
     puts "Successfully indexed #{records.size} records to Algolia index '#{algolia_index_name}'."
+    invoke_global_search_sync(source: 'static', env: domain_env == 'demo' ? 'demo' : 'prod')
   rescue StandardError => e
     puts "Error during indexing: #{e.message}"
   end

--- a/_plugins/hooks/index_static_pages.rb
+++ b/_plugins/hooks/index_static_pages.rb
@@ -25,13 +25,7 @@ end
 
 def invoke_global_search_sync(source:, env:)
   sync_token = ENV['GLOBAL_SEARCH_SYNC_TOKEN']
-  sync_disabled = ENV['GLOBAL_SEARCH_SYNC_DISABLED'].to_s.downcase == 'true'
-  search_domain = ENV['SEARCH_DOMAIN'] || (env == 'demo' ? 'https://demo.crossroads.net' : 'https://www.crossroads.net')
-
-  if sync_disabled
-    puts "[global-search-trigger] skipped because GLOBAL_SEARCH_SYNC_DISABLED=true"
-    return
-  end
+  search_domain = env == 'demo' ? 'https://demo.crossroads.net' : 'https://www.crossroads.net'
 
   if sync_token.nil? || sync_token.strip.empty?
     puts "[global-search-trigger] skipped because GLOBAL_SEARCH_SYNC_TOKEN is missing"

--- a/_plugins/hooks/index_static_pages.rb
+++ b/_plugins/hooks/index_static_pages.rb
@@ -94,6 +94,8 @@ Jekyll::Hooks.register :site, :post_write do |site|
   records = []
   current_date = Time.now.strftime("%B %d, %Y")
   current_timestamp = Time.parse(current_date).to_i
+  resolved_env = ENV['CRDS_ENV'] == 'demo' ? 'demo' : 'prod'
+  domain = resolved_env == 'demo' ? 'demo.crossroads.net' : 'www.crossroads.net'
 
   html_files.each do |file_path|
     doc = Nokogiri::HTML(File.read(file_path))
@@ -111,9 +113,6 @@ Jekyll::Hooks.register :site, :post_write do |site|
     objectID = ObjectIDGenerator.encode(slug_hash)[0...22]
 
     description = doc.at('meta[name="description"]')&.attr('content') || ""
-
-    domain_env = ENV['CRDS_ENV']
-    domain = domain_env == 'demo' ? 'demo.crossroads.net' : 'www.crossroads.net'
 
     # Get the permalink if available, otherwise use the slug
     permalink = doc.at('meta[name="permalink"]')&.attr('content')
@@ -163,7 +162,7 @@ Jekyll::Hooks.register :site, :post_write do |site|
     index.save_objects(records)
 
     puts "Successfully indexed #{records.size} records to Algolia index '#{algolia_index_name}'."
-    invoke_global_search_sync(source: 'static', env: domain_env == 'demo' ? 'demo' : 'prod')
+    invoke_global_search_sync(source: 'static', env: resolved_env)
   rescue StandardError => e
     puts "Error during indexing: #{e.message}"
   end


### PR DESCRIPTION
[Task](https://app.asana.com/1/37330734394864/project/1201454665996628/task/1213644573914621?focus=true)

 ## Summary
- Triggers the `crds-unified` global-search background function after the static Algolia index finishes writing. This completes the upstream-triggered model so `global_search_*` can refresh when static content changes.
- Associated crds-unified PR: https://github.com/crdschurch/crds-unified/pull/2947

## Env Vars
  ### New
  - `GLOBAL_SEARCH_SYNC_TOKEN`

  ### Existing env vars used
  - `CRDS_ENV`
  - `ALGOLIA_APP_ID`
  - `ALGOLIA_API_KEY`
  - `ALGOLIA_INDEX_NAME`

## Prerequisites
  - The `crds-unified` PR must be deployed first so the background function exists
  - `GLOBAL_SEARCH_SYNC_TOKEN` must match the token configured in `crds-unified` (I already added this in Netlify)

  ## Notes
  - This PR only adds the callback after a successful static index write
  - It does not change how the static index itself is built or written
  - If the callback fails, the static indexing build still succeeds

## How To Test
 ### What Can Be Verified In The Deploy Preview
  1. Confirm static indexing still succeeds.
     - Look for:
       - `Successfully copied settings from 'crds_settings' to 'crds_net_static'`
       - `Successfully indexed 11 records to Algolia index 'crds_net_static'.`
  2. Confirm the build logs show the new callback attempt after static indexing succeeds.
     - Look for:
       - `[global-search-trigger] source=static env=prod status=...`
  3. If the callback returns a non-`200` status in the deploy preview, that can be expected until the `crds-unified`
  background function is deployed on the live target site.
  4. Verify that the static index write itself is unchanged apart from the new callback attempt.

  ### What Must Be Verified After Merge / Live Deploy
  1. Deploy the `crds-unified` PR first so `sync-global-search-background` exists on the live target site.
  2. Deploy this branch.
  3. Run a static indexing build.
  4. Confirm build logs show:
     - static indexing succeeded
     - the global search trigger returned a success status
  5. Verify in Algolia that `global_search_prod` refreshes after the static job completes.
  6. Confirm the existing static child index remains intact and unchanged aside from its normal rebuild.


