### PR TITLE
Person model implementation

### DIFF
--- a/_assets/javascripts/components/preview.js
+++ b/_assets/javascripts/components/preview.js
@@ -46,15 +46,17 @@ function setAuthorInfo(name, slug, bio, img) {
   }
 
   for (var k = 0; k < authorLinks.length; k += 1) {
-    authorLinks[k].href = `/authors/${slug}`;
+    authorLinks[k].href = `/media/authors/${slug}`;
   }
 
   authorBio.innerText = bio;
 
-  getAsset(img).then(function(res) {
-    var imgUrl = `${res.fields.file.url}?auto=format,compress&w=80&h=80&fit=crop`;
-    replaceImg(imgUrl, authorImg);
-  });
+  if (img) {
+    getAsset(img).then(function(res) {
+      var imgUrl = `${res.fields.file.url}?auto=format,compress&w=80&h=80&fit=crop`;
+      replaceImg(imgUrl, authorImg);
+    });
+  }
 }
 
 function replaceImg(src, el) {
@@ -89,9 +91,35 @@ function renderPage(data) {
     hidePreloader();
   }
 
-  if (data.author) {
+  if (data.person && data.person.length) {
+    Promise.all(data.person.map(function(personRef) {
+      return getEntry(personRef.sys.id);
+    })).then(function(people) {
+      var author = people.find(function(person) {
+        return person.fields.roles && person.fields.roles.indexOf('Author') > -1;
+      });
+
+      if (author) {
+        setAuthorInfo(
+          author.fields.name || author.fields.full_name,
+          author.fields.slug,
+          author.fields.bio || author.fields.summary,
+          author.fields.image && author.fields.image.sys ? author.fields.image.sys.id : null
+        );
+      } else {
+        hidePreloader();
+      }
+    }).catch(function(err) {
+      console.log(err);
+    });
+  } else if (data.author && data.author.sys && data.author.sys.id) {
     getEntry(data.author.sys.id).then(function(res) {
-      setAuthorInfo(res.fields.full_name, res.fields.slug, res.fields.summary, res.fields.image.sys.id);
+      setAuthorInfo(
+        res.fields.name || res.fields.full_name,
+        res.fields.slug,
+        res.fields.bio || res.fields.summary,
+        res.fields.image && res.fields.image.sys ? res.fields.image.sys.id : null
+      );
     }).catch(function(err) {
       console.log(err);
     });

--- a/_config.yml
+++ b/_config.yml
@@ -65,7 +65,7 @@ collections:
     output: true
     permalink: /media/humans-of-crossroads/:slug
   authors:
-    output: true
+    output: false
     permalink: /media/:collection/:title
   categories:
     output: true
@@ -103,6 +103,9 @@ collections:
     filename: "{{ permalink }} index"
     output: true
     permalink: /:permalink/index.html
+  people:
+    output: true
+    permalink: /media/authors/:title
   podcasts:
     output: true
     permalink: /media/:collection/:title
@@ -259,6 +262,12 @@ defaults:
   - scope:
       path: ""
       type: authors
+    values:
+      layout: author
+      snail_trail: disabled
+  - scope:
+      path: ""
+      type: people
     values:
       layout: author
       snail_trail: disabled

--- a/_includes/_article-card.html
+++ b/_includes/_article-card.html
@@ -1,5 +1,14 @@
 {% assign post = include.post %}
-{% assign author = post.author | get_doc %}
+{% assign contributor_ref = post.person | first %}
+{% if contributor_ref %}
+  {% assign contributor_page = site.people | where: 'slug', contributor_ref.slug | first %}
+  {% assign contributor = contributor_page | default: contributor_ref %}
+{% else %}
+  {% assign contributor = post.author | get_doc %}
+  {% assign contributor_page = contributor %}
+{% endif %}
+{% assign contributor_name = contributor.name | default: contributor.full_name %}
+{% assign contributor_link = contributor_page.url %}
 {% assign topic = post.category | get_doc %}
 
 <div class="card">
@@ -23,7 +32,11 @@
   </h2>
 
   <p class="text-gray-light font-size-small flush-bottom push-quarter-top">
-    <a href="{{ author.url }}">{{ author.name | titleize }}</a>
+    {% if contributor_link %}
+      <a href="{{ contributor_link }}">{{ contributor_name | titleize }}</a>
+    {% else %}
+      <span>{{ contributor_name | titleize }}</span>
+    {% endif %}
   </p>
 
 </div>

--- a/_includes/_author-bio.html
+++ b/_includes/_author-bio.html
@@ -9,13 +9,13 @@
 
   <div class="media-body">
     <h1 class="font-family-condensed-extra text-uppercase text-white" data-author-name>
-      {{ author.full_name }}
+      {{ author.name | default: author.full_name }}
     </h1>
 
     {% if page.title == "Preview" %}
       <p data-author-bio></p>
     {% else %}
-      <span class="markdown">{{ author.summary | markdownify }}</span>
+      <span class="markdown">{{ author.bio | default: author.summary | markdownify }}</span>
     {% endif %}
 
     <div class="social-inline">

--- a/_includes/_author-social.html
+++ b/_includes/_author-social.html
@@ -1,28 +1,29 @@
-{% if author.facebook_link or author.instagram_link or author.twitter_link or author.youtube_link %}
+{% assign social_author = include.author | default: author %}
+{% if social_author.facebook_link or social_author.instagram_link or social_author.twitter_link or social_author.youtube_link %}
     <div class="social-container">
-      {% if author.instagram_link %}
-      <a class="social-btn" href="{{ author.instagram_link }}" >
+      {% if social_author.instagram_link %}
+      <a class="social-btn" href="{{ social_author.instagram_link }}" >
         <svg class="social-icon" viewBox="0 0 256 256">
           <use class="icon-color" xlink:href="/assets/svgs/icons.svg#instagram"></use>
         </svg>
       </a>
       {% endif %}
-      {% if author.facebook_link %}
-         <a class="social-btn" href="{{ author.facebook_link }}">
+      {% if social_author.facebook_link %}
+         <a class="social-btn" href="{{ social_author.facebook_link }}">
         <svg class="social-icon" viewBox="0 0 256 256">
           <use class="icon-color" xlink:href="/assets/svgs/icons.svg#facebook"></use>
         </svg>
       </a>
       {% endif %}
-      {% if author.twitter_link %}
-          <a class="social-btn"  href=" {{ author.twitter_link }}">
+      {% if social_author.twitter_link %}
+          <a class="social-btn"  href=" {{ social_author.twitter_link }}">
         <svg class="social-icon" viewBox="0 0 256 256">
           <use class="icon-color" xlink:href="/assets/svgs/icons.svg#twitter"></use>
         </svg>
       </a>
       {% endif %}
-      {% if author.youtube_link %}
-          <a class="social-btn"  href="{{ author.youtube_link }}">
+      {% if social_author.youtube_link %}
+          <a class="social-btn"  href="{{ social_author.youtube_link }}">
         <svg class="social-icon" viewBox="0 0 256 256">
           <use class="icon-color" xlink:href="/assets/svgs/icons.svg#youtube"></use>
         </svg>

--- a/_includes/_head.html
+++ b/_includes/_head.html
@@ -67,6 +67,7 @@
 
   <!-- Schema.org Article markup for SEO -->
   {% if page.content_type == "article" %}
+  {% assign primary_contributor = page.person | first | default: page.author %}
   <script type="application/ld+json">
     {
       "@context": "https://schema.org",
@@ -76,7 +77,7 @@
       "datePublished": "{{ page.published_at }}",
       "author": {
         "@type": "Person",
-        "name": "{{ page.author.full_name }}"
+        "name": "{{ primary_contributor.name | default: primary_contributor.full_name }}"
       },
       "publisher": {
         "@type": "Organization",

--- a/_includes/_media-card.html
+++ b/_includes/_media-card.html
@@ -1,4 +1,3 @@
-{% assign author = site.authors | where: "name",item.author | first %}
 {% assign item = include.item %}
 {% assign album_url = item.album_url %}
 
@@ -49,17 +48,28 @@
         <a href="{{ item | media_url }}">{{ item.title }}</a>
       </h3>
 
-      {% if item.author %}
+      {% if item.person or item.author %}
       <p class="card-text soft-quarter-top">
-        {% if item.author.id %}
-        {% assign author = item.author | get_doc %}
-        <a class="text-gray-light font-size-smaller" href="{{ author.url }}">{{ author.full_name }}</a>
-        {% else %}
-        {% assign authors = item.author | get_docs %}
-        {% for author in authors %}
-        <a class="text-gray-light font-size-smaller" href="{{ author.url }}">{{ author.full_name }}</a>{% unless
+        {% if item.person %}
+        {% for contributor_ref in item.person %}
+        {% assign contributor_page = site.people | where: 'slug', contributor_ref.slug | first %}
+        {% assign contributor = contributor_page | default: contributor_ref %}
+        {% assign contributor_link = contributor_page.url %}
+        {% if contributor_link %}
+        <a class="text-gray-light font-size-smaller" href="{{ contributor_link }}">{{ contributor.name | default: contributor.full_name }}</a>{% else %}<span class="text-gray-light font-size-smaller">{{ contributor.name | default: contributor.full_name }}</span>{% endif %}{% unless
         forloop.last %}<span class="text-gray-light">&amp;</span>{% endunless %}
         {% endfor %}
+        {% else %}
+          {% if item.author.id %}
+          {% assign author = item.author | get_doc %}
+          <a class="text-gray-light font-size-smaller" href="{{ author.url }}">{{ author.full_name }}</a>
+          {% else %}
+          {% assign authors = item.author | get_docs %}
+          {% for author in authors %}
+          <a class="text-gray-light font-size-smaller" href="{{ author.url }}">{{ author.full_name }}</a>{% unless
+          forloop.last %}<span class="text-gray-light">&amp;</span>{% endunless %}
+          {% endfor %}
+          {% endif %}
         {% endif %}
       </p>
       {% endif %}

--- a/_includes/_overlay-card.html
+++ b/_includes/_overlay-card.html
@@ -44,7 +44,6 @@
   <div class="overlay-card-content">
     <p class="overlay-card-category">{{ item.category.title }}</p>
     <h2 class="overlay-card-title {% if include.title == 'h2' %}font-size-h2{% endif %}">{{ item.title | truncate: 60 }}</h2>
-    <p class="overlay-card-author">{{ item.author.full_name }}</p>
+    <p class="overlay-card-author">{% if item.person %}{{ item.person | map: 'name' | join: ', ' }}{% elsif item.author.id %}{{ item.author.full_name }}{% else %}{{ item.author | map: 'full_name' | join: ', ' }}{% endif %}</p>
   </div>
 </a>
-

--- a/_includes/_overlay-feature-card.html
+++ b/_includes/_overlay-feature-card.html
@@ -11,7 +11,7 @@
         <div class="overlay-feature-card-content">
           <p class="overlay-feature-card-category">{{ item.category.title }}</p>
           <h1 class="overlay-feature-card-title">{{ item.title | truncate: 55 }}</h1>
-          <p class="overlay-feature-card-author">{{ item.author | map: 'full_name' | join: ', ' }}</p>
+          <p class="overlay-feature-card-author">{% if item.person %}{{ item.person | map: 'name' | join: ', ' }}{% elsif item.author.id %}{{ item.author.full_name }}{% else %}{{ item.author | map: 'full_name' | join: ', ' }}{% endif %}</p>
         </div>
       </div>
     </div>

--- a/_includes/_video-card.html
+++ b/_includes/_video-card.html
@@ -32,9 +32,16 @@
         <h5 class="card-title font-size-smaller push-quarter-bottom">{{ video.title }}</h5>
         {% endif %}
         <div class="font-size-smaller push-quarter-top push-half-bottom">
-          {% for person in video.authors %}
-          {% assign video_author = site.authors | where: "name", person | first %}
-          <a class="text-gray" href="{{ video_author.url }}">{{ person }}</a>
+          {% assign contributors = video.person | default: video.author %}
+          {% for contributor_ref in contributors %}
+          {% assign contributor_page = site.people | where: 'slug', contributor_ref.slug | first %}
+          {% assign contributor = contributor_page | default: contributor_ref %}
+          {% assign contributor_link = contributor_page.url %}
+          {% if contributor_link %}
+          <a class="text-gray" href="{{ contributor_link }}">{{ contributor.name | default: contributor.full_name }}</a>
+          {% else %}
+          <span class="text-gray">{{ contributor.name | default: contributor.full_name }}</span>
+          {% endif %}
           {% unless forloop.last %}
           <span class="text-gray">&amp;</span>
           {% endunless %}

--- a/_includes/media-homepage/_author-card.html
+++ b/_includes/media-homepage/_author-card.html
@@ -1,16 +1,26 @@
-{% assign author_full_name = item.full_name | split: " " %}
+{% assign author_name = item.name | default: item.full_name %}
+{% assign author_bio = item.bio | default: item.summary %}
+{% assign author_page = site.people | where: 'slug', item.slug | first %}
+{% assign author_link = author_page.url %}
+{% assign author_full_name = author_name | split: " " %}
 
 <div class="push-half-top">
   <div class="flex-align-center">
     <div>
-      <img src="{{ item.image.url | imgix: site.imgix }}?{{ site.imgix_params.placeholder_square }}" class="img-circle img-size-5" sizes="{{ site.image_sizes.avatar }}" data-optimize-img>
+      {% if author_link %}
+        <a href="{{ author_link }}"><img src="{{ item.image.url | imgix: site.imgix }}?{{ site.imgix_params.placeholder_square }}" class="img-circle img-size-5" sizes="{{ site.image_sizes.avatar }}" data-optimize-img></a>
+      {% else %}
+        <img src="{{ item.image.url | imgix: site.imgix }}?{{ site.imgix_params.placeholder_square }}" class="img-circle img-size-5" sizes="{{ site.image_sizes.avatar }}" data-optimize-img>
+      {% endif %}
     </div>
     <div class="push-left">
       <p class="flush-bottom font-family-base-mid media-author-card-title">{{ author_full_name | join: "<br />" }}</p>
-      <a href="{{ item | media_url }}" class="font-family-base-mid font-size-smaller font-family-base-bold text-orange-dark">View articles</a>
+      {% if author_link %}
+        <a href="{{ author_link }}" class="font-family-base-mid font-size-smaller font-family-base-bold text-orange-dark">View articles</a>
+      {% endif %}
     </div>
   </div>
   <div class="push-half-top">
-    <p class="font-size-smaller">{{ item.summary | strip_html | truncate: 150 }}</p>
+    <p class="font-size-smaller">{{ author_bio | strip_html | truncate: 150 }}</p>
   </div>
 </div>

--- a/_layouts/article.html
+++ b/_layouts/article.html
@@ -3,7 +3,27 @@ layout: default_footer_flush
 title: Articles
 ---
 
-{% assign author = page.author | get_doc %}
+{% assign author_page = nil %}
+{% if page.person %}
+  {% for contributor_ref in page.person %}
+    {% assign matched_author_page = site.people | where: 'slug', contributor_ref.slug | first %}
+    {% if matched_author_page %}
+      {% assign author_page = matched_author_page %}
+      {% break %}
+    {% endif %}
+  {% endfor %}
+{% endif %}
+{% if author_page %}
+  {% assign author = author_page %}
+{% else %}
+  {% assign author = page.author | get_doc %}
+  {% assign author_page = author %}
+{% endif %}
+{% assign author_name = author.name | default: author.full_name %}
+{% assign author_bio = author.bio | default: author.summary %}
+{% assign author_link = author_page.url %}
+{% assign author_image = author.image | default: author_page.image %}
+{% assign author_social = author_page | default: author %}
 {% assign topic = page.category | get_doc %}
 {% assign tags = page.tags | get_doc %}
 
@@ -282,7 +302,7 @@ title: Articles
             <p class="overlay-card-category">{{ page.category.title }}</p>
             <h1 data-media-title="{{page.title}}" data-media-id="{{page.id}}"
               class="overlay-card-title overlay-card-heading">{{ page.title | truncate: 70 }}</h1>
-            <p class="overlay-card-author text-gray-light">{{ page.author.full_name }}</p>
+            <p class="overlay-card-author text-gray-light">{{ author_name }}</p>
             <div class="card-stamp text-white">
               {% if page.podcast_episode != null %}
               <span class="font-size-smallest soft-quarter-right">
@@ -329,12 +349,19 @@ title: Articles
         <div class="article-tpl-content article-tpl-author-section row row-no-gutters soft-ends">
           <div>
             <address class="article-tpl-author">
-              <a class="push-half-right" href="{{ author.url }}" data-author-link>
+              {% if author_link %}
+                <a class="push-half-right" href="{{ author_link }}" data-author-link>
+                  <img data-author-img
+                    src="{{ author_image.url | imgix: site.imgix }}?{{ site.imgix_params.placeholder_square }}"
+                    class="img-circle img-size-5" sizes="{{ site.image_sizes.avatar }}" alt="{{ author_name }}"
+                    data-optimize-img>
+                </a>
+              {% else %}
                 <img data-author-img
-                  src="{{ author.image.url | imgix: site.imgix }}?{{ site.imgix_params.placeholder_square }}"
-                  class="img-circle img-size-5" sizes="{{ site.image_sizes.avatar }}" alt="{{ author.full_name }}"
+                  src="{{ author_image.url | imgix: site.imgix }}?{{ site.imgix_params.placeholder_square }}"
+                  class="img-circle img-size-5 push-half-right" sizes="{{ site.image_sizes.avatar }}" alt="{{ author_name }}"
                   data-optimize-img>
-              </a>
+              {% endif %}
 
               <div>
                 <small class="font-size-smaller text-gray">
@@ -342,9 +369,13 @@ title: Articles
                 </small>
                 <br>
                 <h2 class="flush font-family-condensed-extra font-size-h4 text-gray-dark text-uppercase">
-                  <a href="{{ author.url }}" data-grouping-media-author="{{ author.full_name }}">
-                    {{ author.full_name }}
-                  </a>
+                  {% if author_link %}
+                    <a href="{{ author_link }}" data-grouping-media-author="{{ author_name }}">
+                      {{ author_name }}
+                    </a>
+                  {% else %}
+                    <span data-grouping-media-author="{{ author_name }}">{{ author_name }}</span>
+                  {% endif %}
                 </h2>
               </div>
             </address>
@@ -354,10 +385,10 @@ title: Articles
               {% if page.title == "Preview" %}
               <p data-author-bio></p>
               {% else %}
-              <p class="font-size-smaller">{{ author.summary | markdownify }}</p>
+              <p class="font-size-smaller">{{ author_bio | markdownify }}</p>
               {% endif %}
               <div>
-                {% include _author-social.html %}
+                {% include _author-social.html author=author_social %}
               </div>
             </div>
           </div>
@@ -458,15 +489,27 @@ title: Articles
           {% assign featured_authors = media_featured_authors.entries %}
           {% for content in featured_authors limit: 6 %}
           {% assign item = content | get_doc %}
+          {% assign item_author_page = site.people | where: 'slug', item.slug | first %}
+          {% assign item_author_link = item_author_page.url %}
           <div class="col-md-2 carousel-cell">
             <div class="d-flex flex-align-center flex-column justify-content-center push-half-top">
-              <a href="{{ item | media_url }}">
+              {% if item_author_link %}
+                <a href="{{ item_author_link }}">
+                  <img src="{{ item.image.url | imgix: site.imgix }}?auto=format,compress&w=140&h=140&fit=crop"
+                    alt="{{ item.name | default: item.full_name }}" class="img-circle" width="140px">
+                </a>
+              {% else %}
                 <img src="{{ item.image.url | imgix: site.imgix }}?auto=format,compress&w=140&h=140&fit=crop"
-                  alt="{{ author_full_name }}" class="img-circle" width="140px">
-              </a>
+                  alt="{{ item.name | default: item.full_name }}" class="img-circle" width="140px">
+              {% endif %}
               <div class="push-half-top text-center">
-                <a href="{{ item | media_url }}" class="text-blue font-family-base-bold font-size-smaller">{{
-                  item.full_name }}</a>
+                {% if item_author_link %}
+                  <a href="{{ item_author_link }}" class="text-blue font-family-base-bold font-size-smaller">{{
+                    item.name | default: item.full_name }}</a>
+                {% else %}
+                  <span class="text-blue font-family-base-bold font-size-smaller">{{
+                    item.name | default: item.full_name }}</span>
+                {% endif %}
               </div>
             </div>
           </div>

--- a/_layouts/author.html
+++ b/_layouts/author.html
@@ -16,11 +16,89 @@ layout: default
 
 						{% assign featured = "" | split: "" %}
  
-							
-      {% assign articles = site.articles | filter: 'author.full_name', author.full_name | sort: 'date' | reverse %}
-      {% assign videos = site.videos | filter: 'author.full_name', author.full_name | reverse %}
-      {% assign messages = site.messages | filter: 'author.full_name', author.full_name | reverse %}
-      {% assign podcasts = site.podcasts | filter: 'author.full_name', author.full_name | reverse %}
+      {% assign articles = "" | split: "" %}
+      {% for item in site.articles %}
+        {% assign matches_author = false %}
+        {% if item.person %}
+          {% for contributor in item.person %}
+            {% if contributor.slug == author.slug %}
+              {% assign matches_author = true %}
+            {% endif %}
+          {% endfor %}
+        {% elsif item.author and item.author.slug == author.slug %}
+          {% assign matches_author = true %}
+        {% endif %}
+        {% if matches_author %}
+          {% assign articles = articles | push: item %}
+        {% endif %}
+      {% endfor %}
+      {% assign articles = articles | sort: 'date' | reverse %}
+
+      {% assign videos = "" | split: "" %}
+      {% for item in site.videos %}
+        {% assign matches_author = false %}
+        {% if item.person %}
+          {% for contributor in item.person %}
+            {% if contributor.slug == author.slug %}
+              {% assign matches_author = true %}
+            {% endif %}
+          {% endfor %}
+        {% elsif item.author %}
+          {% for contributor in item.author %}
+            {% if contributor.slug == author.slug %}
+              {% assign matches_author = true %}
+            {% endif %}
+          {% endfor %}
+        {% endif %}
+        {% if matches_author %}
+          {% assign videos = videos | push: item %}
+        {% endif %}
+      {% endfor %}
+      {% assign videos = videos | reverse %}
+
+      {% assign messages = "" | split: "" %}
+      {% for item in site.messages %}
+        {% assign matches_author = false %}
+        {% if item.person %}
+          {% for contributor in item.person %}
+            {% if contributor.slug == author.slug %}
+              {% assign matches_author = true %}
+            {% endif %}
+          {% endfor %}
+        {% elsif item.author %}
+          {% for contributor in item.author %}
+            {% if contributor.slug == author.slug %}
+              {% assign matches_author = true %}
+            {% endif %}
+          {% endfor %}
+        {% endif %}
+        {% if matches_author %}
+          {% assign messages = messages | push: item %}
+        {% endif %}
+      {% endfor %}
+      {% assign messages = messages | reverse %}
+
+      {% assign podcasts = "" | split: "" %}
+      {% for item in site.podcasts %}
+        {% assign matches_author = false %}
+        {% if item.person %}
+          {% for contributor in item.person %}
+            {% if contributor.slug == author.slug %}
+              {% assign matches_author = true %}
+            {% endif %}
+          {% endfor %}
+        {% elsif item.author %}
+          {% for contributor in item.author %}
+            {% if contributor.slug == author.slug %}
+              {% assign matches_author = true %}
+            {% endif %}
+          {% endfor %}
+        {% endif %}
+        {% if matches_author %}
+          {% assign podcasts = podcasts | push: item %}
+        {% endif %}
+      {% endfor %}
+      {% assign podcasts = podcasts | reverse %}
  
 
 					
@@ -29,21 +107,17 @@ layout: default
 
 
 						{% for item in articles %}
-							{% if item.featured_to_author %}
-									{% if item.featured_to_author.id == item.author.id %}
-											{% assign featured = featured | push: item %}
-									{% endif %}
+							{% if item.featured_to_author and item.featured_to_author.slug == author.slug %}
+								{% assign featured = featured | push: item %}
 							{% endif %}
 						{% endfor %}
 					
 						{% for item in all_items %}
 								{% if item.featured_to_author %}
 										{% for fta in item.featured_to_author %}
-												{% for item_author in item.author %}
-														{% if fta.id == item_author.id %}
-																{% assign featured = featured | push: item %}
-														{% endif %}
-												{% endfor %}
+												{% if fta.slug == author.slug %}
+													{% assign featured = featured | push: item %}
+												{% endif %}
 										{% endfor %}
 								{% endif %}
 						{% endfor %}
@@ -254,4 +328,3 @@ layout: default
    </div>
   </div>
 </section>
-

--- a/_layouts/episode.html
+++ b/_layouts/episode.html
@@ -53,13 +53,19 @@ layout: default
 
     <div class="row push-bottom soft-bottom">
       <div class="col-sm-8 col-sm-offset-2">
-        {% for author_obj in podcast.author %}
-          {% assign author = site.authors | where: 'full_name', author_obj.full_name | first %}
-          {% if author %}
-            {% if forloop.first %}<p class="push-ends">Hosted by {% endif %}
-              <a href="{{ author.url }}" data-grouping-media-author="{{ author.full_name | titleize }}">{{ author.full_name | titleize }}</a> {% if forloop.last == false %} and {% endif %}
-            {% if forloop.last %}</p>{% endif %}
-          {% endif %}
+        {% assign contributors = podcast.person | default: podcast.author %}
+        {% for contributor_ref in contributors %}
+          {% assign contributor_page = site.people | where: 'slug', contributor_ref.slug | first %}
+          {% assign contributor = contributor_page | default: contributor_ref %}
+          {% assign contributor_name = contributor.name | default: contributor.full_name %}
+          {% assign contributor_link = contributor_page.url %}
+          {% if forloop.first %}<p class="push-ends">Hosted by {% endif %}
+            {% if contributor_link %}
+              <a href="{{ contributor_link }}" data-grouping-media-author="{{ contributor_name | titleize }}">{{ contributor_name | titleize }}</a>
+            {% else %}
+              <span data-grouping-media-author="{{ contributor_name | titleize }}">{{ contributor_name | titleize }}</span>
+            {% endif %} {% if forloop.last == false %} and {% endif %}
+          {% if forloop.last %}</p>{% endif %}
         {% endfor %}
 
         <p>{{ page.published_at | format_date }} {% if page.duration != nil %} <span class="divider push-quarter-sides">•</span> {% include _read-time.html duration=page.duration content_type='episode' %} {% endif %}</p>

--- a/_layouts/podcast.html
+++ b/_layouts/podcast.html
@@ -93,13 +93,19 @@ title: Podcast
     <div class="row">
       <div class="col-sm-8 col-sm-offset-2">
         <div>{{ page.description | markdownify }}</div>
-        {% for author_obj in page.author %}
-          {% assign author = site.authors | where: 'full_name', author_obj.full_name | first %}
-          {% if author %}
-            {% if forloop.first %}<p class="push-ends">Hosted by {% endif %}
-              <a href="{{ author.url }}" data-grouping-media-author="{{ author.full_name | titleize }}">{{ author.full_name | titleize }}</a> {% if forloop.last == false %} and {% endif %}
-            {% if forloop.last %}</p>{% endif %}
-          {% endif %}
+        {% assign contributors = page.person | default: page.author %}
+        {% for contributor_ref in contributors %}
+          {% assign contributor_page = site.people | where: 'slug', contributor_ref.slug | first %}
+          {% assign contributor = contributor_page | default: contributor_ref %}
+          {% assign contributor_name = contributor.name | default: contributor.full_name %}
+          {% assign contributor_link = contributor_page.url %}
+          {% if forloop.first %}<p class="push-ends">Hosted by {% endif %}
+            {% if contributor_link %}
+              <a href="{{ contributor_link }}" data-grouping-media-author="{{ contributor_name | titleize }}">{{ contributor_name | titleize }}</a>
+            {% else %}
+              <span data-grouping-media-author="{{ contributor_name | titleize }}">{{ contributor_name | titleize }}</span>
+            {% endif %} {% if forloop.last == false %} and {% endif %}
+          {% if forloop.last %}</p>{% endif %}
         {% endfor%}
       </div>
     </div>

--- a/_layouts/topic.html
+++ b/_layouts/topic.html
@@ -51,12 +51,15 @@ layout: default
           <div class="topic soft-quarter-top">{{ page.title }}</div>
           <h3 class="title flush-ends">{{ item.title }}</h3>
           <div class="credit">
-            {% if item.author %}
-            {% assign author = item.author | get_doc %}
-            {{ author.full_name }}
-            {% elsif item.authors %}
-            {% assign authors = item.author | get_docs %}
-            {{ authors | map:'full_name' | join:', ' }}
+            {% if item.person %}
+            {{ item.person | map:'name' | join:', ' }}
+            {% elsif item.author %}
+              {% if item.author.id %}
+              {% assign author = item.author | get_doc %}
+              {{ author.full_name }}
+              {% else %}
+              {{ item.author | map:'full_name' | join:', ' }}
+              {% endif %}
             {% endif %}
           </div>
         </div>
@@ -112,12 +115,15 @@ layout: default
           </div>
 
           <p class="credit">
-            {% if item.author %}
-            {% assign author = item.author | get_doc %}
-            {{ author.full_name }}
-            {% elsif item.authors %}
-            {% assign authors = item.author | get_docs %}
-            {{ authors | map:'full_name' | join:', ' }}
+            {% if item.person %}
+            {{ item.person | map:'name' | join:', ' }}
+            {% elsif item.author %}
+              {% if item.author.id %}
+              {% assign author = item.author | get_doc %}
+              {{ author.full_name }}
+              {% else %}
+              {{ item.author | map:'full_name' | join:', ' }}
+              {% endif %}
             {% endif %}
           </p>
         </div>
@@ -145,12 +151,15 @@ layout: default
             {{ item | content | markdownify | strip_html | truncate: 125 }}
           </div>
           <div class="credit">
-            {% if item.author %}
-            {% assign author = item.author | get_doc %}
-            {{ author.full_name }}
-            {% elsif item.authors %}
-            {% assign authors = item.author | get_docs %}
-            {{ authors | map: 'full_name' | join: ', ' }}
+            {% if item.person %}
+            {{ item.person | map:'name' | join:', ' }}
+            {% elsif item.author %}
+              {% if item.author.id %}
+              {% assign author = item.author | get_doc %}
+              {{ author.full_name }}
+              {% else %}
+              {{ item.author | map:'full_name' | join:', ' }}
+              {% endif %}
             {% endif %}
           </div>
         </div>

--- a/_plugins/filters/jsonify_message.rb
+++ b/_plugins/filters/jsonify_message.rb
@@ -14,6 +14,7 @@ module Jekyll
             category: m["category"],
             title: m["title"].truncate(55),
             author: m["author"],
+            person: m["person"],
             duration: m["duration"],
             image: m["image"],
             podcast: m["podcast"],

--- a/_plugins/generators/public_people_generator.rb
+++ b/_plugins/generators/public_people_generator.rb
@@ -1,0 +1,20 @@
+module Jekyll
+  class PublicPeopleGenerator < Generator
+    priority :highest
+
+    def generate(site)
+      people = site.collections['people']&.docs || []
+      return if people.empty?
+
+      site.collections['people'].docs.select! do |person|
+        author_like_person?(person)
+      end
+    end
+
+    private
+
+    def author_like_person?(person)
+      Array(person.data['roles']).compact.include?('Author')
+    end
+  end
+end

--- a/media/authors.html
+++ b/media/authors.html
@@ -2,11 +2,11 @@
 layout: default
 snail_trail: media
 title: Authors
+permalink: /media/authors/index.html
 paginate:
-  authors:
+  people:
     per: 8
 ---
-
 <div class="container">
   <ol class="breadcrumb hard-sides push-top">
     <li><a href="/media">Media</a></li>
@@ -17,24 +17,20 @@ paginate:
   <div data-card-deck class="card-deck">
     <div class="cards-4x">
       <div class="row">
-      {% for author in page.authors.docs %}
+      {% for person in page.people.docs %}
         <div class="card">
-          <a href="{{ author.url }}">
-            <img class="card-img-top img-responsive" src="{{ author.image.url | imgix: site.imgix }}?{{ site.imgix_params.placeholder_card_face }}" sizes="{{ site.image_sizes.podcast_thumb }}" data-optimize-img>
+          <a href="{{ person.url }}">
+            <img class="card-img-top img-responsive" src="{{ person.image.url | imgix: site.imgix }}?{{ site.imgix_params.placeholder_card_face }}" sizes="{{ site.image_sizes.podcast_thumb }}" data-optimize-img>
           </a>
           <div class="card-block">
-            <a href="{{ author.url }}">
-              <h4 class="card-title card-title--overlap text-uppercase">{{ author.full_name }}</h4>
+            <a href="{{ person.url }}">
+              <h4 class="card-title card-title--overlap text-uppercase">{{ person.name | default: person.full_name }}</h4>
             </a>
-
-            <h5 class="card-subtitle">{% include _count.html collection=site.articles key="author" subject=author label="article" %}</h5>
-            <h5 class="card-subtitle">{% include _count.html collection=site.podcasts key="authors" subject=author label="podcast" %}</h5>
-            <h5 class="card-subtitle">{% include _count.html collection=site.videos key="authors" subject=author label="video" %}</h5>
           </div>
         </div>
       {% endfor %}
       </div>
     </div>
   </div>
-  {% include _pagination.html collection="authors" link_root="authors" %}
+  {% include _pagination.html collection="people" link_root="authors" %}
 </div>

--- a/media/next-level-academy.html
+++ b/media/next-level-academy.html
@@ -110,11 +110,20 @@ snail_trail: disabled
     <div class="teaching-pastors-grid">
       {% for pastor in teaching_pastors %}
         {% assign item = pastor | get_doc %}
+        {% assign pastor_page = site.people | where: 'slug', item.slug | first %}
+        {% assign pastor_link = pastor_page.url %}
         <div>
-          <a class="shows-pastors-card text-center" href="{{ item | media_url }}">
-            <div class="shows-pastors-card-img" style="background-image: url('{{ item.image.url | imgix: site.imgix }}?w=228&h=228&crop=bottom,center&fit=crop');"></div>
-            <p class="font-family-condensed-extra font-size-h4 text-uppercase push-top text-white">{{ item.full_name }}</p>
-          </a>
+          {% if pastor_link %}
+            <a class="shows-pastors-card text-center" href="{{ pastor_link }}">
+              <div class="shows-pastors-card-img" style="background-image: url('{{ item.image.url | imgix: site.imgix }}?w=228&h=228&crop=bottom,center&fit=crop');"></div>
+              <p class="font-family-condensed-extra font-size-h4 text-uppercase push-top text-white">{{ item.name | default: item.full_name }}</p>
+            </a>
+          {% else %}
+            <div class="shows-pastors-card text-center">
+              <div class="shows-pastors-card-img" style="background-image: url('{{ item.image.url | imgix: site.imgix }}?w=228&h=228&crop=bottom,center&fit=crop');"></div>
+              <p class="font-family-condensed-extra font-size-h4 text-uppercase push-top text-white">{{ item.name | default: item.full_name }}</p>
+            </div>
+          {% endif %}
         </div>
       {% endfor %}
     </div>

--- a/media/shows.html
+++ b/media/shows.html
@@ -110,11 +110,20 @@ snail_trail: disabled
     <div class="row">
       {% for pastor in teaching_pastors %}
         {% assign item = pastor | get_doc %}
+        {% assign pastor_page = site.people | where: 'slug', item.slug | first %}
+        {% assign pastor_link = pastor_page.url %}
         <div class="col-sm-6 col-md-3">
-          <a class="shows-pastors-card text-center" href="{{ item | media_url }}">
-            <div class="shows-pastors-card-img" style="background-image: url('{{ item.image.url | imgix: site.imgix }}?w=228&h=228&crop=bottom,center&fit=crop');"></div>
-            <p class="font-family-condensed-extra font-size-h4 text-uppercase push-top text-white">{{ item.full_name }}</p>
-          </a>
+          {% if pastor_link %}
+            <a class="shows-pastors-card text-center" href="{{ pastor_link }}">
+              <div class="shows-pastors-card-img" style="background-image: url('{{ item.image.url | imgix: site.imgix }}?w=228&h=228&crop=bottom,center&fit=crop');"></div>
+              <p class="font-family-condensed-extra font-size-h4 text-uppercase push-top text-white">{{ item.name | default: item.full_name }}</p>
+            </a>
+          {% else %}
+            <div class="shows-pastors-card text-center">
+              <div class="shows-pastors-card-img" style="background-image: url('{{ item.image.url | imgix: site.imgix }}?w=228&h=228&crop=bottom,center&fit=crop');"></div>
+              <p class="font-family-condensed-extra font-size-h4 text-uppercase push-top text-white">{{ item.name | default: item.full_name }}</p>
+            </div>
+          {% endif %}
         </div>
       {% endfor %}
     </div>


### PR DESCRIPTION
## Task
[[Publishing] Person model implementation](https://app.asana.com/1/37330734394864/project/1201454665996628/task/1211826374181315?focus=true)

## Overview

This PR updates `crds-net` to support the Author -> Person model migration while keeping existing author pages, URLs, and media behavior intact.

The main changes in this PR:
- Generate author resources from `Person` entries with `roles: Author`
- Keep public author URLs author-shaped rather than introducing `/people` resources
- Update media/page surfaces to use person-backed author data where needed
- Update serialized player/preview payloads to include person-compatible data without breaking legacy behavior

## Why

`crds-net` still serves a number of legacy media and author-facing surfaces. This PR prepares those surfaces for the Person model migration while preserving the current public contract:
- author pages remain author pages
- author URLs remain `/media/authors/:slug`
- person data becomes the underlying source

## Tester Notes
Suggested validation URLs:
- [Author index](https://deploy-preview-3541--crds-jekyll.netlify.app/media/authors/)
- [Alli Patterson author page](https://deploy-preview-3541--crds-jekyll.netlify.app/media/authors/alli-patterson)
- [Article example](https://deploy-preview-3541--crds-jekyll.netlify.app/media/podcasts/audio-articles/what-are-spiritual-gifts-by-alli-patterson)
- [Video example](https://deploy-preview-3541--crds-jekyll.netlify.app/media/videos/get-to-know-alli)
- [Message example](https://deploy-preview-3541--crds-jekyll.netlify.app/media/series/spark-2017/steven-manuel-and-alli-patterson)
- [Podcast/episode example](https://deploy-preview-3541--crds-jekyll.netlify.app/media/podcasts/still-standing/how-to-build-a-rock-solid-life-with-alli-patterson)

What to verify:
- Author index and author detail pages still render and resolve correctly
- Only person entries with `roles: Author` appear in author surfaces
- Message detail pages still render correctly
- Video detail pages still render correctly
- Article pages with contributor/byline data still render correctly
- Media/article bylines still render correctly
- Author links still go to `/media/authors/:slug`
- No new `/people` routes or semantics have been introduced
- Bitmovin/player payloads still render without regression
- Any real legacy author redirects that are still expected to work still resolve correctly

## Callouts / Things To Know

- This PR intentionally does not introduce new `/people` pages or speculative people redirects
- We removed speculative redirects and kept the redirect layer focused on real author-facing behavior
- Player/preview payloads are additive so the legacy runtime can continue working during transition

## Blockers / Follow-Up

- Content parity is still important here, especially for authors that do not yet have correct linked Person data
- If we want to validate Weekend/Video/other linked-person scenarios fully, some manual content setup may still be needed before migration re-run
- `crds-components` is not being treated as a launch blocker for this migration, so this PR assumes the current transitional payload strategy remains in place

## Deploy Preview
[https://deploy-preview-3541--crds-jekyll.netlify.app](https://deploy-preview-3541--crds-jekyll.netlify.app)
