### PR TITLE
Trigger global search sync after static indexing

### DIFF
--- a/_plugins/hooks/index_static_pages.rb
+++ b/_plugins/hooks/index_static_pages.rb
@@ -4,6 +4,8 @@ require 'json'
 require 'securerandom'
 require 'algolia'
 require 'time'
+require 'net/http'
+require 'uri'
 
 module ObjectIDGenerator
   CHARS = '0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz'.chars.freeze
@@ -19,6 +21,33 @@ module ObjectIDGenerator
     end
     encoded
   end
+end
+
+def invoke_global_search_sync(source:, env:)
+  sync_token = ENV['GLOBAL_SEARCH_SYNC_TOKEN']
+
+  if sync_token.nil? || sync_token.strip.empty?
+    puts "[global-search-trigger] skipped because GLOBAL_SEARCH_SYNC_TOKEN is missing"
+    return
+  end
+
+  search_domain = env == 'demo' ? 'https://demo.crossroads.net' : 'https://www.crossroads.net'
+  sync_url = "#{search_domain.sub(%r{/$}, '')}/.netlify/functions/sync-global-search-background"
+  uri = URI.parse(sync_url)
+  params = URI.decode_www_form(String(uri.query))
+  params << ['env', env]
+  params << ['slice', 'crds_net_static']
+  params << ['applySettings', 'false']
+  uri.query = URI.encode_www_form(params)
+
+  request = Net::HTTP::Post.new(uri)
+  request['x-global-search-sync-token'] = sync_token
+
+  response = Net::HTTP.start(uri.hostname, uri.port, use_ssl: uri.scheme == 'https') do |http|
+    http.request(request)
+  end
+
+  puts "[global-search-trigger] source=#{source} env=#{env} status=#{response.code}"
 end
 
 # Copy static pages to the _site_static directory
@@ -68,6 +97,7 @@ Jekyll::Hooks.register :site, :post_write do |site|
   records = []
   current_date = Time.now.strftime("%B %d, %Y")
   current_timestamp = Time.parse(current_date).to_i
+  resolved_env = ENV['CRDS_ENV'] == 'demo' ? 'demo' : 'prod'
 
   html_files.each do |file_path|
     doc = Nokogiri::HTML(File.read(file_path))
@@ -86,8 +116,7 @@ Jekyll::Hooks.register :site, :post_write do |site|
 
     description = doc.at('meta[name="description"]')&.attr('content') || ""
 
-    domain_env = ENV['CRDS_ENV']
-    domain = domain_env == 'demo' ? 'demo.crossroads.net' : 'www.crossroads.net'
+    domain = resolved_env == 'demo' ? 'demo.crossroads.net' : 'www.crossroads.net'
 
     # Get the permalink if available, otherwise use the slug
     permalink = doc.at('meta[name="permalink"]')&.attr('content')
@@ -137,6 +166,11 @@ Jekyll::Hooks.register :site, :post_write do |site|
     index.save_objects(records)
 
     puts "Successfully indexed #{records.size} records to Algolia index '#{algolia_index_name}'."
+    begin
+      invoke_global_search_sync(source: 'static', env: resolved_env)
+    rescue StandardError => callback_error
+      puts "[global-search-trigger:error] source=static env=#{resolved_env} message=#{callback_error.message}"
+    end
   rescue StandardError => e
     puts "Error during indexing: #{e.message}"
   end


### PR DESCRIPTION
## Problem
`crds-net` still indexes legacy static pages into the child Algolia static index (`demo_crds_net_static` / `crds_net_static`), but that work did not trigger a rebuild of the blended global search index afterward.

That meant static-page updates could be present in the child index while still being stale or missing in `global_search_demo` / `global_search_prod`.

## Solution
After static-page indexing completes in `crds-net`, this change sends a follow-up request to `sync-global-search-background` in `crds-unified` with:

- `slice=crds_net_static`
- `applySettings=false`
- the current resolved environment (`demo` or `prod`)

This keeps the existing static indexing behavior in place, but adds the missing handoff so the global search index can rebuild from the updated static slice.

### Corresponding Branches
Related search rollout work also exists in:
- `crds-unified` on `prod/global-search-indexing`
- `crds-unified-components` on `prod/global-search-modal`

## Testing
Validate this change from the `crds-net` deploy/build logs.

### What to verify in the build log
Look for the static indexing hook output in this order:

- `Copied: ... -> _site_static/... for static page indexing`
- `Copying settings from 'crds_settings' to 'demo_crds_net_static'...`
- `Successfully copied settings from 'crds_settings' to 'demo_crds_net_static'`
- `Successfully indexed 11 records to Algolia index 'demo_crds_net_static'.`
- `[global-search-trigger] source=static env=demo status=...`

### What has already been validated
A deploy preview built from commit `dc9a10b` showed:

- 11 static pages were copied into `_site_static`
- settings were copied from `crds_settings` to `demo_crds_net_static`
- 11 records were successfully indexed into `demo_crds_net_static`
- the new global search callback executed

### Current known gap
That same deploy log returned:

- `[global-search-trigger] source=static env=demo status=404`

This means:

- child static indexing is working
- the new callback is being attempted
- the receiving `sync-global-search-background` endpoint was not available on stable demo for that build

### QA expectation for this PR
For this PR specifically, the important validation is:

- `crds-net` still successfully builds and indexes static records
- the new callback is attempted after indexing
- no static indexing regression was introduced

### Follow-up validation after `crds-unified` is live on demo
Once `sync-global-search-background` is available on stable demo, rerun a `crds-net` build and confirm:

- the callback log changes from `404` to `200` or `202`
- a known static page such as `About Us`, `What We Believe`, or `Seven Hills` exists in `demo_crds_net_static`
- that same page is then searchable in `global_search_demo`
