### PR TITLE
Check env in weekend discussion generator

### DIFF
--- a/_plugins/generators/the_chaser_generator.rb
+++ b/_plugins/generators/the_chaser_generator.rb
@@ -16,7 +16,8 @@ module Jekyll
       def client
         @client ||= ::Contentful::Client.new(
           space: ENV['CONTENTFUL_SPACE_ID'],
-          access_token: ENV['CONTENTFUL_ACCESS_TOKEN']
+          access_token: ENV['CONTENTFUL_ACCESS_TOKEN'],
+          environment: ENV['CONTENTFUL_ENV'] || 'master'
         )
       end
 


### PR DESCRIPTION
## Problem
On demo, `/weekendfollowup` could render an empty discussion questions block because the page content was being loaded from demo, but the chaser lookup was still pulling the “latest discussion” from master. That mismatch meant the page could look for a discussion that didn’t exist in the current environment.

## Solution
This updates the weekend follow-up chaser generator to use the current `CONTENTFUL_ENV` instead of always falling back to Contentful master.

## Testing
https://deploy-preview-3553--demo-crds-jekyll.netlify.app/weekendfollowup/
Confirm the discussion questions section is populated instead of rendering as an empty box.