### PR TITLE
Support KC resources in legacy series

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -64,6 +64,8 @@ collections:
   humans_of_crossroads:
     output: true
     permalink: /media/humans-of-crossroads/:slug
+  kcResources:
+    output: false
   authors:
     output: false
     permalink: /media/:collection/:title

--- a/_includes/_message-card.html
+++ b/_includes/_message-card.html
@@ -4,8 +4,14 @@
   {% assign image = page.image.url %}
 {% endif %}
 
+{% if item.content_type == 'kcResource' %}
+  {% assign item_url = '/kids-club/resources/' | append: item.slug %}
+{% else %}
+  {% assign item_url = item | media_url %}
+{% endif %}
+
 <div class="card">
-  <a class="relative block" href="{{ item | media_url }}" title="{{ item.title }}">
+  <a class="relative block" href="{{ item_url }}" title="{{ item.title }}">
     {% if item.duration > 0 %}
     <div class="card-stamp text-white">
       <span class="font-size-smallest soft-quarter-right">{{ item.duration | duration: "long" }}</span>

--- a/_layouts/series.html
+++ b/_layouts/series.html
@@ -89,6 +89,9 @@ title: Series
             {% unless item %}
             {% assign item = site.messages | where: 'slug', msg_obj.slug | first %}
             {% endunless %}
+            {% unless item %}
+            {% assign item = site.kcResources | where: 'slug', msg_obj.slug | first %}
+            {% endunless %}
             {% if item %}
             {% include _message-card.html %}
             {% endif %}
@@ -103,6 +106,9 @@ title: Series
           {% assign item = site.videos | where: 'slug', msg_obj.slug | first %}
           {% unless item %}
           {% assign item = site.messages | where: 'slug', msg_obj.slug | first %}
+          {% endunless %}
+          {% unless item %}
+          {% assign item = site.kcResources | where: 'slug', msg_obj.slug | first %}
           {% endunless %}
           {% if item %}
           {% include _message-card.html %}


### PR DESCRIPTION
## Problem

Legacy Series pages only resolve linked Full Services entries as Videos or Messages, so KC Resources do not render.

## Solution

Registers the KC Resource collection and renders linked KC Resources in legacy Series cards. KC Resource cards link to `/kids-club/resources/{slug}`, while existing Video and Message behavior remains unchanged.

### Corresponding Branch
https://github.com/crdschurch/crds-unified/pull/3150

## Testing

- [ ] Open a legacy Series page containing a KC Resource.
- [ ] Confirm its title and image render.
- [ ] Confirm the card links to `/kids-club/resources/{slug}`.
- [ ] Confirm existing Video and Message cards remain unchanged.