### PR TITLE
Fix View Question button on /weekendfollowup

### DIFF
--- a/media/weekend-follow-up.html
+++ b/media/weekend-follow-up.html
@@ -58,6 +58,12 @@ permalink: /weekendfollowup/
 </section>
 
 <style>
+  html {
+    scroll-behavior: smooth;
+  }
+  #questions {
+    scroll-margin-top: 50px;
+  }
   .jumbotron-image {
     object-fit: cover;
     width: 100%;

--- a/media/weekend-follow-up.html
+++ b/media/weekend-follow-up.html
@@ -39,7 +39,7 @@ permalink: /weekendfollowup/
         For the Weekend of {{ site.chaser_message.date | date: '%B %-d, %Y' }}
       </p>
       {% endif %}
-      <div class="push-bottom">
+      <div class="push-bottom" {% unless site.chaser_message %}id="questions"{% endunless %}>
 
         {% include _discussion-questions.html type='chaser' discussion=discussion %}
 


### PR DESCRIPTION
## Problem

Currently on `/weekendfollowup`, clicking on "View This Week's Question" results in nothing happening because the id being referenced is wrapped in an if statement and only accessible if `site.chaser_message` exists.

## Solution

Add an unless statement to the next div so if `site.chaser_message` doesn't exist, the button links to the discussion questions still and jumps down to that div.

## Testing

1. View the deploy preview and navigate to `/weekendfollowup`
2. Confirm clicking on "View This Week's Questions" jumps down to the discussion questions section.
3. Confirm in both desktop and mobile.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1216360152835294