### PR TITLE
Update image on history page

### DIFF
--- a/history.html
+++ b/history.html
@@ -562,7 +562,7 @@ static: true
         data-sal="fade"
         data-sal-easing="ease-in-out-cubic"
       >
-        <img src="https://images.ctfassets.net/y3a9myzsdjan/3gtz9X4KJEcyBM7OV7fwT9/4f5bb41d577522c64521754e7bf0d12c/25th-Aniv-Map-min-2.png" class="img-responsive mobile-soft-top" alt="crossroads multiple church locations map" title="crossroads multiple church locations map" loading="lazy" data-optimize-img>
+        <img src="//crds-media.imgix.net/y3a9myzsdjan/3gtz9X4KJEcyBM7OV7fwT9/4f5bb41d577522c64521754e7bf0d12c/25th-Aniv-Map-min-2.png" class="img-responsive mobile-soft-top" alt="crossroads multiple church locations map" title="crossroads multiple church locations map" loading="lazy" data-optimize-img>
       </div>
     </div>
 

--- a/history.html
+++ b/history.html
@@ -562,7 +562,7 @@ static: true
         data-sal="fade"
         data-sal-easing="ease-in-out-cubic"
       >
-        <img src="//crds-media.imgix.net/4kcZ0znf2j8xrdKnABgn1s/327f56ea72eb4900d5de62bb6416badf/25thAniv_Map-min__1_.png?auto=format,compress&w=800" class="img-responsive mobile-soft-top" alt="crossroads multiple church locations map" title="crossroads multiple church locations map" loading="lazy" data-optimize-img>
+        <img src="https://images.ctfassets.net/y3a9myzsdjan/3gtz9X4KJEcyBM7OV7fwT9/4f5bb41d577522c64521754e7bf0d12c/25th-Aniv-Map-min-2.png" class="img-responsive mobile-soft-top" alt="crossroads multiple church locations map" title="crossroads multiple church locations map" loading="lazy" data-optimize-img>
       </div>
     </div>
 

--- a/history.html
+++ b/history.html
@@ -562,7 +562,7 @@ static: true
         data-sal="fade"
         data-sal-easing="ease-in-out-cubic"
       >
-        <img src="//crds-media.imgix.net/y3a9myzsdjan/3gtz9X4KJEcyBM7OV7fwT9/4f5bb41d577522c64521754e7bf0d12c/25th-Aniv-Map-min-2.png" class="img-responsive mobile-soft-top" alt="crossroads multiple church locations map" title="crossroads multiple church locations map" loading="lazy" data-optimize-img>
+        <img src="//crds-media.imgix.net/y3a9myzsdjan/3gtz9X4KJEcyBM7OV7fwT9/4f5bb41d577522c64521754e7bf0d12c/25th-Aniv-Map-min-2.png?auto=format,compress&w=800" class="img-responsive mobile-soft-top" alt="crossroads multiple church locations map" title="crossroads multiple church locations map" loading="lazy" data-optimize-img>
       </div>
     </div>
 


### PR DESCRIPTION
## Problem

Studio Request to update an image on /history:

<img width="1294" height="66" alt="Screenshot 2026-07-14 at 10 03 44 AM" src="https://github.com/user-attachments/assets/1b85491c-6bf5-4dee-9009-1de2e7c14e44" />

## Solution


Replace image source

### Corresponding Branch

## Testing

1. View /history page and scroll down to "If God is Using It..."
2. Verify new image is being displayed (the new image should **not** have a dot for Georgetown)