### PR TITLE
Student Ministry & Young Adult video filter

### DIFF
--- a/_plugins/generators/series_video_flags.rb
+++ b/_plugins/generators/series_video_flags.rb
@@ -1,5 +1,7 @@
 module GetSeriesVideoFlags
   class Generator < Jekyll::Generator
+    priority :high
+
     def generate(site)
       videos = site.collections['videos'].docs
       series_entries = site.collections['series'].docs

--- a/_plugins/generators/series_video_flags.rb
+++ b/_plugins/generators/series_video_flags.rb
@@ -5,6 +5,9 @@ module GetSeriesVideoFlags
       series_entries = site.collections['series'].docs
 
       videos.each do |video|
+        video.data['is_student_ministry_series_video'] = false
+        video.data['is_young_adult_series_video'] = false
+
         series_id = video.data.dig('series', 'id')
         next unless series_id.present?
 

--- a/_plugins/generators/series_video_flags.rb
+++ b/_plugins/generators/series_video_flags.rb
@@ -7,6 +7,7 @@ module GetSeriesVideoFlags
       videos.each do |video|
         video.data['is_student_ministry_series_video'] = false
         video.data['is_young_adult_series_video'] = false
+        video.data['ministry_series_type'] = 'standard'
 
         series_id = video.data.dig('series', 'id')
         next unless series_id.present?
@@ -16,6 +17,8 @@ module GetSeriesVideoFlags
 
         video.data['is_student_ministry_series_video'] = series.data['is_student_ministry_series']
         video.data['is_young_adult_series_video'] = series.data['is_young_adult_series']
+        video.data['ministry_series_type'] = 'student_ministry' if series.data['is_student_ministry_series']
+        video.data['ministry_series_type'] = 'young_adult' if series.data['is_young_adult_series']
       end
     end
   end

--- a/media/videos.html
+++ b/media/videos.html
@@ -8,8 +8,7 @@ paginate:
     per: 8
     sort: date desc
     where:
-      is_student_ministry_series_video: false
-      is_young_adult_series_video: false
+      ministry_series_type: standard
 ---
 
 <div class="container">

--- a/media/videos.html
+++ b/media/videos.html
@@ -7,6 +7,9 @@ paginate:
     offset: 2
     per: 8
     sort: date desc
+    where:
+      is_student_ministry_series_video: false
+      is_young_adult_series_video: false
 ---
 
 <div class="container">


### PR DESCRIPTION
## Problem

[Asana Task](https://app.asana.com/1/37330734394864/project/1201625621694614/task/1215681196996608?focus=true)
Student Ministry & Young Adult videos are being moved to their own section in `/media/` and are excluded from the `/media/video/<slug>` build. This update removes them from rendering on the `/media/videos` landing page.

## Solution
- Filter out student ministry & young adult videos from the Videos landing page.

### Corresponding Branch
https://github.com/crdschurch/crds-unified/pull/3114

## Testing
[Deploy Preview](https://deploy-preview-3549--crds-jekyll.netlify.app/media/videos/)
The 'recent' tab now excludes Student Ministry & Young Adult videos.